### PR TITLE
chore(ci): Add CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,34 @@
+name: test
+
+# On every pull request, but only on push to master
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test-node:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Use Node.js
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
+        with:
+          node-version: '18.x'
+
+      - name: Install dependencies
+        run: |
+          yarn bootstrap
+
+      - name: Run tests
+        run: |
+          yarn test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,11 +17,13 @@ jobs:
       checks: write
       contents: read
 
+    # NOTE: Pin official GitHub actions to a version number, pin third-party actions to a SHA1.
+    # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v4.1.1
 
       - name: Use Node.js
-        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
+        uses: actions/setup-node@v4.0.0
         with:
           node-version: '18.x'
 


### PR DESCRIPTION
Copied from deck.gl's `test.yaml`, with modifications. Currently `yarn test` just runs a linter, but this will run unit tests as well after #31.