### PR TITLE
Draft: Deckgl Fiber Renderer

### DIFF
--- a/examples/react-fiber/app.jsx
+++ b/examples/react-fiber/app.jsx
@@ -1,0 +1,108 @@
+import React, {useCallback, useEffect, useState, useTransition} from 'react';
+import {createRoot} from 'react-dom/client';
+import {
+  Button,
+  Grid,
+  View,
+  Flex,
+  defaultTheme,
+  LabeledValue,
+  Provider
+} from '@adobe/react-spectrum';
+import {DeckGL} from '../../modules/react-fiber/src';
+import {Metrics} from './metrics';
+import {BasemapLayer} from './basemap-layer';
+import {RandomPointLayer, RandomPointLayerMemo} from './random-point-layer';
+
+deck.log.enable();
+deck.log.level = 2;
+
+const INITIAL_VIEW_STATE = {
+  longitude: -77.0369,
+  latitude: 38.9072,
+  zoom: 5,
+  minZoom: 2,
+  maxZoom: 20
+};
+
+// Example passthrough component to showcase that you nest React components however you want
+function Parent(props) {
+  const {children} = props;
+
+  useEffect(() => {
+    console.log('logging <Parent /> effect');
+  }, []);
+
+  return (
+    <>
+      <BasemapLayer />
+      {children}
+    </>
+  );
+}
+
+function App() {
+  const [_, startTransition] = useTransition();
+  const [viewState, setViewState] = useState(() => INITIAL_VIEW_STATE);
+  const onViewStateChange = useCallback((event) => {
+    startTransition(() => {
+      setViewState(event.viewState);
+    });
+  }, []);
+
+  const [i, setI] = useState(0);
+  const [metrics, setMetrics] = useState({});
+
+  const increment = useCallback(() => {
+    setI((prev) => prev + 1);
+  }, []);
+
+  const onMetrics = useCallback((e) => {
+    increment();
+
+    startTransition(() => {
+      setMetrics(e);
+    });
+  }, []);
+
+  return (
+    <Provider theme={defaultTheme} height="100%">
+      <Grid
+        areas={['sidebarleft content sidebarright']}
+        columns={['size-3000', '1fr', 'size-3000']}
+        gap="size-100"
+        height="100%"
+      >
+        <View backgroundColor="gray-100" gridArea="sidebarleft" padding="size-100">
+          <Flex direction="column" gap="size-100">
+            <LabeledValue label="Count" value={i} labelPosition="side" />
+            <Button variant="accent" onClick={increment}>
+              Increment
+            </Button>
+          </Flex>
+        </View>
+        <View backgroundColor="gray-50" gridArea="content" position="relative">
+          <DeckGL
+            viewState={viewState}
+            onViewStateChange={onViewStateChange}
+            _onMetrics={onMetrics}
+            // initialViewState={INITIAL_VIEW_STATE}
+          >
+            <mapView controller={true} id="mapview" repeat>
+              <Parent>
+                <RandomPointLayer />
+                <RandomPointLayerMemo />
+              </Parent>
+            </mapView>
+          </DeckGL>
+        </View>
+        <View backgroundColor="gray-100" gridArea="sidebarright" padding="size-100">
+          <Metrics data={metrics} />
+        </View>
+      </Grid>
+    </Provider>
+  );
+}
+
+const root = createRoot(document.getElementById('app'));
+root.render(<App />);

--- a/examples/react-fiber/basemap-layer.tsx
+++ b/examples/react-fiber/basemap-layer.tsx
@@ -1,0 +1,21 @@
+import React, {memo} from 'react';
+
+// The memo() here is ultimately not necessary even though this component is
+// rendering anytime the viewState changes (e.g. expected React behavior).
+// Since we have a static dataset Deck will take over and properly diff the
+// layer to determine if it needs to rerender or not.
+function _BasemapLayer() {
+  return (
+    <geoJsonLayer
+      id="basemap"
+      data="https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_land.geojson"
+      stroked={true}
+      filled={true}
+      getFillColor={[30, 80, 120]}
+      getLineColor={[0, 255, 255]}
+      lineWidthMinPixels={1}
+    />
+  );
+}
+
+export const BasemapLayer = memo(_BasemapLayer);

--- a/examples/react-fiber/index.html
+++ b/examples/react-fiber/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>deck.gl Example</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body {margin: 0; padding: 0; width: 100vw; height: 100vh; overflow: hidden;}
+    #app { height:100vh; }
+  </style>
+</head>
+<body>
+<div id="app"></div>
+</body>
+<script type="module">
+  import './app.jsx';
+</script>
+</html>

--- a/examples/react-fiber/metrics.tsx
+++ b/examples/react-fiber/metrics.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {Flex, LabeledValue} from '@adobe/react-spectrum';
+
+export function Metrics(props) {
+  const {data} = props;
+
+  const output = Object.entries(data).reduce((prev, next, i) => {
+    if (prev[i]) {
+      prev[i] = next;
+    } else {
+      prev.push(next);
+    }
+
+    return prev;
+  }, []);
+
+  return (
+    <Flex direction="column" gap="size-100">
+      {output.map(pairs => {
+        return (
+          <LabeledValue key={pairs[0]} label={pairs[0]} value={pairs[1]} labelPosition="side" />
+        );
+      })}
+    </Flex>
+  );
+}

--- a/examples/react-fiber/package.json
+++ b/examples/react-fiber/package.json
@@ -1,0 +1,24 @@
+{
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "start": "vite --open",
+    "start-local": "vite --config ../vite.config.local.mjs"
+  },
+  "dependencies": {
+    "@adobe/react-spectrum": "^3.34.1",
+    "@deck.gl/core": "^9.0.0-beta.5",
+    "@deck.gl/extensions": "^9.0.0-beta.5",
+    "@deck.gl/geo-layers": "^9.0.0-beta.5",
+    "@deck.gl/layers": "^9.0.0-beta.5",
+    "@deck.gl/mesh-layers": "^9.0.0-beta.5",
+    "@turf/random": "^6.5.0",
+    "@turf/sample": "^6.5.0",
+    "@types/react": "^18.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.12"
+  }
+}

--- a/examples/react-fiber/random-point-layer.tsx
+++ b/examples/react-fiber/random-point-layer.tsx
@@ -1,0 +1,48 @@
+import React, {memo} from 'react';
+import {randomPoint} from '@turf/random';
+import sample from '@turf/sample';
+
+const points = randomPoint(10000, {bbox: [-180, -90, 180, 90]});
+
+function getPosition(feature) {
+  return feature.geometry.coordinates;
+}
+
+// This component is rendering anytime the viewState changes (e.g. expected React behavior).
+// Since we have a dataset we are deriving in the component this means that a new data value
+// is being created every render and thus Deck will render the new dataset accordingly.
+export function RandomPointLayer() {
+  const data = sample(points, 1000);
+
+  return (
+    <scatterplotLayer
+      id="random-point-1"
+      data={data.features}
+      getPosition={getPosition}
+      radiusMinPixels={4}
+      filled={true}
+      stroked={false}
+      getFillColor={[255, 0, 0]}
+    />
+  );
+}
+
+// Since this component is memo'd, you will not see it render new data when the viewState changes.
+// This follows the principle of any other React component and allows you to always "think in React".
+function _RandomPointLayerMemo() {
+  const data = sample(points, 1000);
+
+  return (
+    <scatterplotLayer
+      id="random-point-2"
+      data={data.features}
+      getPosition={getPosition}
+      radiusMinPixels={4}
+      filled={true}
+      stroked={false}
+      getFillColor={[0, 255, 0]}
+    />
+  );
+}
+
+export const RandomPointLayerMemo = memo(_RandomPointLayerMemo);

--- a/modules/react-fiber/README.md
+++ b/modules/react-fiber/README.md
@@ -1,0 +1,5 @@
+# @deck.gl-community/template
+
+vis.gl project template.
+
+See [vis.gl](http://vis.gl) for documentation.

--- a/modules/react-fiber/docs/README.md
+++ b/modules/react-fiber/docs/README.md
@@ -1,0 +1,3 @@
+# Overview
+
+vis.gl project template.

--- a/modules/react-fiber/package.json
+++ b/modules/react-fiber/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@deck.gl-community/react-fiber",
+  "description": "React Fiber Renderer for deck.gl",
+  "license": "MIT",
+  "version": "0.0.1",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "webgl",
+    "visualization",
+    "overlay",
+    "layer"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/deck.gl-community.gl.git"
+  },
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "test": "vitest --run"
+  },
+  "dependencies": {
+    "its-fine": "1.1.1",
+    "react-reconciler": "0.29.0",
+    "zustand": "4.3.9"
+  },
+  "devDependencies": {},
+  "peerDependencies": {
+    "@deck.gl/core": "^9.0.0-beta.5",
+    "@deck.gl/extensions": "^9.0.0-beta.5",
+    "@deck.gl/geo-layers": "^9.0.0-beta.5",
+    "@deck.gl/layers": "^9.0.0-beta.5",
+    "@deck.gl/mesh-layers": "^9.0.0-beta.5",
+    "@types/react": "^18.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/modules/react-fiber/src/context.tsx
+++ b/modules/react-fiber/src/context.tsx
@@ -1,0 +1,16 @@
+import React, {createContext, type ReactNode} from 'react';
+import type {UseBoundStore} from 'zustand';
+import type {Store} from './store';
+
+export type ContextStore = UseBoundStore<Store>;
+
+export const context = createContext<ContextStore | null>(null);
+
+type ProviderProps = {
+  store: ContextStore;
+  children: ReactNode;
+};
+
+export function Provider({store, children}: ProviderProps) {
+  return <context.Provider value={store}>{children}</context.Provider>;
+}

--- a/modules/react-fiber/src/deckgl.tsx
+++ b/modules/react-fiber/src/deckgl.tsx
@@ -1,0 +1,151 @@
+import {Deck, type DeckProps} from '@deck.gl/core';
+import {FiberProvider, useContextBridge} from 'its-fine';
+import React, {forwardRef, memo, useImperativeHandle, useRef, type ReactNode} from 'react';
+import {ConcurrentRoot} from 'react-reconciler/constants';
+import {Provider} from './context';
+import {useIsomorphicLayoutEffect} from './react-utils';
+import {reconciler} from './reconciler';
+import {useStore as storeInstance, type Store} from './store';
+
+// NOTE: side effect to build out initial catalogue
+import './extend';
+
+type CanvasElement = HTMLCanvasElement;
+
+const roots = new Map();
+
+type DeckGLProps = DeckProps & {
+  children: ReactNode;
+  width?: string | number;
+  height?: string | number;
+};
+
+export type ReconcilerRoot<TCanvas extends CanvasElement> = {
+  render: (element: ReactNode) => Store;
+  configure: (props: DeckGLProps) => ReconcilerRoot<TCanvas>;
+  unmount: () => void;
+};
+
+function unmountComponentAtNode(canvas: CanvasElement) {
+  const root = roots.get(canvas);
+  const fiber = root?.fiber;
+
+  if (fiber) {
+    const state = root?.store.getState();
+
+    reconciler.updateContainer(null, fiber, null, () => {
+      state.deckgl.finalize();
+      roots.delete(canvas);
+    });
+  }
+}
+
+function createRoot<TCanvas extends CanvasElement>(canvas: TCanvas): ReconcilerRoot<TCanvas> {
+  const prevRoot = roots.get(canvas);
+  const store = prevRoot?.store ?? storeInstance;
+
+  const fiber =
+    prevRoot?.fiber ??
+    reconciler.createContainer(store, ConcurrentRoot, null, false, null, '', reportError, null);
+
+  if (!prevRoot) {
+    roots.set(canvas, {fiber, store});
+  }
+
+  return {
+    configure(props) {
+      const state = store.getState();
+
+      if (!state.deckgl) {
+        const deckgl = new Deck({
+          ...props,
+          canvas,
+          layers: [],
+          onWebGLInitialized: state.setWebgl
+          // TODO: investigate if we need
+          // _customRender: reason => {
+          //   console.log('reason', reason);
+          //   if (reason) {
+          //     deckgl._drawLayers(reason);
+          //   }
+          // },
+        });
+
+        state.setDeckgl(deckgl);
+      }
+
+      // TODO: try and find another way to do this, only required for controlled viewState
+      if (state.deckgl && props.viewState && props.onViewStateChange) {
+        state.deckgl.setProps({viewState: props.viewState});
+      }
+
+      return this;
+    },
+    render(children) {
+      reconciler.updateContainer(<Provider store={store}>{children}</Provider>, fiber, null);
+
+      return store;
+    },
+    unmount() {
+      unmountComponentAtNode(canvas);
+    }
+  };
+}
+
+function CanvasImplementation({children, ...rest}: DeckGLProps, forwardedRef: any) {
+  const canvasRef = useRef<HTMLCanvasElement>(null!);
+  const containerRef = useRef<HTMLDivElement>(null!);
+  const outerRef = useRef<HTMLDivElement>(null!);
+  const root = useRef<ReconcilerRoot<HTMLCanvasElement>>(null!);
+  const Bridge = useContextBridge();
+
+  useImperativeHandle(forwardedRef, () => canvasRef.current);
+
+  useIsomorphicLayoutEffect(() => {
+    const canvas = canvasRef.current;
+
+    if (canvas) {
+      if (!root.current) {
+        root.current = createRoot<HTMLCanvasElement>(canvas);
+      }
+
+      // @ts-expect-error FIXME
+      root.current.configure({
+        ...rest
+      });
+
+      root.current.render(<Bridge>{children}</Bridge>);
+    }
+  });
+
+  useIsomorphicLayoutEffect(
+    () => () => {
+      const canvas = canvasRef.current;
+
+      if (canvas) {
+        unmountComponentAtNode(canvas);
+      }
+    },
+    []
+  );
+
+  return (
+    <div id="deck-wrapper" ref={outerRef}>
+      <div id="deck-container" ref={containerRef}>
+        <canvas id="deck-canvas" ref={canvasRef} />
+      </div>
+    </div>
+  );
+}
+
+const Canvas = memo(forwardRef(CanvasImplementation));
+
+function DeckGLImplementation(props: DeckGLProps, forwardedRef: any) {
+  return (
+    <FiberProvider>
+      <Canvas {...props} ref={forwardedRef} />
+    </FiberProvider>
+  );
+}
+
+export const DeckGL = memo(forwardRef(DeckGLImplementation));

--- a/modules/react-fiber/src/extend.ts
+++ b/modules/react-fiber/src/extend.ts
@@ -1,0 +1,85 @@
+import {
+  MapView,
+  OrthographicView,
+  OrbitView,
+  FirstPersonView,
+  _GlobeView as GlobeView
+} from '@deck.gl/core';
+import {
+  S2Layer,
+  QuadkeyLayer,
+  TileLayer,
+  TripsLayer,
+  H3ClusterLayer,
+  H3HexagonLayer,
+  Tile3DLayer,
+  TerrainLayer,
+  MVTLayer,
+  GeohashLayer
+} from '@deck.gl/geo-layers';
+import {
+  ArcLayer,
+  BitmapLayer,
+  IconLayer,
+  LineLayer,
+  PointCloudLayer,
+  ScatterplotLayer,
+  ColumnLayer,
+  GridCellLayer,
+  PathLayer,
+  PolygonLayer,
+  GeoJsonLayer,
+  TextLayer,
+  SolidPolygonLayer
+} from '@deck.gl/layers';
+import type {Instance} from './types';
+
+// IDEA: we can technically move this purely to userland so that a user is defining precisely
+// the layers they are intending to use in their app. May help out with bundle size for a
+// tradeoff on developer experience / maintainability.
+
+export type Catalogue = {
+  [name: string]: {
+    new (...args: unknown[]): Instance;
+  };
+};
+
+export const catalogue: Catalogue = {};
+
+export function extend(objects: object) {
+  Object.assign(catalogue, objects);
+}
+
+extend({
+  // @deck.gl/core
+  MapView,
+  OrthographicView,
+  OrbitView,
+  FirstPersonView,
+  GlobeView,
+  // @deck.gl/layers
+  ArcLayer,
+  BitmapLayer,
+  IconLayer,
+  LineLayer,
+  PointCloudLayer,
+  ScatterplotLayer,
+  ColumnLayer,
+  GridCellLayer,
+  PathLayer,
+  PolygonLayer,
+  GeoJsonLayer,
+  TextLayer,
+  SolidPolygonLayer,
+  // @deck.gl/geo-layers
+  S2Layer,
+  QuadkeyLayer,
+  TileLayer,
+  TripsLayer,
+  H3ClusterLayer,
+  H3HexagonLayer,
+  Tile3DLayer,
+  TerrainLayer,
+  MVTLayer,
+  GeohashLayer
+});

--- a/modules/react-fiber/src/hooks.ts
+++ b/modules/react-fiber/src/hooks.ts
@@ -1,0 +1,20 @@
+import {useContext} from 'react';
+import {context} from './context';
+import type {State} from './store';
+
+export function useStore() {
+  const store = useContext(context);
+
+  if (!store) {
+    throw new Error('Hooks can only be used within the DeckGL component!');
+  }
+
+  return store;
+}
+
+export function useDeckgl<T = State>(
+  selector: (state: State) => T = state => state as unknown as T,
+  equalityFn?: <T>(state: T, newState: T) => boolean
+) {
+  return useStore()(selector, equalityFn);
+}

--- a/modules/react-fiber/src/index.ts
+++ b/modules/react-fiber/src/index.ts
@@ -1,0 +1,3 @@
+export {DeckGL} from './deckgl';
+export {extend} from './extend';
+export {selectors as deckglStoreSelectors, useStore as useDeckglStore} from './store';

--- a/modules/react-fiber/src/react-utils.tsx
+++ b/modules/react-fiber/src/react-utils.tsx
@@ -1,0 +1,15 @@
+import {useEffect, useLayoutEffect} from 'react';
+import {isDefined, isFn} from './utils';
+
+/**
+ * An SSR-friendly useLayoutEffect.
+ *
+ * React currently throws a warning when using useLayoutEffect on the server.
+ * To get around it, we can conditionally useEffect on the server (no-op) and
+ * useLayoutEffect elsewhere.
+ *
+ * @see https://github.com/facebook/react/issues/14927
+ */
+export const useIsomorphicLayoutEffect =
+  // eslint-disable-next-line
+  isDefined(window) && isFn(window.document?.createElement) ? useLayoutEffect : useEffect;

--- a/modules/react-fiber/src/reconciler.ts
+++ b/modules/react-fiber/src/reconciler.ts
@@ -1,0 +1,304 @@
+import {log} from '@deck.gl/core';
+import {default as Reconciler} from 'react-reconciler';
+import {DefaultEventPriority} from 'react-reconciler/constants';
+import {catalogue} from './extend';
+import {isFn, now} from './utils';
+import type {Store} from './store';
+import type {Instance} from './types';
+import type {LayersList} from '@deck.gl/core';
+
+const noop = () => {};
+
+function handleTextInstance() {
+  console.warn(
+    'Text is not allowed in the DeckGL tree! This could be stray whitespace or characters.'
+  );
+}
+
+function falseReturn() {
+  return false;
+}
+
+function nullReturn() {
+  return null;
+}
+
+const layerCache: Instance[] = [];
+
+// TODO: tree structure for views and layers to auto filter
+const viewCache = new Map<string, any>();
+const filterCache = new Map<string, string[]>();
+
+function toPascal(str: string) {
+  return `${str[0].toUpperCase()}${str.slice(1)}`;
+}
+
+function isView(instance: Instance) {
+  return instance && 'viewportInstance' in instance;
+}
+
+export type InstanceProps = {
+  [key: string]: unknown;
+};
+
+function appendChild(parent: Instance, child: Instance) {
+  log.info('appendChild');
+  log.info('appendChild :: parent: %O', parent);
+  log.info('appendChild :: child: %O', child);
+  log.info('\n');
+
+  // NOTE: on occasion we saw child coming in as null
+  if (child && !isView(child)) {
+    let viewId = isView(parent) ? parent.id : parent.__deckglfiber?.view;
+
+    // If a layer is not a descendent of a View then we won't have a viewId.
+    // We treat these orphans as belonging to the main View.
+    if (!viewId) {
+      // No declarative Views means no orphans :)
+      if (viewCache.size > 0) {
+        console.warn(
+          `Layer: ${child.id} is not a child of a View. This will have unintended side effects.`
+        );
+      }
+
+      const state = child.__deckglfiber.root.getState();
+      const views = state.deckgl.getViews();
+
+      viewId = views[0].id;
+    }
+
+    filterCache.set(viewId, [...(filterCache.get(viewId) ?? []), child.id]);
+    child.__deckglfiber.view = viewId;
+
+    layerCache.push(child);
+  }
+}
+
+// TODO: logic for View components
+function removeChild(parent: Instance, child: Instance) {
+  log.info('removeChild');
+  log.info('removeChild :: parent: %O', parent);
+  log.info('removeChild :: child: %O', child);
+  log.info('\n');
+
+  // NOTE: on occasion we saw child coming in as null
+  if (child) {
+    const currentIndex = layerCache.findIndex(v => v.id === child.id);
+
+    layerCache.splice(currentIndex, 1);
+  }
+}
+
+// TODO: logic for View components
+function insertBefore(parent: Instance, child: Instance, beforeChild: Instance) {
+  log.info('insertBefore');
+  log.info('insertBefore :: parent: %O', parent);
+  log.info('insertBefore :: child: %O', child);
+  log.info('insertBefore :: beforeChild: %O', beforeChild);
+  log.info('\n');
+
+  // NOTE: on occasion we saw child coming in as null
+  if (child) {
+    const beforeIndex = layerCache.findIndex(v => v.id === beforeChild.id);
+
+    // TODO: double check this splice does what we think it does
+    layerCache.splice(beforeIndex, 0, child);
+  }
+}
+
+type HostConfig = {
+  type: string;
+  props: InstanceProps;
+  container: Store;
+  instance: Instance;
+  textInstance: void;
+  suspenseInstance: Instance;
+  hydratableInstance: Instance;
+  publicInstance: Instance;
+  hostContext: never;
+  updatePayload: boolean;
+  childSet: never;
+  timeoutHandle: number | undefined;
+  noTimeout: -1;
+};
+
+export const reconciler = Reconciler<
+  HostConfig['type'],
+  HostConfig['props'],
+  HostConfig['container'],
+  HostConfig['instance'],
+  HostConfig['textInstance'],
+  HostConfig['suspenseInstance'],
+  HostConfig['hydratableInstance'],
+  HostConfig['publicInstance'],
+  HostConfig['hostContext'],
+  HostConfig['updatePayload'],
+  HostConfig['childSet'],
+  HostConfig['timeoutHandle'],
+  HostConfig['noTimeout']
+>({
+  // NOTE: this is fired during a hot reload
+  createInstance(type, props, root) {
+    log.info('createInstance');
+    log.info('createInstance :: type: %s', type);
+    log.info('createInstance :: props: %O', props);
+    log.info('\n');
+
+    const name = toPascal(type);
+
+    if (!catalogue[name]) {
+      throw new Error(`Unsupported element type: ${type}`);
+    }
+
+    const instance: Instance = new catalogue[name](props);
+
+    if (isView(instance)) {
+      viewCache.set(instance.id, instance);
+      filterCache.set(instance.id, []);
+
+      const state = root.getState();
+
+      // Set view immediately so we can use during layer appends
+      state.deckgl.setProps({
+        views: Array.from(viewCache.values())
+      });
+    } else {
+      // NOTE: View classes cannot be extended and or have properties added to it
+      instance.__deckglfiber = {
+        root,
+        view: undefined
+      };
+    }
+
+    return instance;
+  },
+
+  appendChild,
+
+  appendInitialChild: appendChild,
+
+  // @ts-expect-error "parent" type doesn't matter
+  appendChildToContainer: appendChild,
+
+  removeChild,
+
+  // @ts-expect-error "parent" type doesn't matter
+  removeChildFromContainer: removeChild,
+
+  insertBefore,
+
+  // @ts-expect-error "parent" type doesn't matter
+  insertInContainerBefore: insertBefore,
+
+  finalizeInitialChildren: falseReturn,
+
+  // TODO: we could look at cleaning up deckgl here with the caveat that
+  // deck.finalize() is already called in the React component cleanup.
+  clearContainer: falseReturn,
+
+  // NOTE: may need to attach handlers here
+  commitMount: noop,
+
+  // NOTE: this fires per instance, since deckgl cannot update individual layers
+  // atomically we skip doing any work in this function
+  commitUpdate: noop,
+
+  // NOTE: since deck.gl already does extensive diffing, we just need to construct
+  // a new object to replace the prior. "prepareUpdate" appears to fire twice in strict mode.
+  prepareUpdate(oldInstance, type, oldProps, newProps) {
+    log.info('prepareUpdate');
+    log.info('createInstance :: oldInstance: %O', oldInstance);
+    log.info('createInstance :: type: %s', type);
+    log.info('createInstance :: oldProps: %O', oldProps);
+    log.info('createInstance :: newProps: %O', newProps);
+    log.info('\n');
+
+    const name = toPascal(type);
+    const instance: Instance = new catalogue[name](newProps);
+    const currentIndex = layerCache.findIndex(v => v.id === instance.id);
+
+    layerCache[currentIndex] = instance;
+
+    return true;
+  },
+
+  prepareForCommit: nullReturn,
+
+  resetAfterCommit(container: Store) {
+    log.info('resetAfterCommit');
+
+    const state = container.getState();
+
+    /**
+     * TODO: implicit view/layer filter logic
+     * const existingLayerFilter = state.deckgl.props.layerFilter;
+     * const hasDeclarativeViews = viewCache.size > 0;
+     */
+
+    state.deckgl.setProps({
+      // TODO: investigate why we need to spread the array here for deckgl to pick up layer changes
+      layers: [...layerCache] as unknown as LayersList
+    });
+
+    log.info('resetAfterCommit :: layers: %O', layerCache);
+    log.info('\n');
+  },
+
+  getRootHostContext: nullReturn,
+
+  getChildHostContext(parentHostContext) {
+    return parentHostContext;
+  },
+
+  // @ts-expect-error react typing is goofy
+  getPublicInstance(instance) {
+    return instance;
+  },
+
+  scheduleTimeout: (isFn(setTimeout) ? setTimeout : undefined) as any,
+
+  cancelTimeout: (isFn(clearTimeout) ? clearTimeout : undefined) as any,
+
+  // TODO
+  hideInstance: noop,
+
+  // TODO
+  unhideInstance: noop,
+
+  // TODO: look at if we need to tie into different priorities
+  getCurrentEventPriority() {
+    return DefaultEventPriority;
+  },
+
+  preparePortalMount: noop,
+
+  shouldSetTextContent: falseReturn,
+
+  resetTextContent: handleTextInstance,
+
+  createTextInstance: handleTextInstance,
+
+  commitTextUpdate: handleTextInstance,
+
+  hideTextInstance: handleTextInstance,
+
+  unhideTextInstance: handleTextInstance,
+
+  beforeActiveInstanceBlur: noop,
+
+  afterActiveInstanceBlur: noop,
+
+  detachDeletedInstance: noop,
+
+  now,
+
+  supportsMutation: true,
+
+  isPrimaryRenderer: false,
+
+  supportsPersistence: false,
+
+  supportsHydration: false,
+
+  noTimeout: -1
+});

--- a/modules/react-fiber/src/store.ts
+++ b/modules/react-fiber/src/store.ts
@@ -1,0 +1,31 @@
+import {create, type StoreApi} from 'zustand';
+import type {Deck} from '@deck.gl/core';
+
+export type State = {
+  webgl: WebGL2RenderingContext;
+  setWebgl: (instance: WebGL2RenderingContext) => void;
+  deckgl: Deck;
+  setDeckgl: (instance: Deck) => void;
+};
+
+export type Store = StoreApi<State>;
+
+// NOTE: this store is primarily used for the fiber nodes
+
+export const useStore = create<State>()(set => ({
+  webgl: undefined!,
+  setWebgl: instance => {
+    set({webgl: instance});
+  },
+  deckgl: undefined!,
+  setDeckgl: instance => {
+    set({deckgl: instance});
+  }
+}));
+
+export const selectors = {
+  webgl: s => s.webgl,
+  setWebgl: s => s.setWebgl,
+  deckgl: s => s.deckgl,
+  setDeckgl: s => s.setDeckgl
+} satisfies Record<string, (state: State) => State[keyof State]>;

--- a/modules/react-fiber/src/types.ts
+++ b/modules/react-fiber/src/types.ts
@@ -1,0 +1,108 @@
+import type {Store} from './store';
+import type {
+  GetPickingInfoParams,
+  MapView,
+  OrthographicView,
+  OrbitView,
+  FirstPersonView,
+  _GlobeView as GlobeView,
+  View,
+  LayerData
+} from '@deck.gl/core';
+import type {DataFilterExtensionProps} from '@deck.gl/extensions';
+import type {
+  S2LayerProps,
+  QuadkeyLayerProps,
+  TileLayerProps,
+  H3ClusterLayerProps,
+  H3HexagonLayerProps,
+  Tile3DLayerProps,
+  TerrainLayerProps,
+  MVTLayerProps,
+  _Tile2DHeader
+} from '@deck.gl/geo-layers';
+import type {
+  ArcLayerProps,
+  BitmapLayerProps,
+  IconLayerProps,
+  LineLayerProps,
+  PointCloudLayerProps,
+  ScatterplotLayerProps,
+  ColumnLayerProps,
+  GridCellLayerProps,
+  PathLayerProps,
+  PolygonLayerProps,
+  GeoJsonLayerProps,
+  TextLayerProps,
+  SolidPolygonLayerProps
+} from '@deck.gl/layers';
+
+export type BaseInstance = {
+  __deckglfiber: {
+    root: Store;
+    view?: string;
+  };
+};
+
+export type Instance = BaseInstance & {[key: string]: any};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export type ExtractViewProps<T> = T extends View<any, infer P> ? P : never;
+
+export type DeckglElements = {
+  // @deck.gl/core
+  mapView: ExtractViewProps<MapView>;
+  orthographicView: ExtractViewProps<OrthographicView>;
+  orbitView: ExtractViewProps<OrbitView>;
+  firstPersonView: ExtractViewProps<FirstPersonView>;
+  globeView: ExtractViewProps<GlobeView>;
+
+  // @deck.gl/layers
+  arcLayer: ArcLayerProps;
+  bitmapLayer: BitmapLayerProps;
+  iconLayer: IconLayerProps;
+  lineLayer: LineLayerProps;
+  pointCloudLayer: PointCloudLayerProps;
+  scatterplotLayer: ScatterplotLayerProps;
+  columnLayer: ColumnLayerProps;
+  gridCellLayer: GridCellLayerProps;
+  pathLayer: PathLayerProps;
+  polygonLayer: PolygonLayerProps;
+  geoJsonLayer: GeoJsonLayerProps;
+  textLayer: TextLayerProps;
+  solidPolygonLayer: SolidPolygonLayerProps;
+
+  // @deck.gl/geo-layers
+  s2Layer: S2LayerProps;
+  quadkeyLayer: QuadkeyLayerProps;
+  tileLayer: TileLayerProps;
+  h3ClusterLayer: H3ClusterLayerProps;
+  h3HexagonLayer: H3HexagonLayerProps;
+  tile3DLayer: Tile3DLayerProps;
+  terrainLayer: TerrainLayerProps;
+  mVTLayer: MVTLayerProps & DataFilterExtensionProps;
+};
+
+export type DataComparator =
+  | (<LayerDataT = LayerData<unknown>>(newData: LayerDataT, oldData?: LayerDataT) => boolean)
+  | null;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PropertyAccessor<T> = (props: any) => T;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type RenderSubLayersProps<TileData = any> = TileLayerProps<TileData> & {
+  tile: _Tile2DHeader<TileData>;
+};
+
+export type PickingInfoParams<SublayerPickingInfo extends object> = GetPickingInfoParams & {
+  info: SublayerPickingInfo;
+};
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    interface IntrinsicElements extends DeckglElements {}
+  }
+}

--- a/modules/react-fiber/src/utils.ts
+++ b/modules/react-fiber/src/utils.ts
@@ -1,0 +1,14 @@
+export function isDefined(value: any) {
+  return typeof value !== 'undefined';
+}
+
+export function isFn(a: any): a is Function {
+  return typeof a === 'function';
+}
+
+// eslint-disable-next-line
+const performanceNow = isDefined(performance) && isFn(performance.now) && performance.now;
+const dateNow = isFn(Date.now) && Date.now;
+const fallbackNow = () => 0;
+
+export const now = performanceNow || dateNow || fallbackNow;

--- a/modules/react-fiber/tsconfig.json
+++ b/modules/react-fiber/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4507,6 +4507,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-reconciler@^0.28.0":
+  version "0.28.8"
+  resolved "https://registry.yarnpkg.com/@types/react-reconciler/-/react-reconciler-0.28.8.tgz#e51710572bcccf214306833c2438575d310b3e98"
+  integrity sha512-SN9c4kxXZonFhbX4hJrZy37yw9e7EIxcpHCxQv5JUS18wDE5ovkQKlqQEkufdJCCMfuI9BnjUJvhYeJ9x5Ra7g==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "18.2.51"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.51.tgz#01ede6dfc712796257a3443bf8d613149e5c322a"
@@ -10129,6 +10136,13 @@ iterator.prototype@^1.1.2:
     reflect.getprototypeof "^1.0.4"
     set-function-name "^2.0.1"
 
+its-fine@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/its-fine/-/its-fine-1.1.1.tgz#e74b93fddd487441f978a50f64f0f5af4d2fc38e"
+  integrity sha512-v1Ia1xl20KbuSGlwoaGsW0oxsw8Be+TrXweidxD9oT/1lAh6O3K3/GIM95Tt6WCiv6W+h2M7RB1TwdoAjQyyKw==
+  dependencies:
+    "@types/react-reconciler" "^0.28.0"
+
 jackspeak@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-2.3.6.tgz#647ecc472238aee4b06ac0e461acc21a8c505ca8"
@@ -13584,6 +13598,14 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-reconciler@0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.29.0.tgz#ee769bd362915076753f3845822f2d1046603de7"
+  integrity sha512-wa0fGj7Zht1EYMRhKWwoo1H9GApxYLBuhoAuXN0TlltESAjDssB+Apf0T/DngVqaMyPypDmabL37vw/2aRM98Q==
+  dependencies:
+    loose-envify "^1.1.0"
+    scheduler "^0.23.0"
+
 react-select@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.2.0.tgz#de9284700196f5f9b5277c5d850a9ce85f5c72fe"
@@ -15763,6 +15785,11 @@ urlpattern-polyfill@10.0.0:
   resolved "https://registry.yarnpkg.com/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz#f0a03a97bfb03cdf33553e5e79a2aadd22cac8ec"
   integrity sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==
 
+use-sync-external-store@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -16346,3 +16373,10 @@ zstd-codec@^0.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/zstd-codec/-/zstd-codec-0.1.4.tgz#6abb311b63cfacbd06e72797ee6c6e1c7c65248c"
   integrity sha512-KYnWoFWgGtWyQEKNnUcb3u8ZtKO8dn5d8u+oGpxPlopqsPyv60U8suDyfk7Z7UtAO6Sk5i1aVcAs9RbaB1n36A==
+
+zustand@4.3.9:
+  version "4.3.9"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.9.tgz#a7d4332bbd75dfd25c6848180b3df1407217f2ad"
+  integrity sha512-Tat5r8jOMG1Vcsj8uldMyqYKC5IZvQif8zetmLHs9WoZlntTHmIoNM8TpLRY31ExncuUvUOXehd0kvahkuHjDw==
+  dependencies:
+    use-sync-external-store "1.2.0"


### PR DESCRIPTION
Original PR on the deck.gl repo https://github.com/visgl/deck.gl/pull/8560

ℹ️ Opening PR early to get initial feedback while we polish up
⚠️ Example dir currently not working, seems to be an issue with luma.gl

#### Remaining TODOs

- [ ] Implement HTML interleaving (we had some prior art here but removed for the sake of the first pass)
- [ ] Add in a bunch of tests
- [ ] Fix any remaining TS errors
- [ ] Provide more complex examples
- [ ] Detail any known caveats or gotchas
- [ ] Provide example for React driven tooltips

#### Example

```
cd examples/website/react-fiber
yarn
yarn start-local
```

#### Background

Initial discussion in Slack: https://deckgl.slack.com/archives/C34AC5MSQ/p1689366597250129

My company has a very large and complex React application that also uses Deck.gl. Over time as the complexity and scope of the project grew we were running into issues with the existing `@deck.gl/react` package due to some of its limitations with children ordering and a few others. 

A very popular technique adopted in the `three` community was to provide a React renderer for ThreeJS so that developers would not need to swap between the two paradigms in their brain. This is the goal of this effort as well. Allow developers to always "think in React".

This deck.gl fiber renderer has been used in a production app for almost half a year now and has unlocked some really incredible techniques for our team.

Some high level concepts:

```
// all deck.gl layers are supported out of the box, e.g.

<scatterplotLayer />
<tileLayer />
<goeJsonLayer />

// etc..
```

```
// Support for custom layers
class MyCompositeLayer extends CompositeLayer {
  ...
}

// inject into renderer
extend({ MyCompositeLayer });

// use in react
<myCompositeLayer />
```

```
// can nest layers in multiple views
<DeckGL>
  <mapView id="main>
    <MainApplicationLayers />
  </MapView>
  <Some>
    <Nested>
      <mapView id="minimap>
        <MinimapLayers />
      </MapView>
    </Nested>
  </Some>
</DeckGL>
```

```
// Order for layers is based on React tree ordering
// e.g. [bitmapLayer, scatterplotLayer, lineLayer, myCustomLayer]
<MainApplication>
  <bitmapLayer />
  <scatterplotLayer />
  <lineLayer />
  <Some>
    <Nested>
      <Component>
        <myCustomLayer />
      </Component>
    </Nested>
  </Some>
  ...
</MainApplication>
```

```
// colocation becomes incredibly easy and allows you to self contain components more
function MyLayer() {
  const [hovered, setHovered] = useState();
  const [clicked, setClicked] = useState();

  const onHover = useCallback((pickInfo) => {
    // additional logic
    setHovered(...)
  });

  const onClick = useCallback((pickInfo) => {
    // additional logic
    setClicked(...)
  });

  // Make a stable dataset for picked object
  const activeData = useMemo(() => [clicked], [clicked]);


  return (
    <>
      <scatterplotLayer
        id="base"
        onClick={onClick}
        onHover={onHover}
        pickable
        ...
      />
      
      <scatterplotLayer
        id="fancy-active"
        data={activeData}
        visible={Boolean(clicked)}
        ...
      />
    </>
  )
}
```

#### Change List

- Adds in a new package called `@deck.gl/react-fiber`
- Adds in a new website example called `react-fiber`
