### PR TITLE
chore(lint): Resolve all ESLint errors

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,11 +5,17 @@ module.exports = getESLintConfig({
   react: '18.0.0',
   /** This will be deep merged with the default config */
   overrides: {
+    parser: '',
+    parserOptions: {
+      project: ['./tsconfig.json'],
+      ecmaVersion: 2020
+    },
+    extends: ['prettier'],
     env: {
       browser: true,
       node: true,
       jest: true,
-      es6: true
+      es2020: true
     },
     overrides: [
       {
@@ -35,11 +41,6 @@ module.exports = getESLintConfig({
         }
       }
     ],
-    parserOptions: {
-      babelOptions: {
-        presets: ['@babel/preset-react']
-      }
-    },
     rules: {
       // custom rules
     }

--- a/examples/bing-maps/app.ts
+++ b/examples/bing-maps/app.ts
@@ -1,4 +1,4 @@
-import {loadModule} from 'deck.gl-bing-maps';
+import {loadModule} from '@deck.gl-community/bing-maps';
 import {GeoJsonLayer, ArcLayer} from 'deck.gl';
 
 // set your Bing Maps API key here

--- a/examples/bing-maps/app.ts
+++ b/examples/bing-maps/app.ts
@@ -1,4 +1,4 @@
-import {loadModule} from '@deck.gl-community/bing-maps';
+import {loadModule} from 'deck.gl-bing-maps';
 import {GeoJsonLayer, ArcLayer} from 'deck.gl';
 
 // set your Bing Maps API key here

--- a/examples/editable-layers/advanced/src/app.tsx
+++ b/examples/editable-layers/advanced/src/app.tsx
@@ -13,4 +13,5 @@ if (document.body) {
   root.render(<Example />);
 }
 
+// eslint-disable-next-line no-console
 console.info('MapboxAccessToken', import.meta.env.VITE_MAPBOX_ACCESS_TOKEN);

--- a/examples/editable-layers/advanced/src/example.tsx
+++ b/examples/editable-layers/advanced/src/example.tsx
@@ -321,7 +321,7 @@ export default class Example extends React.Component<
         if (eventTarget.files && eventTarget.files[0]) {
           const reader = new FileReader();
           reader.onload = ({ target }) => {
-            this._parseStringJson(target!.result as string);
+            this._parseStringJson(target.result as string);
           };
           reader.readAsText(eventTarget.files[0]);
         }
@@ -906,6 +906,7 @@ export default class Example extends React.Component<
       : this._getDeckColorForFeature(index, 0.5, 1.0);
   };
 
+  // eslint-disable-next-line complexity
   render() {
     const { testFeatures, selectedFeatureIndexes, mode } = this.state;
     let { modeConfig } = this.state;

--- a/examples/editable-layers/codesandbox/getting-started/index.js
+++ b/examples/editable-layers/codesandbox/getting-started/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import DeckGL from "@deck.gl/react";
+// TODO Enable eslint after package is published.
 // eslint-disable-next-line import/named, import/no-extraneous-dependencies
 import { HtmlOverlayItem, HtmlClusterOverlay } from "@deck.gl-community/react";
 import StaticMap from "react-map-gl";

--- a/examples/editable-layers/codesandbox/getting-started/index.js
+++ b/examples/editable-layers/codesandbox/getting-started/index.js
@@ -1,9 +1,9 @@
-/* global document, window */
 import React from "react";
 import ReactDOM from "react-dom";
 import DeckGL from "@deck.gl/react";
+// eslint-disable-next-line import/named, import/no-extraneous-dependencies
 import { HtmlOverlayItem, HtmlClusterOverlay } from "@deck.gl-community/react";
-import { StaticMap } from "react-map-gl";
+import StaticMap from "react-map-gl";
 
 const MAPBOX_ACCESS_TOKEN =
   "pk.eyJ1IjoiZ2Vvcmdpb3MtdWJlciIsImEiOiJjanZidTZzczAwajMxNGVwOGZrd2E5NG90In0.gdsRu_UeU_uPi9IulBruXA";

--- a/examples/editable-layers/codesandbox/getting-started/package.json
+++ b/examples/editable-layers/codesandbox/getting-started/package.json
@@ -2,12 +2,11 @@
   "dependencies": {
     "@deck.gl/core": "^8.8.23",
     "@deck.gl/react": "^8.8.23",
-    "@deck.gl-community/react": "0.0.1",
     "@turf/helpers": "^6.5.0",
     "global": "4.4.0",
     "react": "16.14.0",
     "react-dom": "16.14.0",
-    "react-map-gl": "4.1.16",
+    "react-map-gl": "7.1.7",
     "react-scripts": "2.1.8"
   }
 }

--- a/examples/editable-layers/codesandbox/react-map-gl-draw/index.js
+++ b/examples/editable-layers/codesandbox/react-map-gl-draw/index.js
@@ -1,4 +1,3 @@
-/* global document */
 import React, { Component } from "react";
 import ReactDom from "react-dom";
 import MapGL from "react-map-gl";
@@ -36,15 +35,16 @@ class App extends Component {
     };
   }
 
-  _switchMode = (evt) => {
+  _switchMode(evt) {
     const modeId =
       evt.target.value === this.state.modeId ? null : evt.target.value;
     const mode = MODES.find((m) => m.id === modeId);
+    // eslint-disable-next-line new-cap
     const modeHandler = mode ? new mode.handler() : null;
     this.setState({ modeId, modeHandler });
   };
 
-  _renderToolbar = () => {
+  _renderToolbar() {
     return (
       <div
         style={{ position: "absolute", top: 0, right: 0, maxWidth: "320px" }}
@@ -61,7 +61,7 @@ class App extends Component {
     );
   };
 
-  _updateViewport = (viewport) => {
+  _updateViewport (viewport) {
     this.setState({ viewport });
   };
 

--- a/examples/editable-layers/codesandbox/world-heritage/index.js
+++ b/examples/editable-layers/codesandbox/world-heritage/index.js
@@ -1,7 +1,7 @@
-/* global document, window */
 import React from "react";
 import ReactDOM from "react-dom";
 import DeckGL from "@deck.gl/react";
+// eslint-disable-next-line import/named
 import { HtmlOverlayItem, HtmlClusterOverlay } from "@deck.gl-community/react";
 import { StaticMap } from "react-map-gl";
 

--- a/examples/editable-layers/codesandbox/world-heritage/index.js
+++ b/examples/editable-layers/codesandbox/world-heritage/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import DeckGL from "@deck.gl/react";
+// TODO Enable eslint after package is published.
 // eslint-disable-next-line import/named
 import { HtmlOverlayItem, HtmlClusterOverlay } from "@deck.gl-community/react";
 import { StaticMap } from "react-map-gl";

--- a/examples/editable-layers/editable-h3-cluster-layer/index.tsx
+++ b/examples/editable-layers/editable-h3-cluster-layer/index.tsx
@@ -9,7 +9,7 @@ import {
   DrawRectangleMode
 } from '@deck.gl-community/editable-layers';
 import StaticMap from 'react-map-gl';
-import {hexagonCluster1, hexagonCluster2, hexagonCluster3} from './data.js';
+import {hexagonCluster1, hexagonCluster2, hexagonCluster3} from './data';
 
 const MAPBOX_ACCESS_TOKEN =
   'pk.eyJ1IjoiZ2Vvcmdpb3MtdWJlciIsImEiOiJjanZidTZzczAwajMxNGVwOGZrd2E5NG90In0.gdsRu_UeU_uPi9IulBruXA';

--- a/examples/editable-layers/no-map/app.js
+++ b/examples/editable-layers/no-map/app.js
@@ -1,4 +1,3 @@
-import document from 'global/document';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 

--- a/examples/editable-layers/no-map/package.json
+++ b/examples/editable-layers/no-map/package.json
@@ -9,7 +9,7 @@
     "@deck.gl/react": "^8.8.23",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
-    "react-map-gl": "^3.3.9"
+    "react-map-gl": "^7.1.7"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",

--- a/examples/editable-layers/overlays/example.tsx
+++ b/examples/editable-layers/overlays/example.tsx
@@ -32,15 +32,15 @@ const getWikipediaEntriesNearby = async ({lon, lat}) => {
 
   if (response.ok) {
     return await response.json();
-  } else {
-    console.error(`HTTP Error: ${response.status}`);
-    return {
-      status: 400,
-      query: {
-        pages: []
-      }
-    };
   }
+  // eslint-disable-next-line no-console
+  console.error(`HTTP Error: ${response.status}`);
+  return {
+    status: 400,
+    query: {
+      pages: []
+    }
+  };
 };
 
 const Example = () => {

--- a/examples/editable-layers/overlays/package.json
+++ b/examples/editable-layers/overlays/package.json
@@ -17,7 +17,7 @@
     "mapbox-gl": "^3.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-map-gl": "^5.0.0"
+    "react-map-gl": "^7.1.7"
   },
   "devDependencies": {
     "typescript": "^5.4.4",

--- a/examples/editable-layers/sf/example.tsx
+++ b/examples/editable-layers/sf/example.tsx
@@ -230,7 +230,8 @@ export default class Example extends React.Component<
 
   render() {
     const {segmentsLayer, state} = this;
-    let {viewState, selectedFeatureIndexes} = state;
+    const {selectedFeatureIndexes} = state
+    let {viewState} = state;
     // const { selectionType } = state;
 
     const {innerHeight: height, innerWidth: width} = window;

--- a/examples/graph-layers/react-graph-gl/index.html
+++ b/examples/graph-layers/react-graph-gl/index.html
@@ -6,5 +6,5 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
     <body></body>
-    <script type="module" src="./index.jsx"></script>
+    <script type="module" src="./index.tsx"></script>
 </html>

--- a/examples/graph-layers/react-graph-gl/index.tsx
+++ b/examples/graph-layers/react-graph-gl/index.tsx
@@ -3,6 +3,7 @@ import React, {Component} from 'react';
 import {D3ForceLayout, JSONLoader, NODE_TYPE} from 'deck-graph-layers';
 import {GraphGL} from 'react-deck-graph-layers';
 
+// eslint-disable-next-line import/no-unresolved
 import SAMPLE_GRAPH_DATASETS from 'react-deck-graph-layers/test/utils/data/sample-datasets.js';
 
 const DEFAULT_NODE_SIZE = 5;

--- a/examples/graph-layers/react-graph-gl/tsconfig.json
+++ b/examples/graph-layers/react-graph-gl/tsconfig.json
@@ -1,0 +1,4 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["./*.tsx"]
+}

--- a/modules/editable-layers/src/edit-modes/draw-polygon-by-dragging-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-polygon-by-dragging-mode.ts
@@ -22,8 +22,10 @@ export class DrawPolygonByDraggingMode extends DrawPolygonMode {
   handleStartDragging(event: StartDraggingEvent, props: ModeProps<FeatureCollection>) {
     event.cancelPan();
     if (props.modeConfig && props.modeConfig.throttleMs) {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       this.handleDraggingThrottled = throttle(this.handleDraggingAux, props.modeConfig.throttleMs);
     } else {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       this.handleDraggingThrottled = this.handleDraggingAux;
     }
   }

--- a/modules/editable-layers/src/edit-modes/draw-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-polygon-mode.ts
@@ -79,6 +79,7 @@ export class DrawPolygonMode extends GeoJsonEditMode {
     return guides;
   }
 
+  // eslint-disable-next-line complexity
   handleClick(event: ClickEvent, props: ModeProps<FeatureCollection>) {
     const { picks } = event;
     const clickedEditHandle = getPickedEditHandle(picks);

--- a/modules/editable-layers/src/edit-modes/immutable-feature-collection.ts
+++ b/modules/editable-layers/src/edit-modes/immutable-feature-collection.ts
@@ -59,7 +59,9 @@ export class ImmutableFeatureCollection {
    * @param positionIndexes An array containing the indexes of the postion to remove
    *
    * @returns A new `ImmutableFeatureCollection` with the given coordinate removed. Does not modify this `ImmutableFeatureCollection`.
+   *
    */
+  // eslint-disable-next-line complexity
   removePosition(
     featureIndex: number,
     positionIndexes: number[] | null | undefined

--- a/modules/graph-layers/src/layers/graph-layer.ts
+++ b/modules/graph-layers/src/layers/graph-layer.ts
@@ -12,7 +12,7 @@ import {CircleLayer} from './node-layers/circle-layer';
 import {ImageLayer} from './node-layers/image-layer';
 import {LabelLayer} from './node-layers/label-layer';
 import {RectangleLayer} from './node-layers/rectangle-layer';
-import {RoundedRectangleLayer} from './node-layers/rounded-rectangle-layer.js';
+import {RoundedRectangleLayer} from './node-layers/rounded-rectangle-layer';
 import {PathBasedRoundedRectangleLayer} from './node-layers/path-rounded-rectange-layer';
 import {ZoomableMarkerLayer} from './node-layers/zoomable-marker-layer';
 

--- a/modules/graph-layers/src/layers/node-layers/rounded-rectangle-layer.ts
+++ b/modules/graph-layers/src/layers/node-layers/rounded-rectangle-layer.ts
@@ -1,6 +1,6 @@
 // import {ScatterplotLayer} from '@deck.gl/layers';
 import {fs} from './rounded-rectangle-layer-fragment';
-import {RectangleLayer} from './rectangle-layer.js';
+import {RectangleLayer} from './rectangle-layer';
 
 export class RoundedRectangleLayer extends RectangleLayer {
   static layerName = 'RoundedRectangleLayer';

--- a/modules/layers/src/data-driven-tile-3d-layer/utils/filter-tile.ts
+++ b/modules/layers/src/data-driven-tile-3d-layer/utils/filter-tile.ts
@@ -51,6 +51,7 @@ export const filterTile = async (
   return result;
 };
 
+// eslint-disable-next-line max-statements, complexity
 async function filterTileIndices(
   tile: Tile3D,
   filtersByAttribute: FiltersByAttribute,

--- a/modules/layers/src/tile-source-layer.ts
+++ b/modules/layers/src/tile-source-layer.ts
@@ -119,6 +119,7 @@ function renderSubLayers(props: TileSourceLayerProps & {tile: {index, bbox: {wes
       break;
 
     default:
+      // eslint-disable-next-line no-console
       console.error('Unknown tile mimeType', tileSource?.mimeType);
   }
 

--- a/modules/react-editable-layers/package.json
+++ b/modules/react-editable-layers/package.json
@@ -34,6 +34,7 @@
     "src"
   ],
   "dependencies": {
+    "@deck.gl-community/editable-layers": "^9.0.0-alpha.1",
     "@deck.gl-community/react": "0.0.1",
     "@loaders.gl/core": "^4.1.4",
     "@loaders.gl/wkt": "^4.1.4",

--- a/modules/react-editable-layers/src/import-component.tsx
+++ b/modules/react-editable-layers/src/import-component.tsx
@@ -84,6 +84,7 @@ export type ImportComponentProps = {
   additionalInputs?: React.ReactNode;
 };
 
+// eslint-disable-next-line complexity
 export function ImportComponent(props: ImportComponentProps) {
   const [isImportText, setIsImportText] = React.useState(true);
   const [text, setText] = React.useState('');

--- a/modules/react-editable-layers/src/lib/importer.ts
+++ b/modules/react-editable-layers/src/lib/importer.ts
@@ -47,7 +47,7 @@ function getCleanedFeatures(geojson: AnyGeoJson): Feature[] {
     throw Error('GeoJSON must have type of \'Feature\' or \'FeatureCollection\'');
   }
 
-  // @ts-ignore
+  // @ts-expect-error TODO Improve GeoJSON types.
   const features: Feature[] = geojson.type === 'FeatureCollection' ? geojson.features : [geojson];
 
   return features.map(getCleanedFeature);
@@ -99,6 +99,7 @@ function getCleanedFeature(feature: any): Feature {
   } as any;
 }
 
+// eslint-disable-next-line max-statements, complexity
 function parseImportString(data: string): Promise<ImportData> {
   data = data.trim();
   let validData: ValidImportData | null | undefined;

--- a/modules/react-editable-layers/test/exporter.spec.ts
+++ b/modules/react-editable-layers/test/exporter.spec.ts
@@ -44,8 +44,8 @@ describe('toGeoJson()', () => {
     expect(actual.filename).toEqual(expectedFilename);
     expect(actual.mimetype).toEqual(expectedMimeType);
 
-    expect(actualParsed.features[0].properties!.name).toEqual(
-      featureCollection.features[0].properties!.name
+    expect(actualParsed.features[0].properties.name).toEqual(
+      featureCollection.features[0].properties.name
     );
   });
 });

--- a/modules/react-graph-layers/vite.config.js
+++ b/modules/react-graph-layers/vite.config.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 

--- a/modules/react/test/components/view-control.spec.tsx
+++ b/modules/react/test/components/view-control.spec.tsx
@@ -39,6 +39,7 @@ describe('ViewControl', () => {
     const {container} = render(
       <ViewControl zoomBy={zoomBy} zoomLevel={1} minZoom={1} maxZoom={10} />
     );
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const verticalSlider = container.querySelector('input') as HTMLInputElement;
     expect(verticalSlider).toBeTruthy();
     fireEvent.change(verticalSlider, {target: {value: 8}});

--- a/modules/react/vite.config.js
+++ b/modules/react/vite.config.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "rules": {
-    "import/no-unresolved": 0,
-    "import/no-extraneous-dependencies": 0
-  }
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,14 @@
     "strict": false,
     "noImplicitAny": false
   },
-  "include": ["modules/*/src", "test"],
-  "exclude": []
+  "include": [
+    "modules",
+    "test",
+    "examples",
+    "scripts"
+  ],
+  "exclude": [
+    "**/node_modules",
+    "**/dist"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12488,9 +12488,9 @@ nise@^5.1.5:
     path-to-regexp "^6.2.1"
 
 node-abi@^3.26.0:
-  version "3.57.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.57.0.tgz#d772cb899236c0aa46778d0d25256917cf15eb15"
-  integrity sha512-Dp+A9JWxRaKuHP35H77I4kCKesDy5HUDEmScia2FyncMTOXASMyg251F5PhFoDA5uqBrDDffiLpbqnrZmNXW+g==
+  version "3.58.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.58.0.tgz#3df24fb742e27c3d2a56375ade5dcc68e9aa9710"
+  integrity sha512-pXY1jnGf5T7b8UNzWzIqf0EkX4bx/w8N2AvwlGnk2SYYA/kzDVPaH0Dh0UG4EwxBB5eKOIZKPr8VAHSHL1DPGg==
   dependencies:
     semver "^7.3.5"
 


### PR DESCRIPTION
Fixes or disables ESLint errors. Some 500+ warnings remain, and `yarn lint` will not pass until we also apply Prettier to the codebase, but that is left for a future PR.