### PR TITLE
Exported edit-mode utils

### DIFF
--- a/modules/editable-layers/src/index.ts
+++ b/modules/editable-layers/src/index.ts
@@ -36,6 +36,8 @@ import * as utils from './utils';
 
 export {utils};
 
+export {getPickedEditHandle, getEditHandlesForGeometry} from './edit-modes/utils';
+
 export type {EditMode} from './edit-modes/edit-mode';
 export type {GeoJsonEditModeType} from './edit-modes/geojson-edit-mode';
 export type {GeoJsonEditModeConstructor} from './edit-modes/geojson-edit-mode';


### PR DESCRIPTION
This little PR exports the util functions that were previously available under `@nebula.gl/edit-modes`. 
These are useful for implementing custom edit modes or extending upon existing ones. 

Please let me know if there is a different naming convention that would be preferred. 