### PR TITLE
Fix examples/arrow-layers volta path

### DIFF
--- a/examples/arrow-layers/linestring/package.json
+++ b/examples/arrow-layers/linestring/package.json
@@ -21,6 +21,6 @@
     "vite": "^4.0.0"
   },
   "volta": {
-    "extends": "../../package.json"
+    "extends": "../../../package.json"
   }
 }

--- a/examples/arrow-layers/multilinestring/package.json
+++ b/examples/arrow-layers/multilinestring/package.json
@@ -20,6 +20,6 @@
     "vite": "^4.0.0"
   },
   "volta": {
-    "extends": "../../package.json"
+    "extends": "../../../package.json"
   }
 }

--- a/examples/arrow-layers/multipoint/package.json
+++ b/examples/arrow-layers/multipoint/package.json
@@ -20,6 +20,6 @@
     "vite": "^4.0.0"
   },
   "volta": {
-    "extends": "../../package.json"
+    "extends": "../../../package.json"
   }
 }

--- a/examples/arrow-layers/multipolygon/package.json
+++ b/examples/arrow-layers/multipolygon/package.json
@@ -21,6 +21,6 @@
     "vite": "^4.0.0"
   },
   "volta": {
-    "extends": "../../package.json"
+    "extends": "../../../package.json"
   }
 }

--- a/examples/arrow-layers/point/package.json
+++ b/examples/arrow-layers/point/package.json
@@ -20,6 +20,6 @@
     "vite": "^4.0.0"
   },
   "volta": {
-    "extends": "../../package.json"
+    "extends": "../../../package.json"
   }
 }

--- a/examples/arrow-layers/polygon/package.json
+++ b/examples/arrow-layers/polygon/package.json
@@ -21,6 +21,6 @@
     "vite": "^4.0.0"
   },
   "volta": {
-    "extends": "../../package.json"
+    "extends": "../../../package.json"
   }
 }

--- a/examples/arrow-layers/text/package.json
+++ b/examples/arrow-layers/text/package.json
@@ -21,6 +21,6 @@
     "vite": "^4.0.0"
   },
   "volta": {
-    "extends": "../../package.json"
+    "extends": "../../../package.json"
   }
 }

--- a/examples/arrow-layers/trips/package.json
+++ b/examples/arrow-layers/trips/package.json
@@ -21,6 +21,6 @@
     "vite": "^4.0.0"
   },
   "volta": {
-    "extends": "../../package.json"
+    "extends": "../../../package.json"
   }
 }


### PR DESCRIPTION
The examples in the examples/arrow-layers need an extra `../` in the volta path to reach the root