### PR TITLE
Use Carto positron style

### DIFF
--- a/dev-docs/RFCs/editable-layers/react-map-gl-draw.md
+++ b/dev-docs/RFCs/editable-layers/react-map-gl-draw.md
@@ -181,7 +181,7 @@ class App extends React.Component {
         {...viewport}
         width="100%"
         height="100%"
-        mapStyle="mapbox://styles/uberdata/cive48w2e001a2imn5mcu2vrs"
+        mapStyle="https://tiles.basemaps.cartocdn.com/gl/positron-gl-style/style.json"
         onViewportChange={this._updateViewport}
       >
         <MapGLDraw

--- a/examples/editable-layers/advanced/src/example.tsx
+++ b/examples/editable-layers/advanced/src/example.tsx
@@ -826,7 +826,7 @@ export default class Example extends React.Component<
   }
 
   renderStaticMap(viewport: Record<string, any>) {
-    return <StaticMap {...viewport} mapStyle={'mapbox://styles/mapbox/dark-v10'} />;
+    return <StaticMap {...viewport} mapStyle={'https://tiles.basemaps.cartocdn.com/gl/positron-gl-style/style.jsondark-v10'} />;
   }
 
   _featureMenuClick(action: string) {

--- a/examples/editable-layers/advanced/src/example.tsx
+++ b/examples/editable-layers/advanced/src/example.tsx
@@ -826,7 +826,12 @@ export default class Example extends React.Component<
   }
 
   renderStaticMap(viewport: Record<string, any>) {
-    return <StaticMap {...viewport} mapStyle={'https://tiles.basemaps.cartocdn.com/gl/positron-gl-style/style.jsondark-v10'} />;
+    return (
+      <StaticMap
+        {...viewport}
+        mapStyle={'https://tiles.basemaps.cartocdn.com/gl/positron-gl-style/style.jsondark-v10'}
+      />
+    );
   }
 
   _featureMenuClick(action: string) {

--- a/examples/editable-layers/advanced/src/example.tsx
+++ b/examples/editable-layers/advanced/src/example.tsx
@@ -829,7 +829,7 @@ export default class Example extends React.Component<
     return (
       <StaticMap
         {...viewport}
-        mapStyle={'https://tiles.basemaps.cartocdn.com/gl/positron-gl-style/style.jsondark-v10'}
+        mapStyle={'https://basemaps.cartocdn.com/gl/positron-gl-style/style.jsondark-v10'}
       />
     );
   }

--- a/examples/editable-layers/editable-h3-cluster-layer/index.tsx
+++ b/examples/editable-layers/editable-h3-cluster-layer/index.tsx
@@ -197,7 +197,9 @@ export function Example() {
         layers={[layer]}
         getCursor={layer.getCursor.bind(layer)}
       >
-        <StaticMap mapStyle={'https://tiles.basemaps.cartocdn.com/gl/positron-gl-style/style.json'} />
+        <StaticMap
+          mapStyle={'https://tiles.basemaps.cartocdn.com/gl/positron-gl-style/style.json'}
+        />
       </DeckGL>
       <Toolbar
         {...{

--- a/examples/editable-layers/editable-h3-cluster-layer/index.tsx
+++ b/examples/editable-layers/editable-h3-cluster-layer/index.tsx
@@ -197,7 +197,7 @@ export function Example() {
         layers={[layer]}
         getCursor={layer.getCursor.bind(layer)}
       >
-        <StaticMap mapStyle={'mapbox://styles/mapbox/light-v10'} />
+        <StaticMap mapStyle={'https://tiles.basemaps.cartocdn.com/gl/positron-gl-style/style.json'} />
       </DeckGL>
       <Toolbar
         {...{

--- a/examples/editable-layers/editable-h3-cluster-layer/index.tsx
+++ b/examples/editable-layers/editable-h3-cluster-layer/index.tsx
@@ -197,9 +197,7 @@ export function Example() {
         layers={[layer]}
         getCursor={layer.getCursor.bind(layer)}
       >
-        <StaticMap
-          mapStyle={'https://tiles.basemaps.cartocdn.com/gl/positron-gl-style/style.json'}
-        />
+        <StaticMap mapStyle={'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json'} />
       </DeckGL>
       <Toolbar
         {...{

--- a/examples/editable-layers/editor/example.tsx
+++ b/examples/editable-layers/editor/example.tsx
@@ -83,7 +83,7 @@ export function Example() {
             }
         }}
       >
-        <StaticMap mapStyle={'mapbox://styles/mapbox/light-v10'} />
+        <StaticMap mapStyle={'https://tiles.basemaps.cartocdn.com/gl/positron-gl-style/style.json'} />
       </DeckGL>
 
       <Toolbox

--- a/examples/editable-layers/editor/example.tsx
+++ b/examples/editable-layers/editor/example.tsx
@@ -83,9 +83,7 @@ export function Example() {
             }
         }}
       >
-        <StaticMap
-          mapStyle={'https://tiles.basemaps.cartocdn.com/gl/positron-gl-style/style.json'}
-        />
+        <StaticMap mapStyle={'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json'} />
       </DeckGL>
 
       <Toolbox

--- a/examples/editable-layers/editor/example.tsx
+++ b/examples/editable-layers/editor/example.tsx
@@ -83,7 +83,9 @@ export function Example() {
             }
         }}
       >
-        <StaticMap mapStyle={'https://tiles.basemaps.cartocdn.com/gl/positron-gl-style/style.json'} />
+        <StaticMap
+          mapStyle={'https://tiles.basemaps.cartocdn.com/gl/positron-gl-style/style.json'}
+        />
       </DeckGL>
 
       <Toolbox

--- a/examples/editable-layers/sf/example.tsx
+++ b/examples/editable-layers/sf/example.tsx
@@ -307,7 +307,10 @@ export default class Example extends React.Component<
     return (
       <div style={mapContainerStyle}>
         <link href="https://api.mapbox.com/mapbox-gl-js/v3.2.0/mapbox-gl.css" rel="stylesheet" />
-        <StaticMap {...viewState} mapStyle={'https://tiles.basemaps.cartocdn.com/gl/positron-gl-style/style.json'}>
+        <StaticMap
+          {...viewState}
+          mapStyle={'https://tiles.basemaps.cartocdn.com/gl/positron-gl-style/style.json'}
+        >
           <DeckGL
             height={height}
             width={width}

--- a/examples/editable-layers/sf/example.tsx
+++ b/examples/editable-layers/sf/example.tsx
@@ -309,7 +309,7 @@ export default class Example extends React.Component<
         <link href="https://api.mapbox.com/mapbox-gl-js/v3.2.0/mapbox-gl.css" rel="stylesheet" />
         <StaticMap
           {...viewState}
-          mapStyle={'https://tiles.basemaps.cartocdn.com/gl/positron-gl-style/style.json'}
+          mapStyle={'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json'}
         >
           <DeckGL
             height={height}

--- a/examples/editable-layers/sf/example.tsx
+++ b/examples/editable-layers/sf/example.tsx
@@ -307,7 +307,7 @@ export default class Example extends React.Component<
     return (
       <div style={mapContainerStyle}>
         <link href="https://api.mapbox.com/mapbox-gl-js/v3.2.0/mapbox-gl.css" rel="stylesheet" />
-        <StaticMap {...viewState} mapStyle={'mapbox://styles/mapbox/light-v10'}>
+        <StaticMap {...viewState} mapStyle={'https://tiles.basemaps.cartocdn.com/gl/positron-gl-style/style.json'}>
           <DeckGL
             height={height}
             width={width}


### PR DESCRIPTION
This light basemap does the job of showcasing the examples perfectly fine.

<img width="1495" alt="Screenshot 2024-05-01 at 18 26 20" src="https://github.com/visgl/deck.gl-community/assets/74932975/b18cb16b-5022-4c49-b15c-dc15754b1709">
