### PR TITLE
Fix landing page link

### DIFF
--- a/website/src/components/home/index.jsx
+++ b/website/src/components/home/index.jsx
@@ -13,7 +13,7 @@ export default function renderPage({HeroExample, children}) {
         <BannerContainer>
           <ProjectName>{siteConfig.title}</ProjectName>
           <p>{siteConfig.tagline}</p>
-          <GetStartedLink href="./docs/get-started/getting-started">GET STARTED</GetStartedLink>
+          <GetStartedLink href="./docs">GET STARTED</GetStartedLink>
         </BannerContainer>
       </Banner>
       {children}


### PR DESCRIPTION
the "get started" on the landing page leads to a 404