### PR TITLE
Add docusaurus types

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -40,8 +40,11 @@
   },
   "devDependencies": {
     "@docusaurus/core": "^3.2.1",
+    "@docusaurus/module-type-aliases": "^3.2.1",
     "@docusaurus/plugin-content-docs": "^3.2.1",
     "@docusaurus/preset-classic": "^3.2.1",
+    "@docusaurus/tsconfig": "^3.2.1",
+    "@docusaurus/types": "^3.2.1",
     "@mdx-js/react": "^3.0.1",
     "babel-plugin-inline-webgl-constants": "^1.0.3",
     "babel-plugin-remove-glsl-comments": "^1.0.0",

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@docusaurus/tsconfig",
+  "compilerOptions": {
+    "baseUrl": "."
+  }
+}

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1375,7 +1375,7 @@
     vfile "^6.0.1"
     webpack "^5.88.1"
 
-"@docusaurus/module-type-aliases@3.2.1":
+"@docusaurus/module-type-aliases@3.2.1", "@docusaurus/module-type-aliases@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-3.2.1.tgz#fa8fd746890825b4301db2ddbe29d7cfbeee0380"
   integrity sha512-FyViV5TqhL1vsM7eh29nJ5NtbRE6Ra6LP1PDcPvhwPSlA7eiWGRKAn3jWwMUcmjkos5SYY+sr0/feCdbM3eQHQ==
@@ -1615,7 +1615,12 @@
     fs-extra "^11.1.1"
     tslib "^2.6.0"
 
-"@docusaurus/types@3.2.1":
+"@docusaurus/tsconfig@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/tsconfig/-/tsconfig-3.2.1.tgz#6bdc0cb46414d09c7334d632b6d5e5472e6eb5a7"
+  integrity sha512-+biUwtsYW3oChLxYezzA+NIgS3Q9KDRl7add/YT54RXs9Q4rKInebxdHdG6JFs5BaTg45gyjDu0rvNVcGeHODg==
+
+"@docusaurus/types@3.2.1", "@docusaurus/types@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-3.2.1.tgz#88ccd4b8fa236628a29c89b8b0f60f0cc4716b69"
   integrity sha512-n/toxBzL2oxTtRTOFiGKsHypzn/Pm+sXyw+VSk1UbqbXQiHOwHwts55bpKwbcUgA530Is6kix3ELiFOv9GAMfw==


### PR DESCRIPTION
This will add [typescript support](https://docusaurus.io/docs/typescript-support) for the BrowserOnly which is used here:
- https://github.com/visgl/deck.gl-community/pull/90