### PR TITLE
Fix crash in 90 degree editable-layers example

### DIFF
--- a/examples/editable-layers/advanced/src/example.tsx
+++ b/examples/editable-layers/advanced/src/example.tsx
@@ -104,7 +104,7 @@ const ALL_MODES: any = [
       {label: 'Draw Point', mode: DrawPointMode},
       {label: 'Draw LineString', mode: DrawLineStringMode},
       {label: 'Draw Polygon', mode: DrawPolygonMode},
-      // {label: 'Draw 90° Polygon', mode: Draw90DegreePolygonMode},
+      {label: 'Draw 90° Polygon', mode: Draw90DegreePolygonMode},
       {label: 'Draw Polygon By Dragging', mode: DrawPolygonByDraggingMode},
       {label: 'Draw Rectangle', mode: DrawRectangleMode},
       {label: 'Draw Rectangle From Center', mode: DrawRectangleFromCenterMode},
@@ -870,7 +870,7 @@ export default class Example extends React.Component<
   onEdit = ({updatedData, editType, editContext}) => {
     let updatedSelectedFeatureIndexes = this.state.selectedFeatureIndexes;
 
-    if (!['movePosition', 'extruding', 'rotating', 'translating', 'scaling'].includes(editType)) {
+    if (!['movePosition', 'extruding', 'rotating', 'translating', 'scaling', 'updateTentativeFeature'].includes(editType)) {
       // Don't log edits that happen as the pointer moves since they're really chatty
       const updatedDataInfo = featuresToInfoString(updatedData);
       // eslint-disable-next-line

--- a/examples/editable-layers/advanced/src/example.tsx
+++ b/examples/editable-layers/advanced/src/example.tsx
@@ -870,7 +870,16 @@ export default class Example extends React.Component<
   onEdit = ({updatedData, editType, editContext}) => {
     let updatedSelectedFeatureIndexes = this.state.selectedFeatureIndexes;
 
-    if (!['movePosition', 'extruding', 'rotating', 'translating', 'scaling', 'updateTentativeFeature'].includes(editType)) {
+    if (
+      ![
+        'movePosition',
+        'extruding',
+        'rotating',
+        'translating',
+        'scaling',
+        'updateTentativeFeature'
+      ].includes(editType)
+    ) {
       // Don't log edits that happen as the pointer moves since they're really chatty
       const updatedDataInfo = featuresToInfoString(updatedData);
       // eslint-disable-next-line

--- a/modules/editable-layers/src/edit-modes/draw-90degree-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-90degree-polygon-mode.ts
@@ -25,7 +25,7 @@ export class Draw90DegreePolygonMode extends GeoJsonEditMode {
     const {mapCoords} = props.lastPointerMoveEvent;
 
     let p3;
-    if (clickSequence.length === 1) {
+    if (clickSequence.length <= 1) {
       p3 = mapCoords;
     } else {
       const p1 = clickSequence[clickSequence.length - 2];


### PR DESCRIPTION
This example doesn't crash anymore, but it still doesn't add the polygon on completion.