### PR TITLE
Fix 90 degree polygon drawing

### DIFF
--- a/modules/editable-layers/src/edit-modes/draw-90degree-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-90degree-polygon-mode.ts
@@ -143,21 +143,21 @@ export class Draw90DegreePolygonMode extends GeoJsonEditMode {
           props.onEdit(editAction);
         }
       }
+    } else {
+      // Trigger pointer move right away in order for it to update edit handles (to support double-click)
+      const fakePointerMoveEvent: PointerMoveEvent = {
+        screenCoords: [-1, -1],
+        mapCoords: event.mapCoords,
+        picks: [],
+        pointerDownPicks: null,
+        pointerDownScreenCoords: null,
+        pointerDownMapCoords: null,
+        cancelPan: () => {},
+        sourceEvent: null
+      };
+
+      this.handlePointerMove(fakePointerMoveEvent, props);
     }
-
-    // Trigger pointer move right away in order for it to update edit handles (to support double-click)
-    const fakePointerMoveEvent: PointerMoveEvent = {
-      screenCoords: [-1, -1],
-      mapCoords: event.mapCoords,
-      picks: [],
-      pointerDownPicks: null,
-      pointerDownScreenCoords: null,
-      pointerDownMapCoords: null,
-      cancelPan: () => {},
-      sourceEvent: null
-    };
-
-    this.handlePointerMove(fakePointerMoveEvent, props);
   }
 
   finalizedCoordinates(coords: Position[]) {


### PR DESCRIPTION
This pull request fixes drawing polygons with 90 degree angles.
Seems like the issue was running the fake pointer movement even if we were finishing the polygon.

https://github.com/user-attachments/assets/26e888bf-ff6e-4698-84fd-f08d9a4767e5

