### PR TITLE
Add option to override drawing with 90 degree lock by holding shift key

### DIFF
--- a/docs/modules/editable-layers/api-reference/edit-modes/draw-modes.md
+++ b/docs/modules/editable-layers/api-reference/edit-modes/draw-modes.md
@@ -75,6 +75,11 @@ User can draw a new `Polygon` feature with 90 degree corners (right angle) by cl
 
 [Source code](https://github.com/visgl/deck.gl-community/blob/master/modules/editable-layers/src/edit-modes/draw-90degree-polygon-mode.ts)
 
+The following options can be provided in the `modeConfig` object:
+
+- `overrideWithShift` (optional): `boolean`
+  - If `true`, it is possible to unlock from right angle temporarily by holding the shift key.
+
 ## DrawPolygonByDraggingMode
 
 User can draw a new `Polygon` feature by dragging (similar to the lasso tool commonly found in photo editing software).
@@ -98,6 +103,7 @@ The following options can be provided in the `modeConfig` object:
   - If `true`, user can click and drag instead of clicking twice. Note however, that the user will not be able to pan the map while drawing.
 
 ## DrawRectangleFromCenterMode
+
 User can draw a new rectangular `Polygon` feature by clicking the center then along a corner of the rectangle.
 
 The following options can be provided in the `modeConfig` object:
@@ -182,4 +188,3 @@ User can split a polygon by drawing a new `LineString` feature on top of the pol
 - If the clicked position is inside the polygon, it will not split the polygon
 
 [Source code](https://github.com/visgl/deck.gl-community/blob/master/modules/editable-layers/src/edit-modes/split-polygon-mode.ts)
-

--- a/examples/editable-layers/advanced/src/example.tsx
+++ b/examples/editable-layers/advanced/src/example.tsx
@@ -651,6 +651,30 @@ export default class Example extends React.Component<
     );
   }
 
+  _renderDraw90DegreePolygonModeControls() {
+    return (
+      <ToolboxRow key="draw-90-deg-polygon">
+        <ToolboxTitle>Override angle lock with shift</ToolboxTitle>
+        <ToolboxControl>
+          <input
+            type="checkbox"
+            checked={Boolean(
+              this.state.modeConfig && this.state.modeConfig.overrideWithShift
+            )}
+            onChange={(event) =>
+              this.setState({
+                modeConfig: {
+                  ...(this.state.modeConfig || {}),
+                  overrideWithShift: Boolean(event.target.checked)
+                }
+              })
+            }
+          />
+        </ToolboxControl>
+      </ToolboxRow>
+    );
+  }
+
   _renderModeConfigControls() {
     const controls: React.ReactElement[] = [];
 
@@ -675,6 +699,9 @@ export default class Example extends React.Component<
     }
     if (this.state.mode === DrawPolygonMode) {
       controls.push(this._renderDrawPolygonModeControls());
+    }
+    if (this.state.mode === Draw90DegreePolygonMode) {
+      controls.push(this._renderDraw90DegreePolygonModeControls());
     }
 
     return controls;

--- a/modules/editable-layers/src/edit-modes/draw-90degree-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-90degree-polygon-mode.ts
@@ -29,7 +29,10 @@ export class Draw90DegreePolygonMode extends GeoJsonEditMode {
     const {mapCoords} = props.lastPointerMoveEvent;
 
     let p3;
-    if (clickSequence.length <= 1) {
+    if (clickSequence.length <= 1 ||
+      // Allow overriding 90 degree enforcement with shift key
+      (props.modeConfig && props.modeConfig.overrideWithShift && props.lastPointerMoveEvent.sourceEvent.shiftKey)
+    ) {
       p3 = mapCoords;
     } else {
       const p1 = clickSequence[clickSequence.length - 2];

--- a/modules/editable-layers/src/edit-modes/draw-90degree-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-90degree-polygon-mode.ts
@@ -31,7 +31,7 @@ export class Draw90DegreePolygonMode extends GeoJsonEditMode {
     let p3;
     if (clickSequence.length <= 1 ||
       // Allow overriding 90 degree enforcement with shift key
-      (props.modeConfig && props.modeConfig.overrideWithShift && props.lastPointerMoveEvent.sourceEvent.shiftKey)
+      (props.modeConfig?.overrideWithShift && props.lastPointerMoveEvent.sourceEvent.shiftKey)
     ) {
       p3 = mapCoords;
     } else {


### PR DESCRIPTION
This pull request adds an option to temporarily "unlock" drawing with 90 degree angles by holding down the shift key.

https://github.com/user-attachments/assets/24eb4fcf-b113-4a98-a7ac-04fceec38422

