### PR TITLE
fix: update the url field in @deck.gl-community/react package.json

### DIFF
--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -5,7 +5,7 @@
   "version": "9.0.1",
   "repository": {
     "type": "git",
-    "url": "https://github.com/uber/@deck.gl-community"
+    "url": "https://github.com/visgl/deck.gl-community"
   },
   "scripts": {
     "test": "vitest run",


### PR DESCRIPTION
The URL in npm is pointing to wrong repo. This PR will fix this.
I have attached the screenshot of the current url in the npm.
<img width="487" alt="Screenshot 2024-08-08 at 10 08 20 PM" src="https://github.com/user-attachments/assets/e163a4e2-28bd-41c2-8c9c-e4f6fcbcee79">

