### PR TITLE
Enable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: I have a question / I need help
     url: https://github.com/visgl/deck.gl-community/discussions


### PR DESCRIPTION
I was planning to create a new issue to discuss whether arrow layers should accept Table or RecordBatch input. But currently the only way to create an issue is to fill out the full bug template.