### PR TITLE
Update peerdependencies in  package.json

### DIFF
--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -29,8 +29,8 @@
     "test": "vitest run",
     "test-watch": "vitest"
   },
-  "dependencies": {
-    "@deck.gl/core": "^9.0.12",
+  "peerDependencies": {
+   "@deck.gl/core": "^9.0.12",
     "@deck.gl/extensions": "^9.0.12",
     "@deck.gl/geo-layers": "^9.0.12",
     "@deck.gl/layers": "^9.0.12",
@@ -45,5 +45,5 @@
     "@luma.gl/core": "^9.0.11",
     "@luma.gl/engine": "^9.0.11",
     "@math.gl/core": "^4.0.0"
-  }
+  },
 }

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -45,5 +45,5 @@
     "@luma.gl/core": "^9.0.11",
     "@luma.gl/engine": "^9.0.11",
     "@math.gl/core": "^4.0.0"
-  },
+  }
 }


### PR DESCRIPTION
The @deck.gl-community/layers is causing some dependencies problem when using a different version of deck gl.
This PR fixes the problem by using peerdependencies