### PR TITLE
Exporting editable geojson layer props and fixing name casing

### DIFF
--- a/modules/editable-layers/src/editable-layers/editable-geojson-layer.ts
+++ b/modules/editable-layers/src/editable-layers/editable-geojson-layer.ts
@@ -113,7 +113,7 @@ function getEditHandleRadius(handle) {
   }
 }
 
-export type EditableGeojsonLayerProps<DataT = any> = EditableLayerProps & {
+export type EditableGeoJsonLayerProps<DataT = any> = EditableLayerProps & {
   data: DataT;
   mode?: any;
   modeConfig?: any;
@@ -173,7 +173,7 @@ export type EditableGeojsonLayerProps<DataT = any> = EditableLayerProps & {
   billboard?: boolean;
 };
 
-const defaultProps: DefaultProps<EditableGeojsonLayerProps<any>> = {
+const defaultProps: DefaultProps<EditableGeoJsonLayerProps<any>> = {
   mode: DEFAULT_EDIT_MODE,
 
   // Edit and interaction events
@@ -272,7 +272,7 @@ const modeNameMapping = {
 
 export class EditableGeoJsonLayer extends EditableLayer<
   FeatureCollection,
-  EditableGeojsonLayerProps<FeatureCollection>
+  EditableGeoJsonLayerProps<FeatureCollection>
 > {
   static layerName = 'EditableGeoJsonLayer';
   static defaultProps = defaultProps;
@@ -413,7 +413,7 @@ export class EditableGeoJsonLayer extends EditableLayer<
     this.setState({selectedFeatures});
   }
 
-  getModeProps(props: EditableGeojsonLayerProps<any>) {
+  getModeProps(props: EditableGeoJsonLayerProps<any>) {
     return {
       modeConfig: props.modeConfig,
       data: props.data,

--- a/modules/editable-layers/src/index.ts
+++ b/modules/editable-layers/src/index.ts
@@ -44,6 +44,8 @@ export type {EditMode} from './edit-modes/edit-mode';
 export type {GeoJsonEditModeType} from './edit-modes/geojson-edit-mode';
 export type {GeoJsonEditModeConstructor} from './edit-modes/geojson-edit-mode';
 
+export type {EditableGeoJsonLayerProps} from './editable-layers/editable-geojson-layer';
+
 export {GeoJsonEditMode} from './edit-modes/geojson-edit-mode';
 
 // Alter modes


### PR DESCRIPTION
Exporting EditableGeoJsonLayerProps type and fixing the naming casing between layer and props (fixes #163)