### PR TITLE
Adds onCancelPan optional prop and adds more calls to cancelPan

### DIFF
--- a/docs/modules/editable-layers/api-reference/layers/editable-geojson-layer.md
+++ b/docs/modules/editable-layers/api-reference/layers/editable-geojson-layer.md
@@ -145,6 +145,10 @@ The `onEdit` event is the core event provided by this layer and must be handled 
 
 * `editContext` (Object): `null` or an object containing additional context about the edit. This is populated by the active mode.
 
+#### `onCancelPan` (Function, optional)
+
+The `onCancelPan` event is called when map panning should be cancelled to enable feature dragging interactions while editing.
+
 ### Guide style properties and data getters
 
 #### `editHandleType`: (String, optional)

--- a/modules/editable-layers/src/edit-modes/extend-line-string-mode.ts
+++ b/modules/editable-layers/src/edit-modes/extend-line-string-mode.ts
@@ -62,6 +62,10 @@ export class ExtendLineStringMode extends GeoJsonEditMode {
 
     const mapCoords = props.lastPointerMoveEvent && props.lastPointerMoveEvent.mapCoords;
 
+    if (!mapCoords) {
+      return guides;
+    }
+
     // Draw an extension line starting from one end of the selected LineString to the cursor
     let startPosition: Position | null | undefined = null;
     const {modeConfig} = props;

--- a/modules/editable-layers/src/edit-modes/extrude-mode.ts
+++ b/modules/editable-layers/src/edit-modes/extrude-mode.ts
@@ -6,7 +6,8 @@ import bearing from '@turf/bearing';
 import {
   generatePointsParallelToLinePoints,
   getPickedEditHandle,
-  getPickedIntermediateEditHandle
+  getPickedIntermediateEditHandle,
+  shouldCancelPan
 } from './utils';
 import {FeatureCollection} from '../utils/geojson-types';
 import {ModeProps, StartDraggingEvent, StopDraggingEvent, DraggingEvent} from './types';
@@ -61,6 +62,10 @@ export class ExtrudeMode extends ModifyMode {
   }
 
   handleStartDragging(event: StartDraggingEvent, props: ModeProps<FeatureCollection>) {
+    if (shouldCancelPan(event)) {
+      event.cancelPan();
+    }
+
     const selectedFeatureIndexes = props.selectedIndexes;
 
     const editHandle = getPickedIntermediateEditHandle(event.picks);

--- a/modules/editable-layers/src/edit-modes/modify-mode.ts
+++ b/modules/editable-layers/src/edit-modes/modify-mode.ts
@@ -13,7 +13,8 @@ import {
   getPickedExistingEditHandle,
   getPickedIntermediateEditHandle,
   updateRectanglePosition,
-  NearestPointType
+  NearestPointType,
+  shouldCancelPan
 } from './utils';
 import {LineString, Point, Polygon, FeatureCollection, FeatureOf} from '../utils/geojson-types';
 import {
@@ -251,6 +252,10 @@ export class ModifyMode extends GeoJsonEditMode {
   }
 
   handleStartDragging(event: StartDraggingEvent, props: ModeProps<FeatureCollection>) {
+    if (shouldCancelPan(event)) {
+      event.cancelPan();
+    }
+
     const selectedFeatureIndexes = props.selectedIndexes;
 
     const editHandle = getPickedIntermediateEditHandle(event.picks);

--- a/modules/editable-layers/src/edit-modes/resize-circle-mode.ts
+++ b/modules/editable-layers/src/edit-modes/resize-circle-mode.ts
@@ -182,6 +182,7 @@ export class ResizeCircleMode extends GeoJsonEditMode {
 
   handleStartDragging(event: StartDraggingEvent, props: ModeProps<FeatureCollection>) {
     if (this._selectedEditHandle) {
+      event.cancelPan();
       this._isResizing = true;
     }
   }

--- a/modules/editable-layers/src/edit-modes/rotate-mode.ts
+++ b/modules/editable-layers/src/edit-modes/rotate-mode.ts
@@ -128,6 +128,7 @@ export class RotateMode extends GeoJsonEditMode {
 
   handleStartDragging(event: StartDraggingEvent, props: ModeProps<FeatureCollection>) {
     if (this._selectedEditHandle) {
+      event.cancelPan();
       this._isRotating = true;
       this._geometryBeingRotated = this.getSelectedFeaturesAsFeatureCollection(props);
     }

--- a/modules/editable-layers/src/edit-modes/scale-mode.ts
+++ b/modules/editable-layers/src/edit-modes/scale-mode.ts
@@ -152,6 +152,7 @@ export class ScaleMode extends GeoJsonEditMode {
 
   handleStartDragging(event: StartDraggingEvent, props: ModeProps<FeatureCollection>) {
     if (this._selectedEditHandle) {
+      event.cancelPan();
       this._isScaling = true;
       this._geometryBeingScaled = this.getSelectedFeaturesAsFeatureCollection(props);
     }

--- a/modules/editable-layers/src/edit-modes/transform-mode.ts
+++ b/modules/editable-layers/src/edit-modes/transform-mode.ts
@@ -33,6 +33,10 @@ export class TransformMode extends CompositeMode {
     let translateMode: TranslateMode | null = null;
     const filteredModes: GeoJsonEditMode[] = [];
 
+    if (event.picks.length) {
+      event.cancelPan();
+    }
+
     // If the user selects a scaling edit handle that overlaps with part of the selected feature,
     // it is possible for both scale and translate actions to be triggered. This logic prevents
     // this simultaneous action trigger from happening by putting a higher priority on scaling

--- a/modules/editable-layers/src/edit-modes/translate-mode.ts
+++ b/modules/editable-layers/src/edit-modes/translate-mode.ts
@@ -59,6 +59,7 @@ export class TranslateMode extends GeoJsonEditMode {
       return;
     }
 
+    event.cancelPan();
     this._geometryBeforeTranslate = this.getSelectedFeaturesAsFeatureCollection(props);
   }
 

--- a/modules/editable-layers/src/edit-modes/types.ts
+++ b/modules/editable-layers/src/edit-modes/types.ts
@@ -18,6 +18,7 @@ export type Pick = {
   index: number;
   object?: any;
   isGuide?: boolean;
+  featureType?: string;
   featureIndex?: number;
   type?: string;
   isEditingHandle?: boolean | null;

--- a/modules/editable-layers/src/edit-modes/utils.ts
+++ b/modules/editable-layers/src/edit-modes/utils.ts
@@ -11,7 +11,7 @@ import {flattenEach} from '@turf/meta';
 import {point, MultiLineString} from '@turf/helpers';
 import {getCoords} from '@turf/invariant';
 import WebMercatorViewport from 'viewport-mercator-project';
-import {Viewport, Pick, EditHandleFeature, EditHandleType} from './types';
+import {Viewport, Pick, EditHandleFeature, EditHandleType, StartDraggingEvent} from './types';
 import {
   Geometry,
   Position,
@@ -515,4 +515,8 @@ export function mapCoords(
       return mapCoords(coord, callback) as Position;
     })
     .filter(Boolean);
+}
+
+export function shouldCancelPan(event: StartDraggingEvent) {
+  return event.picks.length && event.picks.find((p) => p.featureType === 'points');
 }

--- a/modules/editable-layers/src/editable-layers/editable-layer.ts
+++ b/modules/editable-layers/src/editable-layers/editable-layer.ts
@@ -20,6 +20,7 @@ const EVENT_TYPES = ['anyclick', 'pointermove', 'panstart', 'panmove', 'panend',
 export type EditableLayerProps<DataType = any> = CompositeLayerProps & {
   pickingRadius?: number;
   pickingDepth?: number;
+  onCancelPan?: () => void;
 };
 
 export abstract class EditableLayer<
@@ -154,7 +155,13 @@ export abstract class EditableLayer<
       mapCoords,
       pointerDownScreenCoords: screenCoords,
       pointerDownMapCoords: mapCoords,
-      cancelPan: event.stopImmediatePropagation,
+      cancelPan: () => {
+        if (this.props.onCancelPan) {
+          this.props.onCancelPan();
+        }
+
+        event.stopImmediatePropagation();
+      },
       sourceEvent: event.srcEvent
     });
   }


### PR DESCRIPTION
Hello - thank you for building NebulaGL / `editable-layers`, it is a fantastic library.

This PR contains two small changes:

* Introduces an optional `onCancelPan` prop to `editable-layers`, allowing developers to execute their own logic when NebulaGL determines a map panning operation should be cancelled. This enables the event to propagate to a host mapping framework.
* Adds `event.cancelPan()` invocations for a variety of `EditModes`, ensuring `event.cancelPan` is being called at the appropriate time