### PR TITLE
Fix issue where modify mode can update the wrong vertex

### DIFF
--- a/modules/editable-layers/src/edit-modes/modify-mode.ts
+++ b/modules/editable-layers/src/edit-modes/modify-mode.ts
@@ -284,7 +284,7 @@ export class ModifyMode extends GeoJsonEditMode {
 
   handleStopDragging(event: StopDraggingEvent, props: ModeProps<FeatureCollection>) {
     const selectedFeatureIndexes = props.selectedIndexes;
-    const editHandle = getPickedEditHandle(event.picks);
+    const editHandle = getPickedEditHandle(event.pointerDownPicks);
     if (selectedFeatureIndexes.length && editHandle) {
       this._dragEditHandle('finishMovePosition', props, editHandle, event);
     }

--- a/modules/editable-layers/test/edit-modes/lib/__snapshots__/modify-mode.spec.ts.snap
+++ b/modules/editable-layers/test/edit-modes/lib/__snapshots__/modify-mode.spec.ts.snap
@@ -1,5 +1,91 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Correct coordinate edited when stopping near another guide 1`] = `
+{
+  "features": [
+    {
+      "geometry": {
+        "coordinates": [
+          1,
+          2,
+        ],
+        "type": "Point",
+      },
+      "properties": {
+        "editHandleType": "existing",
+        "featureIndex": 0,
+        "guideType": "editHandle",
+        "positionIndexes": [
+          0,
+        ],
+      },
+      "type": "Feature",
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          2,
+          3,
+        ],
+        "type": "Point",
+      },
+      "properties": {
+        "editHandleType": "existing",
+        "featureIndex": 0,
+        "guideType": "editHandle",
+        "positionIndexes": [
+          1,
+        ],
+      },
+      "type": "Feature",
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          3,
+          4,
+        ],
+        "type": "Point",
+      },
+      "properties": {
+        "editHandleType": "existing",
+        "featureIndex": 0,
+        "guideType": "editHandle",
+        "positionIndexes": [
+          2,
+        ],
+      },
+      "type": "Feature",
+    },
+  ],
+  "type": "FeatureCollection",
+}
+`;
+
+exports[`Correct coordinate edited when stopping near another guide 2`] = `
+{
+  "geometry": {
+    "coordinates": [
+      [
+        3.1,
+        4.1,
+      ],
+      [
+        2,
+        3,
+      ],
+      [
+        3,
+        4,
+      ],
+    ],
+    "type": "LineString",
+  },
+  "properties": {},
+  "type": "Feature",
+}
+`;
+
 exports[`Rectangular polygon feature preserves shape 1`] = `
 {
   "features": [

--- a/modules/editable-layers/test/edit-modes/test-utils.ts
+++ b/modules/editable-layers/test/edit-modes/test-utils.ts
@@ -345,7 +345,8 @@ export function createStartDraggingEvent(
 export function createStopDraggingEvent(
   mapCoords: Position,
   pointerDownMapCoords: Position,
-  picks: Pick[] = []
+  picks: Pick[] = [],
+  pointerDownPicks: Pick[] | null = null
 ): StopDraggingEvent {
   lastCoords = mapCoords;
 
@@ -353,7 +354,7 @@ export function createStopDraggingEvent(
     screenCoords: [-1, -1],
     mapCoords,
     picks,
-    pointerDownPicks: null,
+    pointerDownPicks,
     pointerDownScreenCoords: [-1, -1],
     pointerDownMapCoords,
     sourceEvent: null


### PR DESCRIPTION
Possible fix for https://github.com/visgl/deck.gl-community/issues/150 where ModifyMode can update the wrong vertex in the feature.

The regression test will fail without the fix in place, the test output demonstrating how the wrong vertex is be updated when using "picks" instead of "pointerDownPicks":

![image (1)](https://github.com/user-attachments/assets/3db6860f-3180-4d4f-bbff-5e35e3a2c260)
