### PR TITLE
yarn publish: Do not bump in private packages

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,10 @@
   ],
   "npmClient": "yarn",
   "command": {
-    "bootstrap": {}
+    "bootstrap": {},
+    "version": {
+      "private": false
+    }
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
To avoid unintended changes when running `yarn publish-beta`

Before:
```
yarn publish-beta
...
npx lerna version prerelease --force-publish --exact --no-commit-hooks
Changes:
 - @deck.gl-community/arrow-layers: 9.1.0-beta.0 => 9.1.0-beta.1 (private)
 - @deck.gl-community/bing-maps: 9.1.0-beta.0 => 9.1.0-beta.1
 - @deck.gl-community/editable-layers: 9.1.0-beta.0 => 9.1.0-beta.1
 - @deck.gl-community/experimental: 9.1.0-beta.0 => 9.1.0-beta.1
 - @deck.gl-community/graph-layers: 9.1.0-beta.0 => 9.1.0-beta.1
 - @deck.gl-community/layers: 9.1.0-beta.0 => 9.1.0-beta.1
 - @deck.gl-community/leaflet: 9.1.0-beta.0 => 9.1.0-beta.1 (private)
 - @deck.gl-community/deck.gl-raster: 0.3.1 => 0.3.2-alpha.0 (private)
 - @deck.gl-community/react: 9.1.0-beta.0 => 9.1.0-beta.1
 - @deck.gl-community/template: 0.0.4 => 0.0.5-alpha.0 (private)
```

After:
```
yarn publish-beta
...
npx lerna version prerelease --force-publish --exact --no-commit-hooks
Changes:
 - @deck.gl-community/bing-maps: 9.1.0-beta.0 => 9.1.0-beta.1
 - @deck.gl-community/editable-layers: 9.1.0-beta.0 => 9.1.0-beta.1
 - @deck.gl-community/experimental: 9.1.0-beta.0 => 9.1.0-beta.1
 - @deck.gl-community/graph-layers: 9.1.0-beta.0 => 9.1.0-beta.1
 - @deck.gl-community/layers: 9.1.0-beta.0 => 9.1.0-beta.1
 - @deck.gl-community/react: 9.1.0-beta.0 => 9.1.0-beta.1
```