### PR TITLE
Replace missed occurrences of ocular-dev-tools to @vis.gl/dev-tools

### DIFF
--- a/.ocularrc.js
+++ b/.ocularrc.js
@@ -1,4 +1,4 @@
-/** @typedef {import('ocular-dev-tools').OcularConfig} OcularConfig */
+/** @typedef {import('@vis.gl/dev-tools').OcularConfig} OcularConfig */
 
 import {dirname, join} from 'path';
 import {fileURLToPath} from 'url';

--- a/examples/vite.config.local.mjs
+++ b/examples/vite.config.local.mjs
@@ -3,7 +3,7 @@
 // of building against their installed version of the modules.
 
 import {defineConfig} from 'vite';
-import {getOcularConfig} from 'ocular-dev-tools';
+import {getOcularConfig} from '@vis.gl/dev-tools';
 import {join} from 'path';
 
 const rootDir = join(__dirname, '..');


### PR DESCRIPTION
Running `yarn start-local` in examples directories fails with:

```
❯ yarn start-local
failed to load config from /Users/zakjan/code/zakjan/deck.gl-community/examples/vite.config.local.mjs
error when starting dev server:
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'ocular-dev-tools' imported from /Users/zakjan/code/zakjan/deck.gl-community/examples/vite.config.local.mjs.timestamp-1739689952140-95c3fea2c2856.mjs
    at packageResolve (node:internal/modules/esm/resolve:854:9)
    at moduleResolve (node:internal/modules/esm/resolve:927:18)
    at defaultResolve (node:internal/modules/esm/resolve:1169:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:542:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:510:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:239:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:96:40)
    at link (node:internal/modules/esm/module_job:95:36)
```

The cause is a replaced package from ocular-dev-tools to @vis.gl/dev-tools in https://github.com/visgl/deck.gl-community/pull/215