### PR TITLE
[editable-layers] Real double-click used to finish drawing

### DIFF
--- a/modules/editable-layers/src/edit-modes/draw-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-polygon-mode.ts
@@ -10,7 +10,8 @@ import {
   ModeProps,
   GuideFeatureCollection,
   TentativeFeature,
-  GuideFeature
+  GuideFeature,
+  DoubleClickEvent
 } from './types';
 import {Polygon, FeatureCollection} from '../utils/geojson-types';
 import {getPickedEditHandle} from './utils';
@@ -83,6 +84,23 @@ export class DrawPolygonMode extends GeoJsonEditMode {
     return guides;
   }
 
+  finishDrawing(props: ModeProps<FeatureCollection>) {
+    const clickSequence = this.getClickSequence();
+    if (clickSequence.length > 2) {
+      const polygonToAdd: Polygon = {
+        type: 'Polygon',
+        coordinates: [[...clickSequence, clickSequence[0]]]
+      };
+
+      this.resetClickSequence();
+
+      const editAction = this.getAddFeatureOrBooleanPolygonAction(polygonToAdd, props);
+      if (editAction) {
+        props.onEdit(editAction);
+      }
+    }
+  }
+
   // eslint-disable-next-line complexity
   handleClick(event: ClickEvent, props: ModeProps<FeatureCollection>) {
     const {picks} = event;
@@ -117,19 +135,7 @@ export class DrawPolygonMode extends GeoJsonEditMode {
         clickedEditHandle.properties.positionIndexes[0] === clickSequence.length - 1)
     ) {
       // They clicked the first or last point (or double-clicked), so complete the polygon
-
-      // Remove the hovered position
-      const polygonToAdd: Polygon = {
-        type: 'Polygon',
-        coordinates: [[...clickSequence, clickSequence[0]]]
-      };
-
-      this.resetClickSequence();
-
-      const editAction = this.getAddFeatureOrBooleanPolygonAction(polygonToAdd, props);
-      if (editAction) {
-        props.onEdit(editAction);
-      }
+      this.finishDrawing(props);
     } else if (positionAdded) {
       // new tentative point
       props.onEdit({
@@ -143,21 +149,13 @@ export class DrawPolygonMode extends GeoJsonEditMode {
     }
   }
 
+  handleDoubleClick(event: DoubleClickEvent, props: ModeProps<FeatureCollection>) {
+    this.finishDrawing(props);
+  }
+
   handleKeyUp(event: KeyboardEvent, props: ModeProps<FeatureCollection>) {
     if (event.key === 'Enter') {
-      const clickSequence = this.getClickSequence();
-      if (clickSequence.length > 2) {
-        const polygonToAdd: Polygon = {
-          type: 'Polygon',
-          coordinates: [[...clickSequence, clickSequence[0]]]
-        };
-        this.resetClickSequence();
-
-        const editAction = this.getAddFeatureOrBooleanPolygonAction(polygonToAdd, props);
-        if (editAction) {
-          props.onEdit(editAction);
-        }
-      }
+      this.finishDrawing(props);
     } else if (event.key === 'Escape') {
       this.resetClickSequence();
       props.onEdit({

--- a/modules/editable-layers/src/edit-modes/edit-mode.ts
+++ b/modules/editable-layers/src/edit-modes/edit-mode.ts
@@ -11,12 +11,15 @@ import {
   StopDraggingEvent,
   DraggingEvent,
   Tooltip,
-  ModeProps
+  ModeProps,
+  DoubleClickEvent
 } from './types';
 
 export interface EditMode<TData, TGuides> {
   // Called when the pointer went down and up without dragging regardless of whether something was picked
   handleClick(event: ClickEvent, props: ModeProps<TData>): void;
+  // Called when the pointer double-clicked
+  handleDoubleClick(event: DoubleClickEvent, props: ModeProps<TData>): void;
   // Called when the pointer moved, regardless of whether the pointer is down, up, and whether something was picked
   handlePointerMove(event: PointerMoveEvent, props: ModeProps<TData>): void;
   // Called when the pointer went down on something rendered by this layer and the pointer started to move

--- a/modules/editable-layers/src/edit-modes/geojson-edit-mode.ts
+++ b/modules/editable-layers/src/edit-modes/geojson-edit-mode.ts
@@ -253,6 +253,8 @@ export class GeoJsonEditMode implements EditMode<FeatureCollection, GuideFeature
   }
 
   handleClick(event: ClickEvent, props: ModeProps<FeatureCollection>): void {}
+  handleDoubleClick(event: ClickEvent, props: ModeProps<FeatureCollection>): void {}
+
   handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>): void {
     const tentativeFeature = this.createTentativeFeature(props);
     if (tentativeFeature) {

--- a/modules/editable-layers/src/edit-modes/types.ts
+++ b/modules/editable-layers/src/edit-modes/types.ts
@@ -44,6 +44,9 @@ export type BasePointerEvent = {
 // Represents a click event
 export type ClickEvent = BasePointerEvent;
 
+// Represents a double click event
+export type DoubleClickEvent = BasePointerEvent;
+
 // Represents an event that occurs when the pointer goes down and the cursor starts moving
 export type StartDraggingEvent = BasePointerEvent & {
   pointerDownPicks?: Pick[] | null;

--- a/modules/editable-layers/src/editable-layers/editable-geojson-layer.ts
+++ b/modules/editable-layers/src/editable-layers/editable-geojson-layer.ts
@@ -12,7 +12,8 @@ import {
   StartDraggingEvent,
   StopDraggingEvent,
   DraggingEvent,
-  PointerMoveEvent
+  PointerMoveEvent,
+  DoubleClickEvent
 } from '../edit-modes/types';
 
 import {ViewMode} from '../edit-modes/view-mode';
@@ -565,6 +566,12 @@ export class EditableGeoJsonLayer extends EditableLayer<
 
   onLayerClick(event: ClickEvent): void {
     this.getActiveMode().handleClick(event, this.getModeProps(this.props) as any);
+  }
+
+  onLayerDoubleClick(event: DoubleClickEvent): void {
+    if (this.getActiveMode().handleDoubleClick) {
+      this.getActiveMode().handleDoubleClick(event, this.getModeProps(this.props) as any);
+    }
   }
 
   onLayerKeyUp(event: KeyboardEvent): void {

--- a/modules/editable-layers/src/editable-layers/editable-layer.ts
+++ b/modules/editable-layers/src/editable-layers/editable-layer.ts
@@ -11,11 +11,12 @@ import {
   ClickEvent,
   StartDraggingEvent,
   StopDraggingEvent,
-  PointerMoveEvent
+  PointerMoveEvent,
+  DoubleClickEvent
 } from '../edit-modes/types';
 import {Position} from '../utils/geojson-types';
 
-const EVENT_TYPES = ['click', 'pointermove', 'panstart', 'panmove', 'panend', 'keyup'];
+const EVENT_TYPES = ['click', 'pointermove', 'panstart', 'panmove', 'panend', 'keyup', 'dblclick'];
 
 // TODO(v9): remove generic layer
 export type EditableLayerProps<DataType = any> = CompositeLayerProps & {
@@ -34,6 +35,9 @@ export abstract class EditableLayer<
 
   // Overridable interaction event handlers
   onLayerClick(event: ClickEvent): void {
+    // default implementation - do nothing
+  }
+  onLayerDoubleClick(event: DoubleClickEvent): void {
     // default implementation - do nothing
   }
 
@@ -130,6 +134,10 @@ export abstract class EditableLayer<
       picks,
       sourceEvent: srcEvent
     });
+  }
+
+  _ondblclick({srcEvent}: any) {
+    this.onLayerDoubleClick(srcEvent);
   }
 
   _onkeyup({srcEvent}: {srcEvent: KeyboardEvent}) {


### PR DESCRIPTION
Drawing of Polygon and LineString can now be finished using a normal double click.
Before this change drawing was finished by "Enter" key or by "slow double click" which wasn't recognized as a normal "double click".
This was a regress to old nebula.gl and older deck which I was using earlier.