### PR TITLE
feat: GlobalGridLayer example (experimental)

### DIFF
--- a/examples/geo-layers/globe-views/app.ts
+++ b/examples/geo-layers/globe-views/app.ts
@@ -1,0 +1,94 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+
+import { Deck, _GlobeView } from '@deck.gl/core';
+import { GlobalGridLayer, H3Grid, A5Grid, S2Grid, GeohashGrid, QuadkeyGrid } from '@deck.gl-community/layers';
+import { getRes0Cells } from 'h3-js';
+
+const INITIAL_VIEW_STATE = {
+  latitude: 0,
+  longitude: 0,
+  zoom: 1,
+  minZoom: 1,
+  maxZoom: 1,
+  pitch: 0,
+  bearing: 0
+};
+
+const GRIDS = [
+  {
+    globalGrid: H3Grid,
+    data: getRes0Cells(),
+    // data: ['85283473fffffff', '85283477fffffff'],
+    color: [255, 0, 0, 100],
+    padding: { left: 100, right: 0, top: 100, bottom: 0 }
+  },
+  {
+    globalGrid: H3Grid,
+    data: getRes0Cells(),
+    // data: ['85283473fffffff', '85283477fffffff'],
+    color: [0, 255, 0, 100],
+    padding: { left: 0, right: 0, top: 400, bottom: 0 }
+  },
+  // {
+  //   grid: A5Grid,
+  //   data: ['63605e0000000000', '63606a0000000000']
+  // },
+  // {
+  //   grid: S2Grid,
+  //   data: ['89c25', '89c259']
+  // },
+  // {
+  //   grid: GeohashGrid,
+  //   data: ['u4pruydqqvj', 'u4pruydqqvm']
+  // },
+  // {
+  //   grid: QuadkeyGrid,
+  //   data: ['023112232', '023112233']
+  // }
+];
+
+const ViewProps = [
+  [255, 0, 0, 100],
+  [0, 128, 255, 100],
+  [0, 255, 0, 100],
+  [255, 255, 0, 100],
+  [255, 0, 255, 100]
+] as const satisfies [number, number, number, number][];
+
+
+export function exampleApplication() {
+  const views = GRIDS.map(({ globalGrid, padding }, i) => new _GlobeView({
+    id: globalGrid.name,
+    controller: true,
+    padding,
+  }));
+
+  const layers = GRIDS.map(({ globalGrid, data, color }, i) => new GlobalGridLayer({
+    id: globalGrid.name,
+    data: data.map(cellId => ({ cellId })),
+    globalGrid,
+    filled: true,
+    stroked: true,
+    getFillColor: color as [number, number, number, number],
+    getLineColor: [255, 255, 255],
+    lineWidthUnits: 'pixels',
+    lineWidthScale: 10,
+    lineWidthMinPixels: 1,
+    parameters: {
+      depthWriteEnabled: true,
+      depthCompare: 'less-equal',
+      cullMode: 'back'
+    }
+  }));
+
+  const deck = new Deck<_GlobeView[]>({
+    initialViewState: {
+      H3: INITIAL_VIEW_STATE,
+      A5: INITIAL_VIEW_STATE,
+    },
+    views,
+    layerFilter: ({ layer, viewport }) => layer.id == viewport.id,
+    layers
+  });
+}

--- a/examples/geo-layers/globe-views/index.html
+++ b/examples/geo-layers/globe-views/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>GlobalGridLayer Globe Views</title>
+    <style>
+      body { margin: 0; }
+      #container { position: absolute; width: 100%; height: 100%; }
+    </style>
+  </head>
+  <body>
+    <div id="container"></div>
+    <script type="module">
+      import {exampleApplication} from './app.ts';
+      exampleApplication();
+    </script>
+  </body>
+</html>

--- a/examples/geo-layers/globe-views/package.json
+++ b/examples/geo-layers/globe-views/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "global-grid-layer-globe-views",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "start": "vite --open",
+    "start-local": "vite --config ../../vite.config.local.mjs"
+  },
+  "dependencies": {
+    "@deck.gl-community/layers": "^9.1.0-beta.5",
+    "@deck.gl/core": "^9.1.12"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.4",
+    "vite": "^5.2.8"
+  }
+}

--- a/examples/geo-layers/globe-views/tsconfig.json
+++ b/examples/geo-layers/globe-views/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./*.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1939,7 +1939,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@deck.gl-community/layers@workspace:modules/layers":
+"@deck.gl-community/layers@npm:^9.1.0-beta.5, @deck.gl-community/layers@workspace:modules/layers":
   version: 0.0.0-use.local
   resolution: "@deck.gl-community/layers@workspace:modules/layers"
   dependencies:
@@ -14455,6 +14455,17 @@ __metadata:
   checksum: 10c0/2f6c2b9ee019ee21dc258ae97a88719614591e4c979cb4580b1b9df6f0f778a3cb38b4bdaf18dfa584637ea10f89a3c5f2533a5e449cf8741514ad18b0951f2e
   languageName: node
   linkType: hard
+
+"global-grid-layer-globe-views@workspace:examples/geo-layers/globe-views":
+  version: 0.0.0-use.local
+  resolution: "global-grid-layer-globe-views@workspace:examples/geo-layers/globe-views"
+  dependencies:
+    "@deck.gl-community/layers": "npm:^9.1.0-beta.5"
+    "@deck.gl/core": "npm:^9.1.12"
+    typescript: "npm:^5.4.4"
+    vite: "npm:^5.2.8"
+  languageName: unknown
+  linkType: soft
 
 "global-modules@npm:^1.0.0":
   version: 1.0.0


### PR DESCRIPTION
Super quick test to see how feasible a minimal multi-globe res0 example for GlobalGridLayer would be:

![global-grids](https://github.com/user-attachments/assets/ccb22322-2d25-41a5-b8d2-ebbfd0c429ab)

One problem is generating the grids, H3 has a function for this.
