### PR TITLE
docs: fix url to turf distance documentation

### DIFF
--- a/docs/modules/editable-layers/api-reference/edit-modes/measurement-modes.md
+++ b/docs/modules/editable-layers/api-reference/edit-modes/measurement-modes.md
@@ -10,7 +10,7 @@ The following options can be provided in the `modeConfig` object:
 
 - `turfOptions` (Object, optional)
 
-  - `options` object passed to turf's [distance](https://turfjs.org/docs/#distance) function
+  - `options` object passed to turf's [distance](https://turfjs.org/docs/api/distance) function
   - Default: `undefined`
 
 - `formatTooltip` (Function, optional)


### PR DESCRIPTION
Current url does not work.
![image](https://github.com/user-attachments/assets/44e2bb12-138f-4092-bc7f-a9349d40dc29)
