### PR TITLE
fix: prevent removing corner of a rectangle when lockRectangles is used

### DIFF
--- a/modules/editable-layers/src/edit-modes/modify-mode.ts
+++ b/modules/editable-layers/src/edit-modes/modify-mode.ts
@@ -146,25 +146,31 @@ export class ModifyMode extends GeoJsonEditMode {
     if (pickedExistingHandle) {
       const {featureIndex, positionIndexes} = pickedExistingHandle.properties;
 
-      let updatedData;
-      try {
-        updatedData = new ImmutableFeatureCollection(props.data)
-          .removePosition(featureIndex, positionIndexes)
-          .getObject();
-      } catch (ignored) {
-        // This happens if user attempts to remove the last point
-      }
+      const feature = props.data.features[featureIndex];
+      const canRemovePosition = !(
+        props.modeConfig?.lockRectangles && feature?.properties.shape === 'Rectangle'
+      );
+      if (canRemovePosition) {
+        let updatedData;
+        try {
+          updatedData = new ImmutableFeatureCollection(props.data)
+            .removePosition(featureIndex, positionIndexes)
+            .getObject();
+        } catch (ignored) {
+          // This happens if user attempts to remove the last point
+        }
 
-      if (updatedData) {
-        props.onEdit({
-          updatedData,
-          editType: 'removePosition',
-          editContext: {
-            featureIndexes: [featureIndex],
-            positionIndexes,
-            position: pickedExistingHandle.geometry.coordinates
-          }
-        });
+        if (updatedData) {
+          props.onEdit({
+            updatedData,
+            editType: 'removePosition',
+            editContext: {
+              featureIndexes: [featureIndex],
+              positionIndexes,
+              position: pickedExistingHandle.geometry.coordinates
+            }
+          });
+        }
       }
     } else if (pickedIntermediateHandle) {
       const {featureIndex, positionIndexes} = pickedIntermediateHandle.properties;


### PR DESCRIPTION
Added a simple check, similar to the one just below for hiding intermediate handles.
https://github.com/visgl/deck.gl-community/blob/b67a0b1635fa2a9831706ac1d8884cf554890531/modules/editable-layers/src/edit-modes/modify-mode.ts#L172-L177

When `lockRectangles: true` it is no longer possible to click on a corner of a rectangle to remove it.
