### PR TITLE
Horizon Layer

### DIFF
--- a/examples/layers/horizon-graph-layer/app.tsx
+++ b/examples/layers/horizon-graph-layer/app.tsx
@@ -1,0 +1,509 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {OrthographicViewState} from '@deck.gl/core';
+
+import React, {useState, useMemo, ReactElement} from 'react';
+import DeckGL from '@deck.gl/react';
+import {OrthographicView} from '@deck.gl/core';
+import {TextLayer, LineLayer} from '@deck.gl/layers';
+import {MultiHorizonGraphLayer} from '@deck.gl-community/layers';
+
+const INITIAL_VIEW_STATE: OrthographicViewState = {
+  target: [400, 300, 0],
+  zoom: 0
+};
+
+type ExampleDataType = 'sine' | 'sine+noise' | 'noise' | 'flat' | 'sawtooth' | 'square';
+
+type ExampleData = {
+  name: string;
+  type: ExampleDataType;
+  values: Float32Array;
+  scale: number;
+};
+
+const POINTS_PER_SERIES = 10000;
+
+const generateSeriesData = (
+  type: ExampleDataType,
+  count: number = POINTS_PER_SERIES
+): Float32Array => {
+  const seriesValues = new Float32Array(count);
+  for (let i = 0; i < count; i++) {
+    const t = i * 0.0015;
+
+    switch (type) {
+      case 'sine':
+        seriesValues[i] = Math.sin(t) * 100;
+        break;
+      case 'sine+noise':
+        seriesValues[i] = Math.sin(t) * 100 + (Math.random() - 0.5) * 30;
+        break;
+      case 'noise':
+        seriesValues[i] = (Math.random() - 0.5) * 100;
+        break;
+      case 'flat':
+        seriesValues[i] = 42; // Answer to Everything
+        break;
+      case 'sawtooth': {
+        const period = 2 * Math.PI;
+        const phaseShifted = t % period;
+        seriesValues[i] = (phaseShifted / Math.PI - 1) * 100;
+        break;
+      }
+      case 'square':
+        seriesValues[i] = Math.sin(t) > 0 ? 100 : -100;
+        break;
+      default:
+        throw new Error('bad data type');
+    }
+  }
+
+  return seriesValues;
+};
+
+// Helper functions to convert between RGB arrays and hex colors
+const rgbToHex = (rgb: [number, number, number]) => {
+  return `#${rgb.map((c) => c.toString(16).padStart(2, '0')).join('')}`;
+};
+
+const hexToRgb = (hex: string): [number, number, number] => {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return result
+    ? [parseInt(result[1], 16), parseInt(result[2], 16), parseInt(result[3], 16)]
+    : [0, 0, 0];
+};
+
+export default function App(): ReactElement {
+  const [bands, setBands] = useState(2);
+  const [seriesCount, setSeriesCount] = useState(5);
+  const [seriesTypes, setSeriesTypes] = useState<ExampleDataType[]>([
+    'sine',
+    'sine+noise',
+    'noise',
+    'sawtooth',
+    'square'
+  ]);
+  const [dividerWidth, setDividerWidth] = useState(0.75);
+
+  // Color controls
+  const [positiveColor, setPositiveColor] = useState<[number, number, number]>([0, 128, 0]);
+  const [negativeColor, setNegativeColor] = useState<[number, number, number]>([0, 0, 255]);
+  const [dividerColor, setDividerColor] = useState<[number, number, number]>([0, 0, 0]);
+
+  // Position and size controls
+  const [x, setX] = useState(0);
+  const [y, setY] = useState(0);
+  const [width, setWidth] = useState(800);
+  const [heightPerSeries, setHeightPerSeries] = useState(25);
+
+  const height = heightPerSeries * seriesCount;
+
+  // Mouse tracking for crosshair
+  const [mousePosition, setMousePosition] = useState<[number, number] | null>(null);
+
+  // Generate sample time-series data as series arrays
+
+  const sampleData = useMemo(() => {
+    const _sampleData: Float32Array[] = [];
+
+    for (let series = 0; series < 5; series++) {
+      _sampleData.push(generateSeriesData(seriesTypes[series]));
+    }
+
+    return _sampleData;
+  }, [seriesTypes]);
+
+  const data = useMemo(() => {
+    const _data: ExampleData[] = [];
+
+    for (let series = 0; series < seriesCount; series++) {
+      _data.push({
+        name: `Series ${series + 1}`,
+        type: seriesTypes[series % 5],
+        values: sampleData[series % 5],
+        scale: 120
+      });
+    }
+
+    return _data;
+  }, [seriesCount, seriesTypes]);
+
+  // Generate text labels for each series
+  const textLabels = useMemo(() => {
+    const totalDividerSpace = dividerWidth * (seriesCount + 1);
+    const availableHeight = height - totalDividerSpace;
+    const seriesHeight = availableHeight / seriesCount;
+
+    return data.map((series, index) => ({
+      text: `${series.name} (${series.type})`,
+      position: [
+        x - 10,
+        y + dividerWidth + index * (seriesHeight + dividerWidth) + seriesHeight / 2,
+        0
+      ],
+      size: 12,
+      color: [80, 80, 80],
+      angle: 0,
+      textAnchor: 'end',
+      alignmentBaseline: 'center'
+    }));
+  }, [data, seriesCount, dividerWidth, height, x, y]);
+
+  // Calculate intersection values when mouse is over the chart
+  const intersectionData = useMemo(() => {
+    if (!mousePosition) return [];
+
+    const [mouseX] = mousePosition;
+
+    // Check if mouse is within chart X bounds
+    if (mouseX < x || mouseX > x + width) {
+      return [];
+    }
+
+    // Calculate which x-index we're at in the data
+    const xRatio = (mouseX - x) / width;
+    const dataIndex = Math.round(xRatio * (POINTS_PER_SERIES - 1)); // 0-99 data points
+
+    if (dataIndex < 0 || dataIndex >= POINTS_PER_SERIES) return [];
+
+    const totalDividerSpace = dividerWidth * (seriesCount + 1);
+    const availableHeight = height - totalDividerSpace;
+    const seriesHeight = availableHeight / seriesCount;
+
+    // Show values for ALL series when mouse is within chart X bounds
+    return data.map((series, index) => {
+      const seriesBottom = y + dividerWidth + index * (seriesHeight + dividerWidth);
+      const value = series.values[dataIndex];
+      const seriesCenter = seriesBottom + seriesHeight / 2;
+
+      return {
+        text: `${value.toFixed(1)}`,
+        position: [x + width + 10, seriesCenter, 0],
+        size: 12,
+        color: [80, 80, 80],
+        angle: 0,
+        textAnchor: 'start',
+        alignmentBaseline: 'center'
+      };
+    });
+  }, [mousePosition, data, x, y, width, height, seriesCount, dividerWidth]);
+
+  // Vertical line data
+  const verticalLineData = useMemo(() => {
+    if (!mousePosition) return [];
+
+    const [mouseX] = mousePosition;
+
+    // Only show line if mouse is within chart X bounds
+    if (mouseX < x || mouseX > x + width) return [];
+
+    return [
+      {
+        sourcePosition: [mouseX, y, 0],
+        targetPosition: [mouseX, y + height, 0]
+      }
+    ];
+  }, [mousePosition, x, y, width, height]);
+
+  const layers = [
+    new MultiHorizonGraphLayer({
+      id: 'horizon-graph-layer',
+      data,
+      bands,
+      dividerWidth,
+      positiveColor,
+      negativeColor,
+      dividerColor,
+      x,
+      y,
+      width,
+      height
+    }),
+    new TextLayer({
+      id: 'series-labels',
+      data: textLabels,
+      getText: (d: any) => d.text,
+      getPosition: (d: any) => d.position,
+      getSize: (d: any) => d.size,
+      getColor: (d: any) => d.color,
+      getAngle: (d: any) => d.angle,
+      getTextAnchor: (d: any) => d.textAnchor,
+      getAlignmentBaseline: (d: any) => d.alignmentBaseline,
+      fontFamily: 'Arial, sans-serif',
+      fontWeight: 'normal'
+    }),
+    new LineLayer({
+      id: 'vertical-crosshair',
+      data: verticalLineData,
+      getSourcePosition: (d: any) => d.sourcePosition,
+      getTargetPosition: (d: any) => d.targetPosition,
+      getColor: [0, 0, 0, 200],
+      getWidth: 1,
+      widthUnits: 'pixels'
+    }),
+    new TextLayer({
+      id: 'intersection-values',
+      data: intersectionData,
+      getText: (d: any) => d.text,
+      getPosition: (d: any) => d.position,
+      getSize: (d: any) => d.size,
+      getColor: (d: any) => d.color,
+      getAngle: (d: any) => d.angle,
+      getTextAnchor: (d: any) => d.textAnchor,
+      getAlignmentBaseline: (d: any) => d.alignmentBaseline,
+      fontFamily: 'Arial, sans-serif',
+      fontWeight: 'normal'
+    })
+  ];
+
+  return (
+    <div style={{display: 'flex', width: '100vw', height: '100vh', overflow: 'hidden'}}>
+      <div
+        style={{
+          width: '350px',
+          height: '100vh',
+          overflowY: 'auto',
+          background: 'rgba(255, 255, 255, 0.95)',
+          padding: '15px',
+          fontFamily: 'Arial, sans-serif',
+          boxShadow: '2px 0 10px rgba(0,0,0,0.1)',
+          borderRight: '1px solid #ddd'
+        }}
+      >
+        <div style={{marginBottom: '15px'}}>
+          <label style={{display: 'block', fontWeight: 'bold', marginBottom: '5px'}}>
+            Number of Series:
+          </label>
+          <select
+            value={seriesCount}
+            onChange={(e) => setSeriesCount(Number(e.target.value))}
+            style={{width: '100%', padding: '5px'}}
+          >
+            <option value={1}>1</option>
+            <option value={2}>2</option>
+            <option value={3}>3</option>
+            <option value={4}>4</option>
+            <option value={5}>5</option>
+            <option value={10}>10</option>
+            <option value={20}>20</option>
+            <option value={100}>100</option>
+            <option value={1000}>1000</option>
+            <option value={10000}>10000</option>
+          </select>
+        </div>
+
+        <div style={{marginBottom: '15px'}}>
+          <label style={{display: 'block', fontWeight: 'bold', marginBottom: '5px'}}>Bands:</label>
+          <select
+            value={bands}
+            onChange={(e) => setBands(Number(e.target.value))}
+            style={{width: '100%', padding: '5px'}}
+          >
+            <option value={1}>1</option>
+            <option value={2}>2</option>
+            <option value={3}>3</option>
+            <option value={4}>4</option>
+            <option value={5}>5</option>
+            <option value={6}>6</option>
+          </select>
+        </div>
+
+        <div style={{marginBottom: '15px'}}>
+          <label style={{display: 'block', fontWeight: 'bold', marginBottom: '5px'}}>
+            Divider Line Width:
+          </label>
+          <input
+            type="range"
+            min="0"
+            max="10"
+            step="0.25"
+            value={dividerWidth}
+            onChange={(e) => setDividerWidth(Number(e.target.value))}
+            style={{width: '100%'}}
+          />
+          <div style={{fontSize: '12px', color: '#666', textAlign: 'center'}}>{dividerWidth}</div>
+        </div>
+
+        <div style={{marginBottom: '15px'}}>
+          <label style={{display: 'block', fontWeight: 'bold', marginBottom: '10px'}}>
+            Series Data Types:
+          </label>
+          {Array.from({length: 5}, (_, i) => (
+            <div key={i} style={{marginBottom: '8px'}}>
+              <label style={{display: 'block', fontSize: '12px', marginBottom: '3px'}}>
+                Series {i + 1}:
+              </label>
+              <select
+                value={seriesTypes[i]}
+                onChange={(e) => {
+                  const newTypes = [...seriesTypes];
+                  newTypes[i] = e.target.value as ExampleDataType;
+                  setSeriesTypes(newTypes);
+                }}
+                style={{width: '100%', padding: '3px', fontSize: '12px'}}
+              >
+                <option value="sine">Sine Wave</option>
+                <option value="sine+noise">Sine Wave + Noise</option>
+                <option value="noise">Noise Only</option>
+                <option value="flat">Flat Line</option>
+                <option value="sawtooth">Sawtooth</option>
+                <option value="square">Square Wave</option>
+              </select>
+            </div>
+          ))}
+        </div>
+
+        <div style={{marginBottom: '15px'}}>
+          <label style={{display: 'block', fontWeight: 'bold', marginBottom: '10px'}}>
+            Colors:
+          </label>
+
+          <div style={{marginBottom: '12px'}}>
+            <label style={{display: 'block', fontSize: '12px', marginBottom: '5px'}}>
+              Positive Color:
+            </label>
+            <div style={{display: 'flex', alignItems: 'center', gap: '10px'}}>
+              <input
+                type="color"
+                value={rgbToHex(positiveColor)}
+                onChange={(e) => setPositiveColor(hexToRgb(e.target.value))}
+                style={{
+                  width: '50px',
+                  height: '30px',
+                  border: 'none',
+                  borderRadius: '4px',
+                  cursor: 'pointer'
+                }}
+              />
+              <span style={{fontSize: '11px', color: '#666', fontFamily: 'monospace'}}>
+                RGB({positiveColor.join(', ')})
+              </span>
+            </div>
+          </div>
+
+          <div style={{marginBottom: '12px'}}>
+            <label style={{display: 'block', fontSize: '12px', marginBottom: '5px'}}>
+              Negative Color:
+            </label>
+            <div style={{display: 'flex', alignItems: 'center', gap: '10px'}}>
+              <input
+                type="color"
+                value={rgbToHex(negativeColor)}
+                onChange={(e) => setNegativeColor(hexToRgb(e.target.value))}
+                style={{
+                  width: '50px',
+                  height: '30px',
+                  border: 'none',
+                  borderRadius: '4px',
+                  cursor: 'pointer'
+                }}
+              />
+              <span style={{fontSize: '11px', color: '#666', fontFamily: 'monospace'}}>
+                RGB({negativeColor.join(', ')})
+              </span>
+            </div>
+          </div>
+
+          <div style={{marginBottom: '12px'}}>
+            <label style={{display: 'block', fontSize: '12px', marginBottom: '5px'}}>
+              Divider Color:
+            </label>
+            <div style={{display: 'flex', alignItems: 'center', gap: '10px'}}>
+              <input
+                type="color"
+                value={rgbToHex(dividerColor)}
+                onChange={(e) => setDividerColor(hexToRgb(e.target.value))}
+                style={{
+                  width: '50px',
+                  height: '30px',
+                  border: 'none',
+                  borderRadius: '4px',
+                  cursor: 'pointer'
+                }}
+              />
+              <span style={{fontSize: '11px', color: '#666', fontFamily: 'monospace'}}>
+                RGB({dividerColor.join(', ')})
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div style={{marginBottom: '15px'}}>
+          <label style={{display: 'block', fontWeight: 'bold', marginBottom: '10px'}}>
+            Position & Size:
+          </label>
+          <div style={{marginBottom: '8px'}}>
+            <label style={{display: 'block', fontSize: '12px', marginBottom: '3px'}}>
+              X Position: {x}
+            </label>
+            <input
+              type="range"
+              min="-2000"
+              max="2000"
+              value={x}
+              onChange={(e) => setX(Number(e.target.value))}
+              style={{width: '100%'}}
+            />
+          </div>
+          <div style={{marginBottom: '8px'}}>
+            <label style={{display: 'block', fontSize: '12px', marginBottom: '3px'}}>
+              Y Position: {y}
+            </label>
+            <input
+              type="range"
+              min="-2000"
+              max="2000"
+              value={y}
+              onChange={(e) => setY(Number(e.target.value))}
+              style={{width: '100%'}}
+            />
+          </div>
+          <div style={{marginBottom: '8px'}}>
+            <label style={{display: 'block', fontSize: '12px', marginBottom: '3px'}}>
+              Width: {width}
+            </label>
+            <input
+              type="range"
+              min="1"
+              max="5000"
+              value={width}
+              onChange={(e) => setWidth(Number(e.target.value))}
+              style={{width: '100%'}}
+            />
+          </div>
+          <div style={{marginBottom: '8px'}}>
+            <label style={{display: 'block', fontSize: '12px', marginBottom: '3px'}}>
+              Height (per series): {heightPerSeries}
+            </label>
+            <input
+              type="range"
+              min="1"
+              max="500"
+              value={heightPerSeries}
+              onChange={(e) => setHeightPerSeries(Number(e.target.value))}
+              style={{width: '100%'}}
+            />
+          </div>
+        </div>
+      </div>
+      <div style={{flex: 1, height: '100vh', position: 'relative', overflow: 'hidden'}}>
+        <DeckGL
+          views={new OrthographicView()}
+          initialViewState={INITIAL_VIEW_STATE}
+          controller={true}
+          layers={layers}
+          onHover={(info) => {
+            if (info.coordinate) {
+              setMousePosition([info.coordinate[0], info.coordinate[1]]);
+            } else {
+              setMousePosition(null);
+            }
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/examples/layers/horizon-graph-layer/index.html
+++ b/examples/layers/horizon-graph-layer/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>Horizon Layer Example</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+    </head>
+    <style>
+        body {
+            margin: 0px;
+            overscroll-behavior: none;
+            overflow: hidden;
+        }
+    </style>
+    <body></body>
+    <script type="module" src="./index.tsx"></script>
+</html>

--- a/examples/layers/horizon-graph-layer/index.tsx
+++ b/examples/layers/horizon-graph-layer/index.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import {createRoot} from 'react-dom/client';
+import App from './app';
+
+const root = createRoot(document.body.appendChild(document.createElement('div')));
+root.render(<App />);

--- a/examples/layers/horizon-graph-layer/package.json
+++ b/examples/layers/horizon-graph-layer/package.json
@@ -1,0 +1,18 @@
+{
+  "license": "MIT",
+  "scripts": {
+    "start": "vite --open",
+    "start-local": "vite --config ../../vite.config.local.mjs"
+  },
+  "dependencies": {
+    "@deck.gl-community/layers": "^9.0.0",
+    "@deck.gl/core": "^9.0.0",
+    "@deck.gl/layers": "^9.0.0",
+    "@deck.gl/react": "^9.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.12"
+  }
+}

--- a/examples/layers/horizon-graph-layer/tsconfig.json
+++ b/examples/layers/horizon-graph-layer/tsconfig.json
@@ -1,0 +1,4 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["./*.tsx"]
+}

--- a/modules/layers/src/horizon-graph-layer/horizon-graph-layer-uniforms.ts
+++ b/modules/layers/src/horizon-graph-layer/horizon-graph-layer-uniforms.ts
@@ -1,0 +1,47 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ShaderModule} from '@luma.gl/shadertools';
+import {Texture} from '@luma.gl/core';
+
+const uniformBlock = `\
+layout(std140) uniform horizonLayerUniforms {
+  float dataTextureSize;  // width = height of the POT texture
+  float dataTextureSizeInv;
+  float dataTextureCount; // actual number of data points
+
+  float bands;
+  float bandsInv;
+  float yAxisScaleInv;
+
+  vec3      positiveColor;
+  vec3      negativeColor;
+} horizonLayer;
+`;
+
+type HorizonLayerBindingProps = {
+  dataTexture: Texture;
+};
+
+type HorizonLayerUniformProps = {};
+
+export type HorizonLayerProps = HorizonLayerBindingProps & HorizonLayerUniformProps;
+
+export const horizonLayerUniforms = {
+  name: 'horizonLayer',
+  vs: uniformBlock,
+  fs: uniformBlock,
+  uniformTypes: {
+    dataTextureSize: 'f32',
+    dataTextureSizeInv: 'f32',
+    dataTextureCount: 'f32',
+
+    bands: 'f32',
+    bandsInv: 'f32',
+    yAxisScaleInv: 'f32',
+
+    positiveColor: 'vec3<f32>',
+    negativeColor: 'vec3<f32>'
+  }
+} as const satisfies ShaderModule<HorizonLayerProps>;

--- a/modules/layers/src/horizon-graph-layer/horizon-graph-layer.fs.ts
+++ b/modules/layers/src/horizon-graph-layer/horizon-graph-layer.fs.ts
@@ -1,0 +1,53 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export default `#version 300 es
+#define SHADER_NAME horizon-graph-layer-fragment-shader
+
+precision highp float;
+precision highp int;
+
+/******* UNIFORM *******/
+
+uniform sampler2D dataTexture;
+
+/******* IN *******/
+
+in vec2 v_uv;
+
+/******* OUT *******/
+
+out vec4 fragColor;
+
+
+/******* MAIN *******/
+
+void main(void) {
+  // horizontal position to sample index
+  float idx = v_uv.x * horizonLayer.dataTextureCount;
+  // idx = clamp(idx, 0.0, horizonLayer.dataTextureCount - 1.0); // NEEDED???
+
+  // fetch single data point & normalize (-1,+1)
+  float fy = floor(idx * horizonLayer.dataTextureSizeInv);
+  float fx = idx - fy * horizonLayer.dataTextureSize;
+  float val = texelFetch(dataTexture, ivec2(int(fx), int(fy)), 0).r;
+  val *= horizonLayer.yAxisScaleInv;
+
+  // band layering
+  float fband    = abs(val) * horizonLayer.bands;
+  float bandIdx  = clamp(floor(fband), 0.0, horizonLayer.bands - 1.0);
+  float bandFrac = fract(fband);
+
+  // calc our position value and find out color (using mix+step instead of if...else)
+  float positive = step(0.0, val);  // 1 if pos, else 0
+  vec3  baseCol  = mix(horizonLayer.negativeColor, horizonLayer.positiveColor, positive);
+  float curPos   = mix(v_uv.y, 1.0 - v_uv.y, positive);
+  float addOne   = step(curPos, bandFrac);
+
+  float band = bandIdx + addOne;
+  float whiten = 1.0 - band * horizonLayer.bandsInv;
+
+  fragColor = vec4(mix(baseCol, vec3(1.0), whiten), 1.0);
+}
+`;

--- a/modules/layers/src/horizon-graph-layer/horizon-graph-layer.ts
+++ b/modules/layers/src/horizon-graph-layer/horizon-graph-layer.ts
@@ -1,0 +1,202 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {DefaultProps, LayerProps, Color, LayerContext, UpdateParameters} from '@deck.gl/core';
+import {Layer, project32} from '@deck.gl/core';
+import {Model, Geometry} from '@luma.gl/engine';
+import vs from './horizon-graph-layer.vs';
+import fs from './horizon-graph-layer.fs';
+import {Texture} from '@luma.gl/core';
+import {horizonLayerUniforms} from './horizon-graph-layer-uniforms';
+
+export type _HorizonGraphLayerProps = {
+  data: number[] | Float32Array;
+
+  yAxisScale?: number;
+
+  bands?: number;
+
+  positiveColor?: Color;
+  negativeColor?: Color;
+
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+};
+
+export type HorizonGraphLayerProps = _HorizonGraphLayerProps & LayerProps;
+
+const defaultProps: DefaultProps<HorizonGraphLayerProps> = {
+  yAxisScale: {type: 'number', value: 1000},
+
+  bands: {type: 'number', value: 2},
+
+  positiveColor: {type: 'color', value: [0, 128, 0]},
+  negativeColor: {type: 'color', value: [0, 0, 255]},
+
+  x: {type: 'number', value: 0},
+  y: {type: 'number', value: 0},
+  width: {type: 'number', value: 800},
+  height: {type: 'number', value: 300}
+};
+
+export class HorizonGraphLayer<ExtraProps extends {} = {}> extends Layer<
+  ExtraProps & Required<_HorizonGraphLayerProps>
+> {
+  static layerName = 'HorizonGraphLayer';
+  static defaultProps = defaultProps;
+
+  state: {
+    model?: Model;
+    dataTexture?: Texture;
+    dataTextureSize?: number;
+    dataTextureCount?: number;
+  } = {};
+
+  initializeState() {
+    this.state = {};
+  }
+
+  getShaders() {
+    return super.getShaders({
+      vs,
+      fs,
+      modules: [project32, horizonLayerUniforms]
+    });
+  }
+
+  _createDataTexture(seriesData: Float32Array | number[]): {
+    dataTexture: Texture;
+    dataTextureSize: number;
+    dataTextureCount: number;
+  } {
+    const _data = seriesData instanceof Float32Array ? seriesData : new Float32Array(seriesData);
+
+    const {device} = this.context;
+    const count = _data.length;
+
+    let dataTextureSize = 32;
+    while (count > dataTextureSize * dataTextureSize) {
+      dataTextureSize *= 2;
+    }
+
+    // TODO: use the right way to only submit the minimum amount of data
+    const data = new Float32Array(dataTextureSize * dataTextureSize);
+    data.set(_data, 0);
+
+    return {
+      dataTexture: device.createTexture({
+        data,
+        format: 'r32float',
+        dimension: '2d',
+        width: dataTextureSize,
+        height: dataTextureSize,
+        sampler: {
+          minFilter: 'nearest',
+          magFilter: 'nearest',
+          addressModeU: 'clamp-to-edge',
+          addressModeV: 'clamp-to-edge'
+        }
+      }),
+      dataTextureSize,
+      dataTextureCount: count
+    };
+  }
+
+  _createModel() {
+    const {x, y, width, height} = this.props;
+
+    // Create a rectangle using triangle strip (4 vertices)
+    // Order: bottom-left, bottom-right, top-left, top-right
+    const positions = [
+      x,
+      y,
+      0.0,
+
+      x + width,
+      y,
+      0.0,
+
+      x,
+      y + height,
+      0.0,
+
+      x + width,
+      y + height,
+      0.0
+    ];
+
+    const uv = [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0];
+
+    const geometry = new Geometry({
+      topology: 'triangle-strip',
+      attributes: {
+        positions: {value: new Float32Array(positions), size: 3},
+        uv: {value: new Float32Array(uv), size: 2}
+      }
+    });
+
+    return new Model(this.context.device, {
+      ...this.getShaders(),
+      geometry,
+      bufferLayout: this.getAttributeManager().getBufferLayouts()
+    });
+  }
+
+  updateState(params: UpdateParameters<Layer<ExtraProps & Required<_HorizonGraphLayerProps>>>) {
+    super.updateState(params);
+
+    const {changeFlags} = params;
+
+    if (changeFlags.dataChanged) {
+      this.state.dataTexture?.destroy();
+      this.setState(this._createDataTexture(this.props.data));
+    }
+
+    if (changeFlags.extensionsChanged || changeFlags.propsChanged) {
+      this.state.model?.destroy();
+      this.setState({model: this._createModel()});
+    }
+  }
+
+  draw() {
+    const {model, dataTexture} = this.state;
+
+    if (!model) {
+      this.setState({model: this._createModel()});
+      return;
+    }
+
+    if (!dataTexture) {
+      this.setState(this._createDataTexture(this.props.data));
+      return;
+    }
+
+    const {bands, yAxisScale, positiveColor, negativeColor} = this.props;
+
+    model.shaderInputs.setProps({
+      horizonLayer: {
+        dataTexture: this.state.dataTexture,
+        dataTextureSize: this.state.dataTextureSize,
+        dataTextureSizeInv: 1.0 / this.state.dataTextureSize,
+        dataTextureCount: this.state.dataTextureCount,
+
+        bands,
+        bandsInv: 1.0 / bands,
+        yAxisScaleInv: 1.0 / yAxisScale,
+
+        positiveColor: positiveColor.map((c) => c / 255),
+        negativeColor: negativeColor.map((c) => c / 255)
+      }
+    });
+    model.draw(this.context.renderPass);
+  }
+
+  finalizeState(context: LayerContext): void {
+    this.state.model?.destroy();
+    this.state.dataTexture?.destroy();
+    super.finalizeState(context);
+  }
+}

--- a/modules/layers/src/horizon-graph-layer/horizon-graph-layer.vs.ts
+++ b/modules/layers/src/horizon-graph-layer/horizon-graph-layer.vs.ts
@@ -1,0 +1,24 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export default `#version 300 es
+#define SHADER_NAME horizon-graph-layer-vertex-shader
+
+in vec3 positions;
+in vec2 uv;
+
+out vec2 v_uv;
+
+void main(void) {
+  geometry.worldPosition = positions;
+  
+  vec4 position_commonspace = project_position(vec4(positions.xy, 0.0, 1.0));
+  gl_Position = project_common_position_to_clipspace(position_commonspace);
+  geometry.position = position_commonspace;
+  
+  DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
+  
+  v_uv = uv;
+}
+`;

--- a/modules/layers/src/horizon-graph-layer/multi-horizon-graph-layer.ts
+++ b/modules/layers/src/horizon-graph-layer/multi-horizon-graph-layer.ts
@@ -1,0 +1,164 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {DefaultProps, LayerProps, Color, LayerDataSource, Accessor} from '@deck.gl/core';
+import {CompositeLayer} from '@deck.gl/core';
+import {SolidPolygonLayer} from '@deck.gl/layers';
+import {HorizonGraphLayer} from './horizon-graph-layer';
+
+export type _MultiHorizonGraphLayerProps<DataT> = {
+  data: LayerDataSource<DataT>;
+  getSeries: Accessor<DataT, number[] | Float32Array>;
+  getScale: Accessor<DataT, number>;
+
+  bands?: number;
+
+  positiveColor?: Color;
+  negativeColor?: Color;
+
+  dividerColor?: Color;
+  dividerWidth?: number;
+
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+};
+
+export type MultiHorizonGraphLayerProps<DataT = unknown> = _MultiHorizonGraphLayerProps<DataT> &
+  LayerProps;
+
+const defaultProps: DefaultProps<MultiHorizonGraphLayerProps> = {
+  getSeries: {type: 'accessor', value: (series: any) => series.values},
+  getScale: {type: 'accessor', value: (series: any) => series.scale},
+
+  bands: {type: 'number', value: 2},
+
+  positiveColor: {type: 'color', value: [0, 128, 0]},
+  negativeColor: {type: 'color', value: [0, 0, 255]},
+
+  dividerColor: {type: 'color', value: [0, 0, 0]},
+  dividerWidth: {type: 'number', value: 2},
+
+  x: {type: 'number', value: 0},
+  y: {type: 'number', value: 0},
+  width: {type: 'number', value: 800},
+  height: {type: 'number', value: 300}
+};
+
+export class MultiHorizonGraphLayer<DataT = any, ExtraProps extends {} = {}> extends CompositeLayer<
+  ExtraProps & Required<_MultiHorizonGraphLayerProps<DataT>>
+> {
+  static layerName = 'MultiHorizonGraphLayer';
+  static defaultProps = defaultProps;
+
+  renderLayers() {
+    const {
+      data,
+      getSeries,
+      getScale,
+      bands,
+      positiveColor,
+      negativeColor,
+      dividerColor,
+      dividerWidth,
+      x,
+      y,
+      width,
+      height
+    } = this.props;
+
+    const seriesCount = (data as any).length;
+
+    if (!seriesCount) {
+      return [];
+    }
+
+    // Calculate layout dimensions
+    const totalDividerSpace = dividerWidth * (seriesCount + 1);
+    const availableHeight = height - totalDividerSpace;
+    const seriesHeight = availableHeight / seriesCount;
+
+    const layers = [];
+
+    // Create divider rectangles
+    if (dividerWidth > 0) {
+      const dividerData = [];
+
+      // Top divider
+      dividerData.push({
+        polygon: [
+          [x, y],
+          [x + width, y],
+          [x + width, y + dividerWidth],
+          [x, y + dividerWidth]
+        ]
+      });
+
+      // Dividers between series
+      for (let i = 0; i < seriesCount - 1; i++) {
+        const dividerY = y + dividerWidth + (i + 1) * seriesHeight + i * dividerWidth;
+        dividerData.push({
+          polygon: [
+            [x, dividerY],
+            [x + width, dividerY],
+            [x + width, dividerY + dividerWidth],
+            [x, dividerY + dividerWidth]
+          ]
+        });
+      }
+
+      // Bottom divider
+      const bottomDividerY = y + height - dividerWidth;
+      dividerData.push({
+        polygon: [
+          [x, bottomDividerY],
+          [x + width, bottomDividerY],
+          [x + width, y + height],
+          [x, y + height]
+        ]
+      });
+
+      layers.push(
+        new SolidPolygonLayer({
+          id: `${this.props.id}-dividers`,
+          data: dividerData,
+          getPolygon: (d: any) => d.polygon,
+          getFillColor: dividerColor,
+          pickable: false
+        })
+      );
+    }
+
+    // Create horizon graph layers for each series
+    (data as any).forEach((series, index) => {
+      const seriesData = (getSeries as any)(series);
+
+      if (!seriesData || seriesData.length === 0) {
+        return;
+      }
+
+      const seriesY = y + dividerWidth + index * (seriesHeight + dividerWidth);
+
+      const yAxisScale = (getScale as any)(series);
+
+      layers.push(
+        new HorizonGraphLayer({
+          id: `${this.props.id}-series-${index}`,
+          data: seriesData,
+          yAxisScale,
+          bands,
+          positiveColor,
+          negativeColor,
+          x,
+          y: seriesY,
+          width,
+          height: seriesHeight
+        })
+      );
+    });
+
+    return layers;
+  }
+}

--- a/modules/layers/src/index.ts
+++ b/modules/layers/src/index.ts
@@ -7,3 +7,9 @@ export {PathOutlineLayer} from './path-outline-layer/path-outline-layer';
 
 export type {PathMarkerLayerProps} from './path-marker-layer/path-marker-layer';
 export {PathMarkerLayer} from './path-marker-layer/path-marker-layer';
+
+export type {HorizonGraphLayerProps} from './horizon-graph-layer/horizon-graph-layer';
+export {HorizonGraphLayer} from './horizon-graph-layer/horizon-graph-layer';
+
+export type {MultiHorizonGraphLayerProps} from './horizon-graph-layer/multi-horizon-graph-layer';
+export {MultiHorizonGraphLayer} from './horizon-graph-layer/multi-horizon-graph-layer';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2026,6 +2026,29 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@deck.gl-community/layers@npm:^9.0.0":
+  version: 9.0.3
+  resolution: "@deck.gl-community/layers@npm:9.0.3"
+  dependencies:
+    "@deck.gl/core": "npm:^9.0.12"
+    "@deck.gl/extensions": "npm:^9.0.12"
+    "@deck.gl/geo-layers": "npm:^9.0.12"
+    "@deck.gl/layers": "npm:^9.0.12"
+    "@deck.gl/mesh-layers": "npm:^9.0.12"
+    "@deck.gl/react": "npm:^9.0.12"
+    "@loaders.gl/core": "npm:^4.2.0"
+    "@loaders.gl/i3s": "npm:^4.2.0"
+    "@loaders.gl/loader-utils": "npm:^4.2.0"
+    "@loaders.gl/schema": "npm:^4.2.0"
+    "@loaders.gl/tiles": "npm:^4.2.0"
+    "@luma.gl/constants": "npm:^9.0.11"
+    "@luma.gl/core": "npm:^9.0.11"
+    "@luma.gl/engine": "npm:^9.0.11"
+    "@math.gl/core": "npm:^4.0.0"
+  checksum: 10c0/16c97f224bfb765487cab6d7b2b3ab455f8b813536881f814b73f1f8be0510b6fc4549f6a0a2f47aa7bf56443ae07244135e806bbfbf767241a09787fda82f59
+  languageName: node
+  linkType: hard
+
 "@deck.gl-community/layers@workspace:modules/layers":
   version: 0.0.0-use.local
   resolution: "@deck.gl-community/layers@workspace:modules/layers"
@@ -2238,6 +2261,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@deck.gl/core@npm:^9.0.0, @deck.gl/core@npm:^9.0.12":
+  version: 9.1.13
+  resolution: "@deck.gl/core@npm:9.1.13"
+  dependencies:
+    "@loaders.gl/core": "npm:^4.2.0"
+    "@loaders.gl/images": "npm:^4.2.0"
+    "@luma.gl/constants": "npm:^9.1.5"
+    "@luma.gl/core": "npm:^9.1.5"
+    "@luma.gl/engine": "npm:^9.1.5"
+    "@luma.gl/shadertools": "npm:^9.1.5"
+    "@luma.gl/webgl": "npm:^9.1.5"
+    "@math.gl/core": "npm:^4.1.0"
+    "@math.gl/sun": "npm:^4.1.0"
+    "@math.gl/types": "npm:^4.1.0"
+    "@math.gl/web-mercator": "npm:^4.1.0"
+    "@probe.gl/env": "npm:^4.1.0"
+    "@probe.gl/log": "npm:^4.1.0"
+    "@probe.gl/stats": "npm:^4.1.0"
+    "@types/offscreencanvas": "npm:^2019.6.4"
+    gl-matrix: "npm:^3.0.0"
+    mjolnir.js: "npm:^3.0.0"
+  checksum: 10c0/0b87f41beb227197f68050818e31e53bed64edf8d917db10984498b97179a6a34f0939bc236ac1637f38fc8d9bd3c74bf43ec69b937ad51180a109405c098b3a
+  languageName: node
+  linkType: hard
+
 "@deck.gl/extensions@npm:9.1.12":
   version: 9.1.12
   resolution: "@deck.gl/extensions@npm:9.1.12"
@@ -2250,6 +2298,21 @@ __metadata:
     "@luma.gl/core": ^9.1.5
     "@luma.gl/engine": ^9.1.5
   checksum: 10c0/1c7c8fa16512f0f21b44d8d2329e0d6a627f9c15e86e6aa4d5e3f0706b97ac381de28a2ae581c60acd28134d155ed5fd1f01e5e2282a6bd43ef7d21a5ccd9b58
+  languageName: node
+  linkType: hard
+
+"@deck.gl/extensions@npm:^9.0.12":
+  version: 9.1.13
+  resolution: "@deck.gl/extensions@npm:9.1.13"
+  dependencies:
+    "@luma.gl/constants": "npm:^9.1.5"
+    "@luma.gl/shadertools": "npm:^9.1.5"
+    "@math.gl/core": "npm:^4.1.0"
+  peerDependencies:
+    "@deck.gl/core": ^9.1.0
+    "@luma.gl/core": ^9.1.5
+    "@luma.gl/engine": ^9.1.5
+  checksum: 10c0/90d051d42b59e986ea41e2ded6bbe2cc3512a047db6279d94a4e29864cc80e8229bb4a10ef803aeb72333b856dfeb2d9db5da98ca66c73c4a1c512cf54d519ff
   languageName: node
   linkType: hard
 
@@ -2297,6 +2360,38 @@ __metadata:
     "@luma.gl/core": ^9.1.5
     "@luma.gl/engine": ^9.1.5
   checksum: 10c0/68d23c02cef1544c016789153f9b72e668cd1b7107a33e492b5c5f95ad7e9f3b1e1d9cc37dfaf755f7e47b58c265100e716ee72ea757fdb9f01047731176aa78
+  languageName: node
+  linkType: hard
+
+"@deck.gl/geo-layers@npm:^9.0.12":
+  version: 9.1.13
+  resolution: "@deck.gl/geo-layers@npm:9.1.13"
+  dependencies:
+    "@loaders.gl/3d-tiles": "npm:^4.2.0"
+    "@loaders.gl/gis": "npm:^4.2.0"
+    "@loaders.gl/loader-utils": "npm:^4.2.0"
+    "@loaders.gl/mvt": "npm:^4.2.0"
+    "@loaders.gl/schema": "npm:^4.2.0"
+    "@loaders.gl/terrain": "npm:^4.2.0"
+    "@loaders.gl/tiles": "npm:^4.2.0"
+    "@loaders.gl/wms": "npm:^4.2.0"
+    "@luma.gl/gltf": "npm:^9.1.5"
+    "@luma.gl/shadertools": "npm:^9.1.5"
+    "@math.gl/core": "npm:^4.1.0"
+    "@math.gl/culling": "npm:^4.1.0"
+    "@math.gl/web-mercator": "npm:^4.1.0"
+    "@types/geojson": "npm:^7946.0.8"
+    h3-js: "npm:^4.1.0"
+    long: "npm:^3.2.0"
+  peerDependencies:
+    "@deck.gl/core": ^9.1.0
+    "@deck.gl/extensions": ^9.1.0
+    "@deck.gl/layers": ^9.1.0
+    "@deck.gl/mesh-layers": ^9.1.0
+    "@loaders.gl/core": ^4.2.0
+    "@luma.gl/core": ^9.1.5
+    "@luma.gl/engine": ^9.1.5
+  checksum: 10c0/fcba268d9dc82fdea8e5c323dbe49646a71883f5b22aa1c3ad9c247a120d7ef8dcc804c3d17d568a4821f5203e235b5d2621905add094cf0ba8f9d04a5c88d56
   languageName: node
   linkType: hard
 
@@ -2379,6 +2474,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@deck.gl/layers@npm:^9.0.0, @deck.gl/layers@npm:^9.0.12":
+  version: 9.1.13
+  resolution: "@deck.gl/layers@npm:9.1.13"
+  dependencies:
+    "@loaders.gl/images": "npm:^4.2.0"
+    "@loaders.gl/schema": "npm:^4.2.0"
+    "@luma.gl/shadertools": "npm:^9.1.5"
+    "@mapbox/tiny-sdf": "npm:^2.0.5"
+    "@math.gl/core": "npm:^4.1.0"
+    "@math.gl/polygon": "npm:^4.1.0"
+    "@math.gl/web-mercator": "npm:^4.1.0"
+    earcut: "npm:^2.2.4"
+  peerDependencies:
+    "@deck.gl/core": ^9.1.0
+    "@loaders.gl/core": ^4.2.0
+    "@luma.gl/core": ^9.1.5
+    "@luma.gl/engine": ^9.1.5
+  checksum: 10c0/42cd8d14ac952cfda302d14f3c45e37b819c92a57f881f3d77dc49b3e2a71379f394fcf7a89a2ccf6879621d146d45bbc9bb61eaab11d11b52c5b32baecfeca7
+  languageName: node
+  linkType: hard
+
 "@deck.gl/layers@npm:^9.1.0":
   version: 9.1.0
   resolution: "@deck.gl/layers@npm:9.1.0"
@@ -2427,6 +2543,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@deck.gl/mesh-layers@npm:^9.0.12":
+  version: 9.1.13
+  resolution: "@deck.gl/mesh-layers@npm:9.1.13"
+  dependencies:
+    "@loaders.gl/gltf": "npm:^4.2.0"
+    "@luma.gl/gltf": "npm:^9.1.5"
+    "@luma.gl/shadertools": "npm:^9.1.5"
+  peerDependencies:
+    "@deck.gl/core": ^9.1.0
+    "@luma.gl/core": ^9.1.5
+    "@luma.gl/engine": ^9.1.5
+  checksum: 10c0/1018e287355b9ae18ef4e48e978bee3d956e8fba20739de55425a13fe5450918a90efbd04e452c33a8e4767224385c6a31cabbd8299be705408c85ff6af5f4e2
+  languageName: node
+  linkType: hard
+
 "@deck.gl/mesh-layers@npm:^9.1.0":
   version: 9.1.0
   resolution: "@deck.gl/mesh-layers@npm:9.1.0"
@@ -2451,6 +2582,18 @@ __metadata:
     react: ">=16.3.0"
     react-dom: ">=16.3.0"
   checksum: 10c0/9f59a29417a637a3bf0d6586c3edfbc1a641b08297655d43828bbcbf052af99b8098a8b0ba73eadef0ce7bd24203565fecf87eb8514671d85273b8092e86b0b6
+  languageName: node
+  linkType: hard
+
+"@deck.gl/react@npm:^9.0.0, @deck.gl/react@npm:^9.0.12":
+  version: 9.1.13
+  resolution: "@deck.gl/react@npm:9.1.13"
+  peerDependencies:
+    "@deck.gl/core": ^9.1.0
+    "@deck.gl/widgets": ^9.1.0
+    react: ">=16.3.0"
+    react-dom: ">=16.3.0"
+  checksum: 10c0/3b375236d5f199b8841b59d78d946dd65f99ea5a76a251b35d1f66f46f4925c0ec429d64d7a97df43abbabfd1182fae8bf48b86339cc5be6c4b42bc8997faf70
   languageName: node
   linkType: hard
 
@@ -4299,7 +4442,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@luma.gl/constants@npm:9.1.9, @luma.gl/constants@npm:^9.1.5, @luma.gl/constants@npm:^9.1.9":
+"@luma.gl/constants@npm:9.1.9, @luma.gl/constants@npm:^9.0.11, @luma.gl/constants@npm:^9.1.5, @luma.gl/constants@npm:^9.1.9":
   version: 9.1.9
   resolution: "@luma.gl/constants@npm:9.1.9"
   checksum: 10c0/77b232a8cf9720cdbb80bdf703cbc9e3acae934536a76df4d90e07a094e514d57d94f8eb81a8ac75e23a9c2c6ab5438f75fab3a001d472e9f440a0a1b148e21e
@@ -4320,7 +4463,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@luma.gl/core@npm:^9.1.0, @luma.gl/core@npm:^9.1.5, @luma.gl/core@npm:^9.1.9":
+"@luma.gl/core@npm:^9.0.11, @luma.gl/core@npm:^9.1.0, @luma.gl/core@npm:^9.1.5, @luma.gl/core@npm:^9.1.9":
   version: 9.1.9
   resolution: "@luma.gl/core@npm:9.1.9"
   dependencies:
@@ -4333,7 +4476,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@luma.gl/engine@npm:^9.1.5, @luma.gl/engine@npm:^9.1.9":
+"@luma.gl/engine@npm:^9.0.11, @luma.gl/engine@npm:^9.1.5, @luma.gl/engine@npm:^9.1.9":
   version: 9.1.9
   resolution: "@luma.gl/engine@npm:9.1.9"
   dependencies:
@@ -14331,6 +14474,20 @@ __metadata:
   checksum: 10c0/3c099844f94b8b438f124bd5698bdcfef32b2d455115fb8050d7148e7f7b95fc89ba9922586c491f0e1cdebf437b1053c84ecddb8d596e109e9ac69c5b4a9e27
   languageName: node
   linkType: hard
+
+"horizon-graph-layer-cfbbc6@workspace:examples/layers/horizon-graph-layer":
+  version: 0.0.0-use.local
+  resolution: "horizon-graph-layer-cfbbc6@workspace:examples/layers/horizon-graph-layer"
+  dependencies:
+    "@deck.gl-community/layers": "npm:^9.0.0"
+    "@deck.gl/core": "npm:^9.0.0"
+    "@deck.gl/layers": "npm:^9.0.0"
+    "@deck.gl/react": "npm:^9.0.0"
+    react: "npm:^18.2.0"
+    react-dom: "npm:^18.2.0"
+    vite: "npm:^5.0.12"
+  languageName: unknown
+  linkType: soft
 
 "hosted-git-info@npm:^2.1.4":
   version: 2.8.9


### PR DESCRIPTION
This PR adds support for horizon graph visualizations by introducing `HorizonGraphLayer` and `MultiHorizonGraphLayer`, updates the module exports, and provides an example application to showcase usage.

- Add new horizon graph layer implementations (shaders, uniforms, WebGL resource management).
- Introduce composite `MultiHorizonGraphLayer` for multi-series horizon graphs.
- Update `index.ts` exports and include a fully working example under `examples/layers/horizon-graph-layer`.
