### PR TITLE
Add horizon graph layer website example

### DIFF
--- a/examples/graph-layers/graph-viewer/package.json
+++ b/examples/graph-layers/graph-viewer/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "start": "vite --open",
-    "start-local": "vite --config ../vite.config.local.mjs"
+    "start-local": "vite --config ../../vite.config.local.mjs"
   },
   "dependencies": {
     "@deck.gl-community/graph-layers": "^9.1.0-beta.5",

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -53,6 +53,7 @@ const config = {
             '@deck.gl-community/bing-maps': resolve('../modules/bing-maps/src'),
             '@deck.gl-community/leaflet': resolve('../modules/leaflet/src'),
             '@deck.gl-community/graph-layers': resolve('../modules/graph-layers/src'),
+            '@deck.gl-community/infovis-layers': resolve('../modules/infovis-layers/src'),
             '@deck.gl-community/react': resolve('../modules/react/src'),
             '@deck.gl-community/layers': resolve('../modules/layers/src'),
             '@deck.gl-community/arrow-layers': resolve('../modules/arrow-layers/src'),

--- a/website/src/examples-sidebar.js
+++ b/website/src/examples-sidebar.js
@@ -30,6 +30,13 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: '@deck.gl-community/infovis-layers',
+      items: [
+        "infovis-layers/horizon-graph-layer"
+      ]
+    },
+    {
+      type: 'category',
       label: '@deck.gl-community/editable-layers',
       items: [
         "editable-layers/editor",

--- a/website/src/examples/infovis-layers/horizon-graph-layer.mdx
+++ b/website/src/examples/infovis-layers/horizon-graph-layer.mdx
@@ -1,0 +1,5 @@
+# Horizon Graph Layer Demo
+
+import Demo from './horizon-graph-layer';
+
+<Demo />

--- a/website/src/examples/infovis-layers/horizon-graph-layer.tsx
+++ b/website/src/examples/infovis-layers/horizon-graph-layer.tsx
@@ -1,0 +1,31 @@
+import React, {Component} from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+
+import {GITHUB_TREE} from '../../constants/defaults';
+
+import {makeExample} from '../../components';
+
+class HorizonDemo extends Component {
+  static title = 'Horizon Graph Layer Demo';
+
+  static code = `${GITHUB_TREE}/examples/infovis-layers/horizon-graph-layer`;
+
+  static renderInfo(meta) {
+    return <></>;
+  }
+
+  render() {
+    const {...otherProps} = this.props;
+
+    return (
+      <BrowserOnly>
+        {() => {
+          const App = require('../../../../examples/infovis-layers/horizon-graph-layer/app').default;
+          return <App {...otherProps} />;
+        }}
+      </BrowserOnly>
+    );
+  }
+}
+
+export default makeExample(HorizonDemo);


### PR DESCRIPTION
## Summary
- add Horizon Graph Layer demo for website examples
- register the new demo on the examples sidebar
- load example code lazily on the website
