### PR TITLE
fix: propagate EditableGeoJsonLayer accessor updateTriggers to GeoJsonLayer

### DIFF
--- a/modules/editable-layers/src/editable-layers/editable-geojson-layer.ts
+++ b/modules/editable-layers/src/editable-layers/editable-geojson-layer.ts
@@ -331,10 +331,10 @@ export class EditableGeoJsonLayer extends EditableLayer<
       },
 
       updateTriggers: {
-        getLineColor: [this.props.selectedFeatureIndexes, this.props.mode],
-        getFillColor: [this.props.selectedFeatureIndexes, this.props.mode],
-        getPointRadius: [this.props.selectedFeatureIndexes, this.props.mode],
-        getLineWidth: [this.props.selectedFeatureIndexes, this.props.mode]
+        getLineColor: [this.props.updateTriggers.getLineColor, this.props.selectedFeatureIndexes, this.props.mode],
+        getFillColor: [this.props.updateTriggers.getFillColor, this.props.selectedFeatureIndexes, this.props.mode],
+        getPointRadius: [this.props.updateTriggers.getPointRadius, this.props.selectedFeatureIndexes, this.props.mode],
+        getLineWidth: [this.props.updateTriggers.getLineWidth, this.props.selectedFeatureIndexes, this.props.mode]
       }
     });
 


### PR DESCRIPTION
Propagates accessor updateTriggers from EditableGeoJsonLayer to GeoJsonLayer, following the guidance at https://deck.gl/docs/developer-guide/custom-layers/composite-layers#mapping-properties, so that they work.

Is previously reported in nebula.gl: https://github.com/uber/nebula.gl/issues/609.  

