### PR TITLE
Fix long press button cleanup

### DIFF
--- a/modules/graph-layers/src/widgets/long-press-button.tsx
+++ b/modules/graph-layers/src/widgets/long-press-button.tsx
@@ -11,6 +11,7 @@ export type LongPressButtonProps = {
 
 export class LongPressButton extends Component<LongPressButtonProps> {
   buttonPressTimer: ReturnType<typeof setTimeout> | null = null;
+  private _isMouseUpListenerAttached = false;
 
   _repeat = () => {
     if (this.buttonPressTimer) {
@@ -19,8 +20,16 @@ export class LongPressButton extends Component<LongPressButtonProps> {
     }
   };
 
+  componentWillUnmount(): void {
+    this._handleButtonRelease();
+    this._detachMouseUpListener();
+  }
+
   _handleButtonPress = () => {
-    this.buttonPressTimer = setTimeout(this._repeat, 100);
+    if (!this.buttonPressTimer) {
+      this.buttonPressTimer = setTimeout(this._repeat, 100);
+    }
+    this._attachMouseUpListener();
   };
 
   _handleButtonRelease = () => {
@@ -30,6 +39,25 @@ export class LongPressButton extends Component<LongPressButtonProps> {
     this.buttonPressTimer = null;
   };
 
+  _handleDocumentMouseUp = () => {
+    this._handleButtonRelease();
+    this._detachMouseUpListener();
+  };
+
+  _attachMouseUpListener() {
+    if (!this._isMouseUpListenerAttached) {
+      document.addEventListener('mouseup', this._handleDocumentMouseUp);
+      this._isMouseUpListenerAttached = true;
+    }
+  }
+
+  _detachMouseUpListener() {
+    if (this._isMouseUpListenerAttached) {
+      document.removeEventListener('mouseup', this._handleDocumentMouseUp);
+      this._isMouseUpListenerAttached = false;
+    }
+  }
+
   render() {
     return (
       <div className="deck-widget-button">
@@ -37,9 +65,8 @@ export class LongPressButton extends Component<LongPressButtonProps> {
           style={{
             pointerEvents: 'auto'
           }}
-          onMouseDown={(event) => {
+          onMouseDown={() => {
             this._handleButtonPress();
-            document.addEventListener('mouseup', this._handleButtonRelease, {once: true});
           }}
         >
           {this.props.children}

--- a/modules/react/src/components/long-press-button.tsx
+++ b/modules/react/src/components/long-press-button.tsx
@@ -13,6 +13,7 @@ export class LongPressButton extends PureComponent {
   };
 
   buttonPressTimer: ReturnType<typeof setTimeout> | null = null;
+  private _isMouseUpListenerAttached = false;
 
   _repeat = () => {
     if (this.buttonPressTimer) {
@@ -21,8 +22,16 @@ export class LongPressButton extends PureComponent {
     }
   };
 
+  componentWillUnmount(): void {
+    this._handleButtonRelease();
+    this._detachMouseUpListener();
+  }
+
   _handleButtonPress = () => {
-    this.buttonPressTimer = setTimeout(this._repeat, 100);
+    if (!this.buttonPressTimer) {
+      this.buttonPressTimer = setTimeout(this._repeat, 100);
+    }
+    this._attachMouseUpListener();
   };
 
   _handleButtonRelease = () => {
@@ -32,12 +41,30 @@ export class LongPressButton extends PureComponent {
     this.buttonPressTimer = null;
   };
 
+  _handleDocumentMouseUp = () => {
+    this._handleButtonRelease();
+    this._detachMouseUpListener();
+  };
+
+  _attachMouseUpListener() {
+    if (!this._isMouseUpListenerAttached) {
+      document.addEventListener('mouseup', this._handleDocumentMouseUp);
+      this._isMouseUpListenerAttached = true;
+    }
+  }
+
+  _detachMouseUpListener() {
+    if (this._isMouseUpListenerAttached) {
+      document.removeEventListener('mouseup', this._handleDocumentMouseUp);
+      this._isMouseUpListenerAttached = false;
+    }
+  }
+
   render() {
     return (
       <div
-        onMouseDown={(event) => {
+        onMouseDown={() => {
           this._handleButtonPress();
-          document.addEventListener('mouseup', this._handleButtonRelease, {once: true});
         }}
       >
         {(this.props as any).children}

--- a/modules/react/test/components/long-press-button.spec.tsx
+++ b/modules/react/test/components/long-press-button.spec.tsx
@@ -18,6 +18,7 @@ describe('LongPressButton', () => {
     const {getByText} = render(<LongPressButton onClick={onClick}>{'▲'}</LongPressButton>);
     fireEvent.mouseDown(getByText('▲'));
     await sleep(150); // await long press
+    fireEvent.mouseUp(document);
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- ensure both long press button implementations keep track of the document-level mouseup listener, detach it on release/unmount, and clear timers safely
- prevent duplicate listener registrations when the mouse is pressed repeatedly
- explicitly release the button in the React unit test so the new cleanup logic is exercised

## Testing
- `npx vitest run test/components/long-press-button.spec.tsx`


------
https://chatgpt.com/codex/tasks/task_i_69024d4dd2e0832c8dee71160bbe135c