### PR TITLE
Fix graph random generator flakiness

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -26,6 +26,7 @@ module.exports = getESLintConfig({
           // TODO: Gradually enable, at least for non-test code.
           '@typescript-eslint/no-redundant-type-constituents': 0,
           'import/no-extraneous-dependencies': 0,
+          'import/no-unresolved': ['error', {ignore: ['^@deck\\.gl-community/']}],
           'import/no-named-as-default': ['warn'],
           'import/named': ['warn'],
           '@typescript-eslint/no-unsafe-argument': 0,
@@ -74,6 +75,26 @@ module.exports = getESLintConfig({
     rules: {
       // custom rules
     }
+  },
+  settings: {
+    'import/resolver': {
+      typescript: {
+        project: ['./tsconfig.json']
+      }
+    },
+    'import/core-modules': [
+      '@deck.gl-community/arrow-layers',
+      '@deck.gl-community/bing-maps',
+      '@deck.gl-community/leaflet',
+      '@deck.gl-community/editable-layers',
+      '@deck.gl-community/experimental',
+      '@deck.gl-community/layers',
+      '@deck.gl-community/geo-layers',
+      '@deck.gl-community/infovis-layers',
+      '@deck.gl-community/react',
+      '@deck.gl-community/template',
+      '@deck.gl-community/graph-layers'
+    ]
   },
   /** Print full config JSON for inspection */
   debug: false

--- a/modules/graph-layers/test/data/graphs/random-graph-generator.spec.ts
+++ b/modules/graph-layers/test/data/graphs/random-graph-generator.spec.ts
@@ -1,0 +1,26 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, it, expect} from 'vitest';
+
+import {randomGraphGenerator} from './random-graph-generator';
+
+describe('randomGraphGenerator', () => {
+  it('produces deterministic output for the same input', () => {
+    const first = randomGraphGenerator(5, 4, 'sample');
+    const second = randomGraphGenerator(5, 4, 'sample');
+
+    expect(second).toEqual(first);
+  });
+
+  it('uses a provided random generator when supplied', () => {
+    const graph = randomGraphGenerator(4, 3, 'custom', () => 0);
+
+    expect(graph.edges).toEqual([
+      {id: 0, sourceId: 0, targetId: 1},
+      {id: 1, sourceId: 0, targetId: 2},
+      {id: 2, sourceId: 0, targetId: 3}
+    ]);
+  });
+});

--- a/modules/graph-layers/test/data/graphs/random-graph-generator.ts
+++ b/modules/graph-layers/test/data/graphs/random-graph-generator.ts
@@ -13,22 +13,48 @@ function genAllPairs<T>(s: T[]): T[][] {
   return pairs;
 }
 
-function randomChoose<T>(s: T[], k: number): T[] {
+function createSeededRandom(seed: number): () => number {
+  let state = seed >>> 0 || 1;
+  return function random() {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function hashSeed(n: number, m: number, name: string): number {
+  let hash = 0x811c9dc5;
+  const input = `${name}:${n}:${m}`;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+function randomChoose<T>(s: T[], k: number, random: () => number): T[] {
   const selected = [] as T[];
   let i = -1;
   const setSize = s.length;
   const size = k >= setSize ? setSize : k;
   while (++i < size) {
-    const idx = Math.floor(Math.random() * s.length);
+    const idx = Math.floor(random() * s.length);
     selected.push(s.splice(idx, 1)[0]);
   }
   return selected;
 }
 
-export function randomGraphGenerator(n: number, m: number, name = 'default') {
+export function randomGraphGenerator(
+  n: number,
+  m: number,
+  name = 'default',
+  randomFn?: () => number
+) {
   // generate an array of nodes with id form 0 to n;
   const nodes = Array.from(Array(n).keys()).map((id) => ({id}));
-  const links = randomChoose(genAllPairs(nodes), m);
+  const random = randomFn ?? createSeededRandom(hashSeed(n, m, name));
+  const links = randomChoose(genAllPairs(nodes), m, random);
   const edges = links.map((link, idx) => ({
     id: idx,
     sourceId: link[0].id,


### PR DESCRIPTION
## Summary
- make the graph test data generator deterministic by default with a seeded RNG
- add unit coverage that exercises deterministic and custom-random outputs
- update the eslint config so the deck.gl-community package aliases no longer trigger false import errors

## Testing
- `node_modules/.bin/vitest run modules/graph-layers/test`


------
https://chatgpt.com/codex/tasks/task_e_690282d904008328abc45e7dbcb64e36