### PR TITLE
Fix radial layout example import

### DIFF
--- a/examples/graph-layers/graph-viewer/app-radial-layout-wip.ts
+++ b/examples/graph-layers/graph-viewer/app-radial-layout-wip.ts
@@ -12,8 +12,7 @@ import Color from 'color';
 import {fetchJSONFromS3} from './io';
 
 // graph.gl
-import GraphGL, {JSONLoader, NODE_TYPE} from '@deck.gl-community/graph-layers';
-import RadialLayout from './layouts/radial-layout';
+import GraphGL, {JSONLoader, NODE_TYPE, _RadialLayout as RadialLayout} from '@deck.gl-community/graph-layers';
 
 const DEFAULT_NODE_SIZE = 5;
 const DEFAULT_NODE_LABEL_COLOR = '#646464';


### PR DESCRIPTION
## Summary
- import the radial layout class from the graph-layers package instead of a non-existent local file

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69028d11b4888328b65e5289941c9f01