### PR TITLE
Adjust graph edge attachment points to node boundaries

### DIFF
--- a/modules/graph-layers/src/layers/graph-layer.ts
+++ b/modules/graph-layers/src/layers/graph-layer.ts
@@ -5,16 +5,19 @@
 import type {CompositeLayerProps} from '@deck.gl/core';
 import {COORDINATE_SYSTEM, CompositeLayer} from '@deck.gl/core';
 
+import type {ValueOf} from '../core/constants';
 import {NODE_TYPE, EDGE_DECORATOR_TYPE} from '../core/constants';
 import {Graph} from '../graph/graph';
 import {GraphLayout} from '../core/graph-layout';
 import {GraphEngine} from '../core/graph-engine';
+import type {Node} from '../graph/node';
 
 import {Stylesheet} from '../style/style-sheet';
 import {mixedGetPosition} from '../utils/layer-utils';
 import {InteractionManager} from '../core/interaction-manager';
 
 import {log} from '../utils/log';
+import {getNodeBoundaryIntersection, type NodeGeometry} from '../utils/node-boundary';
 
 // node layers
 import {CircleLayer} from './node-layers/circle-layer';
@@ -33,6 +36,31 @@ import {EdgeArrowLayer} from './edge-layers/edge-arrow-layer';
 
 import {JSONLoader} from '../loaders/json-loader';
 
+type NumericAccessor = ((node: Node) => number) | number | null | undefined;
+type OffsetAccessor =
+  | ((node: Node) => [number, number])
+  | [number, number]
+  | null
+  | undefined;
+
+type NodeStyleAccessors = {
+  type: ValueOf<typeof NODE_TYPE>;
+  getOffset?: OffsetAccessor;
+  getRadius?: NumericAccessor;
+  getWidth?: NumericAccessor;
+  getHeight?: NumericAccessor;
+  getCornerRadius?: NumericAccessor;
+  getSize?: NumericAccessor;
+};
+
+const GEOMETRY_NODE_TYPES = new Set<ValueOf<typeof NODE_TYPE>>([
+  NODE_TYPE.CIRCLE,
+  NODE_TYPE.RECTANGLE,
+  NODE_TYPE.ROUNDED_RECTANGLE,
+  NODE_TYPE.PATH_ROUNDED_RECTANGLE,
+  NODE_TYPE.MARKER
+]);
+
 const NODE_LAYER_MAP = {
   [NODE_TYPE.RECTANGLE]: RectangleLayer,
   [NODE_TYPE.ROUNDED_RECTANGLE]: RoundedRectangleLayer,
@@ -48,6 +76,55 @@ const EDGE_DECORATOR_LAYER_MAP = {
   [EDGE_DECORATOR_TYPE.FLOW]: FlowLayer,
   [EDGE_DECORATOR_TYPE.ARROW]: EdgeArrowLayer
 };
+
+function evaluateNumericAccessor(accessor: NumericAccessor, node: Node): number | undefined {
+  if (typeof accessor === 'function') {
+    const value = accessor(node);
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof accessor === 'number' && Number.isFinite(accessor)) {
+    return accessor;
+  }
+  return undefined;
+}
+
+function evaluateOffsetAccessor(accessor: OffsetAccessor, node: Node): [number, number] {
+  if (!accessor) {
+    return [0, 0];
+  }
+
+  let value = accessor as [number, number];
+  if (typeof accessor === 'function') {
+    value = accessor(node);
+  }
+
+  if (Array.isArray(value) && value.length >= 2) {
+    const offsetX = Number(value[0]);
+    const offsetY = Number(value[1]);
+    if (Number.isFinite(offsetX) && Number.isFinite(offsetY)) {
+      return [offsetX, offsetY];
+    }
+  }
+
+  return [0, 0];
+}
+
+function normalizePosition(value: any): [number, number] | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const candidate = value as {length?: number; [index: number]: number};
+  if (typeof candidate.length === 'number' && candidate.length >= 2) {
+    const x = Number(candidate[0]);
+    const y = Number(candidate[1]);
+    if (Number.isFinite(x) && Number.isFinite(y)) {
+      return [x, y];
+    }
+  }
+
+  return null;
+}
 
 const SHARED_LAYER_PROPS = {
   coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
@@ -194,6 +271,179 @@ export class GraphLayer extends CompositeLayer<GraphLayerProps> {
     }
   }
 
+  private _buildNodeStyleAccessorMap(engine: GraphEngine) {
+    const nodeAccessorMap = new Map<string | number, NodeStyleAccessors>();
+    const {nodeStyle} = this.props;
+
+    if (!nodeStyle) {
+      return nodeAccessorMap;
+    }
+
+    const styles = Array.isArray(nodeStyle) ? nodeStyle : [nodeStyle];
+
+    styles
+      .filter(Boolean)
+      .forEach((style) => {
+        const {data = (nodes) => nodes, ...restStyle} = style as any;
+        const type = restStyle.type as ValueOf<typeof NODE_TYPE> | undefined;
+
+        if (!type || !GEOMETRY_NODE_TYPES.has(type)) {
+          return;
+        }
+
+        const stylesheet = new Stylesheet(restStyle, {
+          stateUpdateTrigger: (this.state.interactionManager as any).getLastInteraction()
+        });
+
+        const nodes = data(engine.getNodes());
+        if (!Array.isArray(nodes)) {
+          return;
+        }
+
+        const accessors: NodeStyleAccessors = {
+          type,
+          getOffset: stylesheet.getDeckGLAccessor('getOffset')
+        };
+
+        switch (type) {
+          case NODE_TYPE.CIRCLE:
+            accessors.getRadius = stylesheet.getDeckGLAccessor('getRadius');
+            break;
+          case NODE_TYPE.MARKER:
+            accessors.getSize = stylesheet.getDeckGLAccessor('getSize');
+            break;
+          case NODE_TYPE.RECTANGLE:
+            accessors.getWidth = stylesheet.getDeckGLAccessor('getWidth');
+            accessors.getHeight = stylesheet.getDeckGLAccessor('getHeight');
+            break;
+          case NODE_TYPE.ROUNDED_RECTANGLE:
+            accessors.getWidth = stylesheet.getDeckGLAccessor('getWidth');
+            accessors.getHeight = stylesheet.getDeckGLAccessor('getHeight');
+            accessors.getCornerRadius = stylesheet.getDeckGLAccessor('getCornerRadius');
+            accessors.getRadius = stylesheet.getDeckGLAccessor('getRadius');
+            break;
+          case NODE_TYPE.PATH_ROUNDED_RECTANGLE:
+            accessors.getWidth = stylesheet.getDeckGLAccessor('getWidth');
+            accessors.getHeight = stylesheet.getDeckGLAccessor('getHeight');
+            accessors.getCornerRadius = stylesheet.getDeckGLAccessor('getCornerRadius');
+            break;
+          default:
+            break;
+        }
+
+        nodes.forEach((node: Node) => {
+          const id = node.getId();
+          if (!nodeAccessorMap.has(id)) {
+            nodeAccessorMap.set(id, accessors);
+          }
+        });
+      });
+
+    return nodeAccessorMap;
+  }
+
+  private _computeNodeGeometry(
+    engine: GraphEngine,
+    node: Node,
+    accessors?: NodeStyleAccessors
+  ): NodeGeometry | null {
+    const basePosition = engine.getNodePosition(node);
+    if (!basePosition) {
+      return null;
+    }
+
+    const offset = evaluateOffsetAccessor(accessors?.getOffset, node);
+    const center: [number, number] = [basePosition[0] + offset[0], basePosition[1] + offset[1]];
+
+    const geometry: NodeGeometry = {
+      type: accessors?.type,
+      center
+    };
+
+    if (!accessors) {
+      return geometry;
+    }
+
+    switch (accessors.type) {
+      case NODE_TYPE.CIRCLE: {
+        const radius = evaluateNumericAccessor(accessors.getRadius, node);
+        if (typeof radius === 'number') {
+          geometry.radius = Math.max(radius, 0);
+        }
+        break;
+      }
+      case NODE_TYPE.MARKER: {
+        const size = evaluateNumericAccessor(accessors.getSize, node);
+        if (typeof size === 'number') {
+          geometry.radius = Math.max(size / 2, 0);
+        }
+        break;
+      }
+      case NODE_TYPE.RECTANGLE: {
+        const width = evaluateNumericAccessor(accessors.getWidth, node);
+        const height = evaluateNumericAccessor(accessors.getHeight, node);
+        if (typeof width === 'number') {
+          geometry.width = Math.max(width, 0);
+        }
+        if (typeof height === 'number') {
+          geometry.height = Math.max(height, 0);
+        }
+        break;
+      }
+      case NODE_TYPE.ROUNDED_RECTANGLE: {
+        const width = evaluateNumericAccessor(accessors.getWidth, node);
+        const height = evaluateNumericAccessor(accessors.getHeight, node);
+        if (typeof width === 'number') {
+          geometry.width = Math.max(width, 0);
+        }
+        if (typeof height === 'number') {
+          geometry.height = Math.max(height, 0);
+        }
+        const cornerRadius = evaluateNumericAccessor(accessors.getCornerRadius, node);
+        if (typeof cornerRadius === 'number') {
+          geometry.cornerRadius = Math.max(cornerRadius, 0);
+        }
+        const radius = evaluateNumericAccessor(accessors.getRadius, node);
+        if (typeof radius === 'number') {
+          geometry.radius = Math.max(radius, 0);
+        }
+        break;
+      }
+      case NODE_TYPE.PATH_ROUNDED_RECTANGLE: {
+        const width = evaluateNumericAccessor(accessors.getWidth, node);
+        const height = evaluateNumericAccessor(accessors.getHeight, node);
+        if (typeof width === 'number') {
+          geometry.width = Math.max(width, 0);
+        }
+        if (typeof height === 'number') {
+          geometry.height = Math.max(height, 0);
+        }
+        const cornerRadius = evaluateNumericAccessor(accessors.getCornerRadius, node);
+        if (typeof cornerRadius === 'number') {
+          geometry.cornerRadius = Math.max(cornerRadius, 0);
+        }
+        break;
+      }
+      default: {
+        const radius = evaluateNumericAccessor(accessors.getRadius, node);
+        if (typeof radius === 'number') {
+          geometry.radius = Math.max(radius, 0);
+        }
+        const width = evaluateNumericAccessor(accessors.getWidth, node);
+        const height = evaluateNumericAccessor(accessors.getHeight, node);
+        if (typeof width === 'number') {
+          geometry.width = Math.max(width, 0);
+        }
+        if (typeof height === 'number') {
+          geometry.height = Math.max(height, 0);
+        }
+        break;
+      }
+    }
+
+    return geometry;
+  }
+
   createNodeLayers() {
     const engine = this.state.graphEngine;
     const {nodeStyle} = this.props;
@@ -237,6 +487,62 @@ export class GraphLayer extends CompositeLayer<GraphLayerProps> {
       return [];
     }
 
+    const nodeAccessorMap = this._buildNodeStyleAccessorMap(engine);
+    const nodeMap = engine
+      .getNodes()
+      .reduce(
+        (acc, node) => acc.set(node.getId(), node),
+        new Map<string | number, Node>()
+      );
+
+    const getLayoutInfo = (edge) => {
+      const layoutInfo = engine.getEdgePosition(edge);
+      if (!layoutInfo) {
+        return layoutInfo;
+      }
+
+      const sourceNode = nodeMap.get(edge.getSourceNodeId());
+      const targetNode = nodeMap.get(edge.getTargetNodeId());
+
+      if (!sourceNode || !targetNode) {
+        return layoutInfo;
+      }
+
+      const sourceGeometry = this._computeNodeGeometry(
+        engine,
+        sourceNode,
+        nodeAccessorMap.get(sourceNode.getId())
+      );
+      const targetGeometry = this._computeNodeGeometry(
+        engine,
+        targetNode,
+        nodeAccessorMap.get(targetNode.getId())
+      );
+
+      if (!sourceGeometry && !targetGeometry) {
+        return layoutInfo;
+      }
+
+      const adjustedLayout = {...layoutInfo};
+
+      const targetReference = targetGeometry?.center ?? normalizePosition(layoutInfo.targetPosition);
+      const sourceReference = sourceGeometry?.center ?? normalizePosition(layoutInfo.sourcePosition);
+
+      if (sourceGeometry) {
+        adjustedLayout.sourcePosition = targetReference
+          ? getNodeBoundaryIntersection(sourceGeometry, targetReference)
+          : [...sourceGeometry.center];
+      }
+
+      if (targetGeometry) {
+        adjustedLayout.targetPosition = sourceReference
+          ? getNodeBoundaryIntersection(targetGeometry, sourceReference)
+          : [...targetGeometry.center];
+      }
+
+      return adjustedLayout;
+    };
+
     return (Array.isArray(edgeStyle) ? edgeStyle : [edgeStyle])
       .filter(Boolean)
       .flatMap((style, idx) => {
@@ -255,7 +561,7 @@ export class GraphLayer extends CompositeLayer<GraphLayerProps> {
           ...SHARED_LAYER_PROPS,
           id: `edge-layer-${idx}`,
           data: data(engine.getEdges()),
-          getLayoutInfo: engine.getEdgePosition,
+          getLayoutInfo,
           pickable: true,
           positionUpdateTrigger: [engine.getLayoutLastUpdate(), engine.getLayoutState()].join(),
           stylesheet,
@@ -278,7 +584,7 @@ export class GraphLayer extends CompositeLayer<GraphLayerProps> {
             ...SHARED_LAYER_PROPS,
             id: `edge-decorator-${idx2}`,
             data: data(engine.getEdges()),
-            getLayoutInfo: engine.getEdgePosition,
+            getLayoutInfo,
             pickable: true,
             positionUpdateTrigger: [engine.getLayoutLastUpdate(), engine.getLayoutState()].join(),
             stylesheet: decoratorStylesheet

--- a/modules/graph-layers/src/utils/node-boundary.ts
+++ b/modules/graph-layers/src/utils/node-boundary.ts
@@ -1,0 +1,186 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {NODE_TYPE, type ValueOf} from '../core/constants';
+
+export type NodeGeometry = {
+  type?: ValueOf<typeof NODE_TYPE>;
+  center: [number, number];
+  radius?: number;
+  width?: number;
+  height?: number;
+  cornerRadius?: number;
+};
+
+const EPSILON = 1e-6;
+
+function normalizeDirection(
+  center: [number, number],
+  target: [number, number]
+): {unit: [number, number]; distance: number} | null {
+  const dx = target[0] - center[0];
+  const dy = target[1] - center[1];
+  const length = Math.hypot(dx, dy);
+
+  if (length <= EPSILON) {
+    return null;
+  }
+
+  return {unit: [dx / length, dy / length], distance: length};
+}
+
+function projectToRectangle(
+  center: [number, number],
+  unit: [number, number],
+  halfWidth: number,
+  halfHeight: number
+): [number, number] {
+  const absUx = Math.abs(unit[0]);
+  const absUy = Math.abs(unit[1]);
+
+  let distance = Number.POSITIVE_INFINITY;
+  if (halfWidth > 0 && absUx > EPSILON) {
+    distance = Math.min(distance, halfWidth / absUx);
+  }
+  if (halfHeight > 0 && absUy > EPSILON) {
+    distance = Math.min(distance, halfHeight / absUy);
+  }
+
+  if (!Number.isFinite(distance)) {
+    return [...center] as [number, number];
+  }
+
+  return [center[0] + unit[0] * distance, center[1] + unit[1] * distance];
+}
+
+function resolveCornerRadius(
+  rawCornerRadius: number | undefined,
+  halfWidth: number,
+  halfHeight: number
+): number {
+  if (!Number.isFinite(rawCornerRadius) || rawCornerRadius <= 0) {
+    return 0;
+  }
+
+  let resolved = rawCornerRadius;
+  if (resolved <= 1) {
+    resolved *= Math.min(halfWidth, halfHeight);
+  }
+
+  return Math.min(resolved, halfWidth, halfHeight);
+}
+
+function intersectRoundedRectangle(
+  geometry: NodeGeometry,
+  unit: [number, number],
+  halfWidth: number,
+  halfHeight: number
+): [number, number] {
+  const cornerRadius = resolveCornerRadius(geometry.cornerRadius, halfWidth, halfHeight);
+
+  if (cornerRadius <= EPSILON) {
+    return projectToRectangle(geometry.center, unit, halfWidth, halfHeight);
+  }
+
+  const innerHalfWidth = Math.max(halfWidth - cornerRadius, 0);
+  const innerHalfHeight = Math.max(halfHeight - cornerRadius, 0);
+
+  if (innerHalfWidth <= EPSILON || innerHalfHeight <= EPSILON) {
+    const radius = Math.min(halfWidth, halfHeight);
+    return [
+      geometry.center[0] + unit[0] * radius,
+      geometry.center[1] + unit[1] * radius
+    ];
+  }
+
+  const rectanglePoint = projectToRectangle(geometry.center, unit, halfWidth, halfHeight);
+  const offsetX = rectanglePoint[0] - geometry.center[0];
+  const offsetY = rectanglePoint[1] - geometry.center[1];
+  const absX = Math.abs(offsetX);
+  const absY = Math.abs(offsetY);
+
+  const insideVerticalFace = absX <= innerHalfWidth + EPSILON && absY <= halfHeight + EPSILON;
+  const insideHorizontalFace = absY <= innerHalfHeight + EPSILON && absX <= halfWidth + EPSILON;
+
+  if (absX <= innerHalfWidth + EPSILON || absY <= innerHalfHeight + EPSILON) {
+    if (insideVerticalFace || insideHorizontalFace) {
+      return rectanglePoint;
+    }
+  }
+
+  const cornerCenter: [number, number] = [
+    geometry.center[0] + Math.sign(offsetX || unit[0]) * innerHalfWidth,
+    geometry.center[1] + Math.sign(offsetY || unit[1]) * innerHalfHeight
+  ];
+  const relativeCornerCenter: [number, number] = [
+    cornerCenter[0] - geometry.center[0],
+    cornerCenter[1] - geometry.center[1]
+  ];
+
+  const dot = unit[0] * relativeCornerCenter[0] + unit[1] * relativeCornerCenter[1];
+  const centerDistanceSq =
+    relativeCornerCenter[0] * relativeCornerCenter[0] +
+    relativeCornerCenter[1] * relativeCornerCenter[1];
+  const discriminant = dot * dot - (centerDistanceSq - cornerRadius * cornerRadius);
+
+  if (discriminant < 0) {
+    return rectanglePoint;
+  }
+
+  const distance = dot - Math.sqrt(Math.max(0, discriminant));
+  return [
+    geometry.center[0] + unit[0] * distance,
+    geometry.center[1] + unit[1] * distance
+  ];
+}
+
+export function getNodeBoundaryIntersection(
+  geometry: NodeGeometry,
+  targetCenter: [number, number]
+): [number, number] {
+  const direction = normalizeDirection(geometry.center, targetCenter);
+  if (!direction) {
+    return [...geometry.center];
+  }
+
+  const {unit} = direction;
+
+  switch (geometry.type) {
+    case NODE_TYPE.CIRCLE:
+    case NODE_TYPE.MARKER: {
+      const radius = geometry.radius ?? 0;
+      return [geometry.center[0] + unit[0] * radius, geometry.center[1] + unit[1] * radius];
+    }
+    case NODE_TYPE.RECTANGLE: {
+      const halfWidth = (geometry.width ?? 0) / 2;
+      const halfHeight = (geometry.height ?? 0) / 2;
+      if (halfWidth <= EPSILON || halfHeight <= EPSILON) {
+        return [...geometry.center];
+      }
+      return projectToRectangle(geometry.center, unit, halfWidth, halfHeight);
+    }
+    case NODE_TYPE.ROUNDED_RECTANGLE:
+    case NODE_TYPE.PATH_ROUNDED_RECTANGLE: {
+      const halfWidth = (geometry.width ?? 0) / 2;
+      const halfHeight = (geometry.height ?? 0) / 2;
+      if (halfWidth <= EPSILON || halfHeight <= EPSILON) {
+        const radius = geometry.radius ?? Math.min(halfWidth, halfHeight);
+        return [
+          geometry.center[0] + unit[0] * radius,
+          geometry.center[1] + unit[1] * radius
+        ];
+      }
+      return intersectRoundedRectangle(geometry, unit, halfWidth, halfHeight);
+    }
+    default: {
+      if (geometry.radius && geometry.radius > EPSILON) {
+        return [
+          geometry.center[0] + unit[0] * geometry.radius,
+          geometry.center[1] + unit[1] * geometry.radius
+        ];
+      }
+      return [...geometry.center];
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- derive node geometry from node styles so edges can attach to the rendered boundary instead of node centers
- add geometry intersection helpers to compute attachment points for circles, rectangles, and rounded rectangles
- update edge layout generation to respect node offsets and decorator layers using the adjusted start/end positions

## Testing
- yarn test --run *(fails: template package has no entry point)*

------
https://chatgpt.com/codex/tasks/task_e_6904bbb89a0c8328921afcee014a74b0