### PR TITLE
docs: overhaul graph-layers styling reference

### DIFF
--- a/docs/modules/graph-layers/api-reference/styling/edge/edge-style-flow.md
+++ b/docs/modules/graph-layers/api-reference/styling/edge/edge-style-flow.md
@@ -1,27 +1,42 @@
-# FLOW
+# Flow decorator
 
-<p align="center">
-  <img src="/gatsby/images/edge-styles/flows.gif" height="200" />
-</p>
+The flow decorator draws animated segments moving along the edge direction. It
+is useful to express throughput or directional emphasis.
 
-### `color` (String | Array | Function, optional)
-- Default: `[255, 255, 255, 255]`
-- The value can be hex code, color name, or color array `[r, g, b, a]` (each component is in the 0 - 255 range).
-- If a color value (hex code, color name, or array) is provided, it is used as the global color for all edges.
-- If a function is provided, it is called on each edge to retrieve its color.
+## Properties
 
-### `speed` (Number | Function, optional)
-- Default: `0`
-- Unit: number of moving segment pass through the line per second.
-- If a number is provided for `speed`, all the flow will have the same speed.
-- If an accessor function is provided, the function will be called to retrieve the speed for each flow.
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `color` | `string \| number[] \| function` | black (`[0, 0, 0]`) | Color of the animated segment. |
+| `speed` | `number \| function` | `0` | Segments per second that travel along the edge. Positive values flow from source to target. |
+| `width` | `number \| function` | `1` | Visual width of the segment in pixels. |
+| `tailLength` | `number \| function` | `1` | Length of the fading trail behind each segment. |
 
-### `width` (Number | Function, optional)
-- Default: `1`
-- If a number is provided for `width`, all the flow will have the same width.
-- If an accessor function is provided, the function will be called to retrieve the width for each flow.
+All fields support accessors and selectors. A speed of `0` disables the motion
+while still rendering a static highlight.
 
-### `tailLength` (Number | Function, optional)
-- Default: `1`
-- If a number is provided for `tailLength`, all the flow will have the same length for the fading tail.
-- If an accessor function is provided, the function will be called to retrieve the length of the fading tail for each flow.
+## Examples
+
+```js
+{
+  type: EDGE_DECORATOR_TYPE.FLOW,
+  color: '#22D3EE',
+  width: 2,
+  speed: edge => edge.capacity > 0 ? edge.load / edge.capacity : 0,
+  tailLength: 4
+}
+```
+
+To create directional emphasis only while hovering:
+
+```js
+{
+  type: EDGE_DECORATOR_TYPE.FLOW,
+  color: '#FACC15',
+  width: 3,
+  speed: {
+    default: 0,
+    hover: 2
+  }
+}
+```

--- a/docs/modules/graph-layers/api-reference/styling/edge/edge-style-label.md
+++ b/docs/modules/graph-layers/api-reference/styling/edge/edge-style-label.md
@@ -1,34 +1,52 @@
-# LABEL
+# Edge label decorator
 
-<p align="center">
-  <img src="/gatsby/images/edge-styles/label.png" height="200" />
-</p>
+Adds text anchored near the edge’s midpoint. Internally this uses the same
+`ZoomableTextLayer` as node labels, so the available options are similar.
 
-### `text` (String | Function, required)
-- The text of the label.
-- If a string is provided for `text`, all the edges will have the same text.
-- If an accessor function is provided, the function will be called to retrieve the text of each edge.
+## Properties
 
-### `color` (String | Array | Function, optional)
-- Default: `[255, 255, 255, 255]`
-- The value can be hex code, color name, or color array `[r, g, b, a]` (each component is in the 0 - 255 range).
-- If a color value (hex code, color name, or array) is provided, it is used as the global color for all edges.
-- If a function is provided, it is called on each edge to retrieve its color.
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `text` | `string \| function` | – (required) | Label content. Functions receive the edge instance. |
+| `color` | `string \| number[] \| function` | black (`[0, 0, 0]`) | Font color. |
+| `fontSize` | `number \| function` | `12` | Font size in pixels. |
+| `textAnchor` | `string \| function` | `'middle'` | Horizontal alignment relative to the computed position. |
+| `alignmentBaseline` | `string \| function` | `'center'` | Vertical alignment. |
+| `angle` | `number \| function` | Automatic | Rotation in degrees. Defaults to the edge direction; override to lock the angle. |
+| `textMaxWidth` | `number \| function` | `-1` | Maximum width before wrapping. `-1` disables wrapping. |
+| `textWordBreak` | `string \| function` | `'break-all'` | Word-breaking mode (`'break-word'`, `'break-all'`, etc.). |
+| `textSizeMinPixels` | `number \| function` | `9` | Minimum rendered size for zooming out. |
+| `scaleWithZoom` | `boolean \| function` | `true` | Whether the label scales with the viewport zoom level. |
+| `offset` | `[number, number] \| function` | `null` | Additional pixel offset from the centroid-derived anchor position. |
 
-### `fontSize` (Number | Function, optional)
-- Default: `12`
-- If a number is provided for `fontSize`, all the labels will have the same font size.
-- If an accessor function is provided, the function will be called to retrieve the font size of each label.
+All properties support selectors (`:hover`, `:selected`, …) and accessors, just
+like the base edge style.
 
-### `textAnchor` (String | Function, optional)
-- Default: `middle`
-- The text anchor. Available options include 'start', 'middle' and 'end'.
+## Examples
 
-- If a string is provided, it is used as the text anchor for all edges.
-- If a function is provided, it is called on each edge to retrieve its text anchor.
+```js
+{
+  type: EDGE_DECORATOR_TYPE.LABEL,
+  text: edge => `${edge.weight} ms`,
+  color: {
+    default: '#1F2937',
+    hover: '#111827'
+  },
+  textAnchor: 'start',
+  offset: [8, 0]
+}
+```
 
-### `alignmentBaseline` (String | Function, optional)
-- Default: `center`
-The alignment baseline. Available options include 'top', 'center' and 'bottom'.
-- If a string is provided, it is used as the alignment baseline for all edges.
-- If a function is provided, it is called on each edge to retrieve its alignment baseline.
+To keep labels readable while zooming, disable scaling at small sizes:
+
+```js
+{
+  type: EDGE_DECORATOR_TYPE.LABEL,
+  text: edge => edge.label,
+  scaleWithZoom: {
+    default: true,
+    dragging: false
+  },
+  textSizeMinPixels: 12
+}
+```

--- a/docs/modules/graph-layers/api-reference/styling/edge/edge-style.md
+++ b/docs/modules/graph-layers/api-reference/styling/edge/edge-style.md
@@ -1,19 +1,28 @@
-# Edge Style
+# Edge stylesheets
 
-### Usage
+Edges are styled with a single object passed to the `edgeStyle` prop of
+`GraphLayer`. Similar to nodes, the stylesheet engine normalizes colors,
+accessors, and interaction states before feeding them into Deck.gl’s `LineLayer`.
 
 ```js
-edgeStyle={{
-  stroke: 'black',
-  strokeWidth: 2,
-  data: (data) => data,
-  visible: true,
+const edgeStyle = {
+  stroke: edge => (edge.isCritical ? '#F97316' : '#94A3B8'),
+  strokeWidth: {
+    default: 1,
+    hover: 3,
+    selected: 4
+  },
   decorators: [
     {
       type: EDGE_DECORATOR_TYPE.LABEL,
       text: edge => edge.id,
       color: '#000',
       fontSize: 18,
+
+      // text: edge => edge.weight.toFixed(1),
+      // color: '#1F2937',
+      // offset: [0, 16]
+
     },
     {
       type: EDGE_DECORATOR_TYPE.ARROW,
@@ -23,30 +32,47 @@ edgeStyle={{
     }
   ],
 }}
+};
 ```
 
-### `stroke` (String | Array | Function, optional)
+## Shared properties
 
-- Default: `[255, 255, 255, 255]`
-- The value can be hex code, color name, or color array `[r, g, b, a]` (each component is in the 0 - 255 range).
-- If a color value (hex code, color name, or array) is provided, it is used as the global color for all edges.
-- If a function is provided, it is called on each rectangle to retrieve its color.
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `stroke` | `string \| number[] \| function` | black (`[0, 0, 0]`) | Line color. Accepts CSS strings or `[r, g, b, a]` arrays. |
+| `strokeWidth` | `number \| function` | `0` | Line width in pixels. Accessors receive the edge object. |
+| `data` | `function(edge) -> any` | `edge => edge` | Overrides the data object passed to the Deck.gl layer. |
+| `visible` | `boolean` | `true` | Toggles the entire edge layer on/off. |
+| `decorators` | `Array` | `[]` | Additional visual adornments such as labels or animated flow indicators. |
 
-### `strokeWidth` (Number | Function, optional)
+### Interaction selectors
 
-- Default: `0`
-  The width of the outline of each rectangle.
-  If a number is provided, it is used as the outline width for all edges.
-  If a function is provided, it is called on each rectangle to retrieve its outline width.
+Edge styles honor the same selectors as node styles: `:hover`, `:dragging`, and
+`:selected`. Selector blocks can override any property, including decorators.
 
-### `data` (Function, optional)
+```js
+const edgeStyle = {
+  stroke: '#CBD5F5',
+  strokeWidth: 1,
+  ':hover': {
+    stroke: '#2563EB',
+    strokeWidth: 2
+  }
+};
+```
 
-Allows setting of the layer data via accessor
+### Decorators
 
-### `visible` (Boolean, optional)
+Decorators add auxiliary visuals that travel along the edge path. Each decorator
+is an object with a `type` field matching one of `EDGE_DECORATOR_TYPE`. The
+following decorator types are available:
 
-Determines if the layer is visible
+* [`EDGE_DECORATOR_TYPE.LABEL`](./edge-style-label.md) – text anchored to the
+  edge midpoint.
+* [`EDGE_DECORATOR_TYPE.FLOW`](./edge-style-flow.md) – animated flow segments to
+  communicate direction or magnitude.
 
+<<<<<<< HEAD
 ### `decorators` (Array, optional)
 
 A set of decorators that can be attached to each rendered edge. Supported decorator `type`
@@ -61,3 +87,7 @@ values and their style attributes include:
   `offset`. The `offset` accessor accepts `[along, perpendicular]` distances in layer units, where
   `along` shifts the arrow away from the target node and `perpendicular` offsets it orthogonally
   from the edge.
+=======
+Decorators are also processed by the stylesheet engine, so they can use
+selectors and accessors just like the main edge style.
+>>>>>>> 0464f83 (docs: overhaul graph-layers styling reference)

--- a/docs/modules/graph-layers/api-reference/styling/node/node-style-circle.md
+++ b/docs/modules/graph-layers/api-reference/styling/node/node-style-circle.md
@@ -1,28 +1,51 @@
-# CIRCLE
+# Circle node style
 
-<p align="center">
-  <img src="/gatsby/images/node-styles/circle.png" height="100" />
-</p>
+The circle primitive renders filled disks using Deck.gl’s `ScatterplotLayer`. It
+is ideal for compact node markers or when you want the radius to encode a
+numerical value.
 
-### `fill` (String | Array | Function, optional)
-- Default: `#fff`
-- The value can be hex code, color name, or color array `[r, g, b, a]` (each component is in the 0 - 255 range).
-If a color value (hex code, color name, or array) is provided, it is used as the global color for all objects.
-If a function is provided, it is called on each rectangle to retrieve its color.
+## Properties
 
-### `radius` (Number | Function, optional)
-- Default: `1`
-- If a number is provided for `radius`, all the circles will have the same radius.
-If an accessor function is provided, the function will be called to retrieve the radius of each circle.
+In addition to the [shared node style options](./node-style.md#shared-properties),
+circle styles understand the following keys:
 
-### `stroke` (String | Array | Function, optional)
-- Default: `[0, 0, 0, 255]`
-- The value can be hex code, color name, or color array `[r, g, b, a]` (each component is in the 0 - 255 range).
-- If a color value (hex code, color name, or array) is provided, it is used as the global color for all objects.
-- If a function is provided, it is called on each rectangle to retrieve its color.
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `fill` | `string \| number[] \| function` | black (`[0, 0, 0]`) | Fill color. Accepts CSS color strings, `[r, g, b]`/`[r, g, b, a]` arrays, or an accessor. |
+| `radius` | `number \| function` | `1` | Radius in pixels. Accessors can read node data to size circles proportionally. |
+| `stroke` | `string \| number[] \| function` | black (`[0, 0, 0]`) | Outline color. |
+| `strokeWidth` | `number \| function` | `0` | Outline width in pixels. |
 
-### `strokeWidth` (Number | Function, optional)
-- Default: `0`
-- The width of the outline of each rectangle.
-- If a number is provided, it is used as the outline width for all rectangles.
-- If a function is provided, it is called on each rectangle to retrieve its outline width.
+All color accessors can return either a color string or an array. Alpha values
+are optional—when omitted the color is treated as fully opaque.
+
+## Examples
+
+```js
+{
+  type: NODE_TYPE.CIRCLE,
+  radius: node => 4 + node.outgoingEdges.length,
+  fill: {
+    default: '#CBD5F5',
+    hover: '#3B82F6'
+  },
+  stroke: '#1E3A8A',
+  strokeWidth: 1.5
+}
+```
+
+To add a subtle highlight when selecting a node you can combine selectors with
+accessors:
+
+```js
+{
+  type: NODE_TYPE.CIRCLE,
+  radius: 10,
+  fill: '#22C55E',
+  strokeWidth: {
+    default: 0,
+    selected: node => (node.state === NODE_STATE.SELECTED ? 4 : 0)
+  },
+  stroke: '#052E16'
+}
+```

--- a/docs/modules/graph-layers/api-reference/styling/node/node-style-label.md
+++ b/docs/modules/graph-layers/api-reference/styling/node/node-style-label.md
@@ -1,40 +1,54 @@
-# LABEL
+# Label node style
 
-<p align="center">
-  <img src="/gatsby/images/node-styles/label.png" height="100" />
-</p>
+Labels are rendered with Deck.gl’s `TextLayer` and are typically combined with a
+background primitive (circle, rectangle, etc.).
 
-### `text` (String | Function, required)
-- The text of the label.
-- If a string is provided for `text`, all the objects will have the same text.
-- If an accessor function is provided, the function will be called to retrieve the text of each object.
+## Properties
 
-### `color` (String | Array | Function, optional)
-- Default: `[0, 0, 0, 255]`
-- The value can be hex code, color name, or color array `[r, g, b, a]` (each component is in the 0 - 255 range).
-- If a color value (hex code, color name, or array) is provided, it is used as the global color for all objects.
-- If a function is provided, it is called on each object to retrieve its color.
+Alongside the [shared node options](./node-style.md#shared-properties), labels
+support the following keys:
 
-### `fontSize` (Number | Function, optional)
-- Default: `12`
-- If a number is provided for `fontSize`, all the labels will have the same font size.
-- If an accessor function is provided, the function will be called to retrieve the font size of each label.
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `text` | `string \| function` | – (required) | Text to display. Functions receive the node instance. |
+| `color` | `string \| number[] \| function` | black (`[0, 0, 0]`) | Font color. |
+| `fontSize` | `number \| function` | `12` | Font size in pixels. |
+| `textAnchor` | `string \| function` | `'middle'` | Horizontal alignment: `'start'`, `'middle'`, or `'end'`. |
+| `alignmentBaseline` | `string \| function` | `'center'` | Vertical alignment: `'top'`, `'center'`, or `'bottom'`. |
+| `angle` | `number \| function` | `0` | Clockwise rotation in degrees. |
+| `textMaxWidth` | `number \| function` | `-1` | Maximum width in pixels before wrapping. `-1` disables wrapping. |
+| `textWordBreak` | `string \| function` | `'break-all'` | Word-breaking mode passed to `TextLayer` (`'break-all'`, `'break-word'`, etc.). |
+| `textSizeMinPixels` | `number \| function` | `9` | Minimum size the text is allowed to shrink to. |
+| `scaleWithZoom` | `boolean \| function` | `true` | Whether the font scales with zoom. Set to `false` to keep screen-space size. |
 
-### `textAnchor` (String | Function, optional)
-- Default: `middle`
-- The text anchor. Available options include 'start', 'middle' and 'end'.
+## Examples
 
-- If a string is provided, it is used as the text anchor for all objects.
-- If a function is provided, it is called on each object to retrieve its text anchor.
+```js
+{
+  type: NODE_TYPE.LABEL,
+  text: node => node.label,
+  color: '#E2E8F0',
+  fontSize: 16,
+  offset: [0, 18],
+  alignmentBaseline: 'top'
+}
+```
 
-### `alignmentBaseline` (String | Function, optional)
-- Default: `center`
-The alignment baseline. Available options include 'top', 'center' and 'bottom'.
-- If a string is provided, it is used as the alignment baseline for all objects.
-- If a function is provided, it is called on each object to retrieve its alignment baseline.
+Using selectors you can provide contextual hints:
 
-### `angle` (Number | Function, optional)
-- Default: `0`
-- The rotating angle of each text label, in degrees.
-- If a number is provided, it is used as the angle for all objects.
-- If a function is provided, it is called on each object to retrieve its angle.
+```js
+{
+  type: NODE_TYPE.LABEL,
+  text: node => node.label,
+  color: {
+    default: '#64748B',
+    hover: '#F8FAFC'
+  },
+  textMaxWidth: 160,
+  textWordBreak: 'break-word',
+  ':selected': {
+    fontSize: 20,
+    scaleWithZoom: false
+  }
+}
+```

--- a/docs/modules/graph-layers/api-reference/styling/node/node-style-marker.md
+++ b/docs/modules/graph-layers/api-reference/styling/node/node-style-marker.md
@@ -1,32 +1,61 @@
-# MARKER
+# Marker node style
 
-<p align="center">
-  <img src="/gatsby/images/node-styles/marker.png" height="100" />
-</p>
+Markers render vector icons from the bundled marker set. Under the hood the
+style uses a Deck.gl `IconLayer` with zoom-aware sizing logic.
 
-### `marker` (String | Function, required)
-- Marker can be one of the following types:
-```js
-"location-marker-filled", "bell-filled", "bookmark-filled", "bookmark", "cd-filled", "cd", "checkmark",
-"circle-check-filled", "circle-check", "circle-filled", "circle-i-filled", "circle-i", "circle-minus-filled",
-"circle-minus", "circle-plus-filled", "circle-plus", "circle-questionmark-filled", "circle-questionmark",
-"circle-slash-filled", "circle-slash", "circle-x-filled", "circle-x", "circle", "diamond-filled", "diamond",
-"flag-filled", "flag", "gear", "heart-filled", "heart", "bell", "location-marker", "octagonal-star-filled",
-"octagonal-star", "person-filled", "person", "pin-filled", "pin", "plus-small", "plus", "rectangle-filled",
-"rectangle", "star-filled", "star", "tag-filled", "tag", "thumb-down-filled", "thumb-down", "thumb-up",
-"thumb_up-filled", "triangle-down-filled", "triangle-down", "triangle-left-filled", "triangle-left",
-"triangle-right-filled", "triangle-right", "triangle-up-filled", "triangle-up", "x-small", "x"
+## Properties
+
+Marker styles extend the [shared node options](./node-style.md#shared-properties)
+with the following keys:
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `marker` | `string \| function` | `'circle'` | Name of the marker glyph. See the list below for supported values. |
+| `size` | `number \| function` | `12` | Marker size in pixels before zoom scaling. |
+| `fill` | `string \| number[] \| function` | black (`[0, 0, 0]`) | Fill color for the glyph. |
+| `scaleWithZoom` | `boolean \| function` | `true` | When `true`, markers grow/shrink with the viewport zoom level. Set to `false` to keep a constant pixel size. |
+
+Supported marker names include:
+
 ```
-- If a string is provided for `marker`, all the objects will use the same marker.
-- If an accessor function is provided, the function will be called to retrieve the marker of each marker.
+"location-marker-filled", "bell-filled", "bookmark-filled", "bookmark", "cd-filled",
+"cd", "checkmark", "circle-check-filled", "circle-check", "circle-filled", "circle-i-filled",
+"circle-i", "circle-minus-filled", "circle-minus", "circle-plus-filled", "circle-plus",
+"circle-questionmark-filled", "circle-questionmark", "circle-slash-filled", "circle-slash",
+"circle-x-filled", "circle-x", "circle", "diamond-filled", "diamond", "flag-filled",
+"flag", "gear", "heart-filled", "heart", "bell", "location-marker", "octagonal-star-filled",
+"octagonal-star", "person-filled", "person", "pin-filled", "pin", "plus-small", "plus",
+"rectangle-filled", "rectangle", "star-filled", "star", "tag-filled", "tag", "thumb-down-filled",
+"thumb-down", "thumb-up", "thumb_up-filled", "triangle-down-filled", "triangle-down",
+"triangle-left-filled", "triangle-left", "triangle-right-filled", "triangle-right",
+"triangle-up-filled", "triangle-up", "x-small", "x"
+```
 
-### `size` (Number | Function, optional)
-- Default: `12`
-- If a number is provided for `size`, all the markers will have the same size.
-- If an accessor function is provided, the function will be called to retrieve the size of each marker.
+## Examples
 
-### `fill` (String | Array | Function, optional)
-- Default: `[0, 0, 0, 255]`
-- The value can be hex code, color name, or color array `[r, g, b, a]` (each component is in the 0 - 255 range).
-If a color value (hex code, color name, or array) is provided, it is used as the global color for all objects.
-- If a function is provided, it is called on each object to retrieve its color.
+```js
+{
+  type: NODE_TYPE.MARKER,
+  marker: node => (node.isOffline ? 'triangle-down-filled' : 'circle-filled'),
+  size: 18,
+  fill: {
+    default: '#6B7280',
+    hover: '#F59E0B'
+  },
+  scaleWithZoom: false
+}
+```
+
+Use selectors to show different icons for interaction states:
+
+```js
+{
+  type: NODE_TYPE.MARKER,
+  marker: {
+    default: 'circle',
+    selected: 'star-filled'
+  },
+  size: 16,
+  fill: '#FBBF24'
+}
+```

--- a/docs/modules/graph-layers/api-reference/styling/node/node-style-path-rounded-rectangle.md
+++ b/docs/modules/graph-layers/api-reference/styling/node/node-style-path-rounded-rectangle.md
@@ -1,0 +1,47 @@
+# Path rounded rectangle node style
+
+This variant generates the rounded rectangle geometry on the CPU and feeds it to
+Deck.gl’s `PolygonLayer`. It trades slightly higher CPU cost for compatibility
+with features that rely on actual polygon outlines (e.g. GPU picking or custom
+polygon processing).
+
+## Properties
+
+Path rounded rectangles accept the rectangle properties plus:
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `cornerRadius` | `number \| function` | `0.1` | Corner rounding factor. As with the shader version, `0` is sharp and `1` is fully rounded. |
+
+The width, height, fill, stroke, and strokeWidth options behave identically to
+[`NODE_TYPE.RECTANGLE`](./node-style-rectangle.md).
+
+## Examples
+
+```js
+{
+  type: NODE_TYPE.PATH_ROUNDED_RECTANGLE,
+  width: node => 120 + node.children.length * 8,
+  height: 48,
+  cornerRadius: 0.35,
+  fill: '#0B1120',
+  stroke: '#38BDF8',
+  strokeWidth: 1.5
+}
+```
+
+Because the geometry is computed per node you can animate the radius as part of
+an interaction:
+
+```js
+{
+  type: NODE_TYPE.PATH_ROUNDED_RECTANGLE,
+  width: 96,
+  height: 40,
+  cornerRadius: {
+    default: 0.2,
+    hover: 0.5
+  },
+  fill: '#1E3A8A'
+}
+```

--- a/docs/modules/graph-layers/api-reference/styling/node/node-style-rectangle.md
+++ b/docs/modules/graph-layers/api-reference/styling/node/node-style-rectangle.md
@@ -1,33 +1,50 @@
-# RECTANGLE
+# Rectangle node style
 
-<p align="center">
-  <img src="/gatsby/images/node-styles/rectangle.png" height="100" />
-</p>
+Rectangles are rendered with Deck.gl’s `PolygonLayer` and are useful for card-like
+nodes or to provide a background behind other primitives.
 
-### `width` (Number | Function, required)
-- The width of the rectancle.
-- If a number is provided, it is used as the width for all objects.
-- If a function is provided, it is called on each object to retrieve its width.
+## Properties
 
-### `height` (Number | Function, required)
-- The height of the rectangle.
-- If a number is provided, it is used as the height for all objects.
-- If a function is provided, it is called on each object to retrieve its height.
+Besides the [shared node options](./node-style.md#shared-properties), rectangles
+support:
 
-### `fill` (String | Array | Function, optional)
-- Default: `[0, 0, 0, 255]`
-- The value can be hex code, color name, or color array `[r, g, b, a]` (each component is in the 0 - 255 range).
-If a color value (hex code, color name, or array) is provided, it is used as the global color for all objects.
-- If a function is provided, it is called on each object to retrieve its color.
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `width` | `number \| function` | – (required) | Rectangle width in pixels. Accessors receive the node instance. |
+| `height` | `number \| function` | – (required) | Rectangle height in pixels. |
+| `fill` | `string \| number[] \| function` | black (`[0, 0, 0]`) | Interior color. |
+| `stroke` | `string \| number[] \| function` | black (`[0, 0, 0]`) | Border color. |
+| `strokeWidth` | `number \| function` | `0` | Border width in pixels. |
 
-### `stroke` (String | Array | Function, optional)
-- Default: `[0, 0, 0, 255]`
-- The value can be hex code, color name, or color array `[r, g, b, a]` (each component is in the 0 - 255 range).
-- If a color value (hex code, color name, or array) is provided, it is used as the global color for all objects.
-- If a function is provided, it is called on each rectangle to retrieve its color.
+## Examples
 
-### `strokeWidth` (Number | Function, optional)
-- Default: `0`
-The width of the outline of each rectangle.
-If a number is provided, it is used as the outline width for all rectangles.
-If a function is provided, it is called on each rectangle to retrieve its outline width.
+```js
+{
+  type: NODE_TYPE.RECTANGLE,
+  width: 120,
+  height: 60,
+  fill: '#1F2937',
+  stroke: '#93C5FD',
+  strokeWidth: 1
+}
+```
+
+You can combine selectors to animate the border as the user interacts with the
+node:
+
+```js
+{
+  type: NODE_TYPE.RECTANGLE,
+  width: node => 100 + node.metadata.padding * 2,
+  height: 48,
+  fill: {
+    default: '#0F172A',
+    hover: '#1E293B'
+  },
+  strokeWidth: {
+    default: 1,
+    selected: 4
+  },
+  stroke: '#38BDF8'
+}
+```

--- a/docs/modules/graph-layers/api-reference/styling/node/node-style-rounded-rectangle.md
+++ b/docs/modules/graph-layers/api-reference/styling/node/node-style-rounded-rectangle.md
@@ -1,0 +1,47 @@
+# Rounded rectangle node style
+
+This primitive uses a custom shader to draw rectangles with smoothly rounded
+corners while keeping the geometry lightweight. It is great for pill-shaped or
+card-style nodes that should remain crisp at any zoom level.
+
+## Properties
+
+Rounded rectangles share all options from [basic rectangles](./node-style-rectangle.md)
+and add the following controls:
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `cornerRadius` | `number \| function` | `0.1` | Amount of corner rounding. `0` keeps sharp corners, `1` approaches a circle. Values between 0 and 1 are typical. |
+| `radius` | `number \| function` | `1` | Optional radius multiplier for the underlying geometry. It is exposed for compatibility and can be used to expand or shrink the shader’s falloff. |
+
+Because the shape is generated in the shader it remains smooth regardless of the
+polygon resolution.
+
+## Examples
+
+```js
+{
+  type: NODE_TYPE.ROUNDED_RECTANGLE,
+  width: 140,
+  height: 56,
+  cornerRadius: 0.5,
+  fill: '#111827',
+  stroke: '#4ADE80',
+  strokeWidth: {
+    default: 1,
+    selected: 3
+  }
+}
+```
+
+You can also adjust the radius dynamically to highlight specific groups:
+
+```js
+{
+  type: NODE_TYPE.ROUNDED_RECTANGLE,
+  width: 110,
+  height: 44,
+  cornerRadius: node => (node.cluster === 'core' ? 0.35 : 0.15),
+  fill: node => node.clusterColor
+}
+```

--- a/docs/modules/graph-layers/api-reference/styling/node/node-style.md
+++ b/docs/modules/graph-layers/api-reference/styling/node/node-style.md
@@ -1,50 +1,143 @@
-# Node Style
+# Node stylesheets
 
-Node accessors control the way how users want to render nodes. Layers provide the flexibility that users can add several visual layers to represent a node, such as adding circles, icons, and text labels.
-
-### Usage
-
-Example of nodeStyle:
+GraphGL renders nodes by stacking one or more *style layers* on top of each
+other. The [`nodeStyle` prop](../../../../modules/graph-layers/api-reference/graph.md)
+accepts an array of style objects. Each object describes one visual layer and is
+compiled into a Deck.gl sublayer by the `Stylesheet` helper.
 
 ```js
-<GraphGL
-  {...shareProps}
-  nodeStyle={[
-    {
-      type: NODE_TYPE.CIRCLE,
-      radius: 10,
-      color: '#f00'
-      data: data => data,
-      visible: true
-    }
-  ]}
-/>
+const nodeStyle = [
+  {
+    type: NODE_TYPE.CIRCLE,
+    radius: 10,
+    fill: node => (node.degree > 5 ? '#3C9EE7' : '#F06449')
+  },
+  {
+    type: NODE_TYPE.LABEL,
+    text: node => node.id,
+    color: '#172B4D',
+    offset: [0, 16]
+  }
+];
 ```
 
-### `type` (String, required)
+The order in the array controls the drawing order: earlier entries are rendered
+first (i.e. they appear underneath later entries).
 
-- `Type` can only be `CIRCLE`, `MARKER`, `RECTANGLE`, or `LABEL`.
-- Different type of layer may requires different properties. See more details in the 'Node style' /docs/api-reference/node-style-circle chapter below.
+## How the stylesheet engine works
 
-### `offset` (null | Array, optional)
+1. `GraphLayer` receives your style objects and instantiates a `Stylesheet` for
+   each entry.
+2. Every property is normalized into either a constant value or an accessor
+   function. Functions are wrapped so you can return plain JavaScript values
+   (strings, arrays, numbers) and the stylesheet will coerce them to the format
+   required by the underlying Deck.gl layer.
+3. Optional state selectors such as `:hover` or `:selected` are expanded into
+   state-aware accessors. At render time the accessor receives a node with a
+   `state` field (`default`, `hover`, `dragging`, `selected`) and returns the
+   matching style variant.
+4. Deck.gl update triggers are wired automatically so that your accessors are
+   re-evaluated when their dependencies change.
 
-- Default: `null`
-- The offset distance from the position of the object.
+This pipeline allows you to focus on the *what* of styling while GraphGL takes
+care of the *how*.
 
-### `scaleWithZoom` (Boolean, optional)
+## Shared properties
 
-- Default: `true`
-- If `scaleWithZoom` is true, the size of the element will be scaled according to the zoom level.
+The following keys are understood by every node style:
 
-### `textSizeMinPixels` (Number, optional)
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `type` | `NODE_TYPE` constant | – | Selects the visual primitive (circle, rectangle, label, etc.). |
+| `data` | `function(node) -> any` | `node => node` | Replaces the data object passed to Deck.gl. Useful when a sublayer needs derived data. |
+| `visible` | `boolean` | `true` | Toggles the sublayer on and off without removing it from the style list. |
+| `opacity` | `number \| function` | `1` | Multiplies the alpha channel produced by the primitive. Accepts 0–1. |
+| `offset` | `[number, number] \| function` | `null` | Pixel offset from the node’s layout position. Positive Y moves up. |
 
-- Default: `9`
-- Sets the minimum text size permitted by pixels
+Every style also accepts accessor functions. You can return a literal value or
+any function; if you use accessors, GraphGL automatically configures Deck.gl’s
+`updateTriggers` so the layer updates when the accessor changes.
 
-### `data` (Function, optional)
+```js
+{
+  type: NODE_TYPE.CIRCLE,
+  radius: node => Math.max(4, node.getPropertyValue('weight')),
+  fill: {
+    default: '#9CA3AF',
+    hover: '#60A5FA',
+    selected: node => node.groupColor
+  }
+}
+```
 
-Allows setting of the layer data via accessor
+## Stateful styling with selectors
 
-### `visible` (Boolean, optional)
+Each style object may contain pseudo-selectors whose keys begin with `:`. The
+supported selectors map to node interaction states:
 
-Determines if the layer is visible
+| Selector | Applies when… |
+| --- | --- |
+| `:hover` | the pointer is hovering the node. |
+| `:dragging` | the node is currently being dragged. |
+| `:selected` | the node has been selected via click/tap. |
+
+Any property placed inside a selector overrides the default variant for that
+state. For example, to brighten a node while dragging:
+
+```js
+{
+  type: NODE_TYPE.CIRCLE,
+  radius: 8,
+  fill: '#2563EB',
+  ':dragging': {
+    fill: '#60A5FA',
+    strokeWidth: 2,
+    stroke: '#1D4ED8'
+  }
+}
+```
+
+If no selector is present the default variant is used for every state.
+
+## Available node style types
+
+Use the type-specific reference pages to learn about the properties that each
+primitive understands:
+
+* [Circle](./node-style-circle.md) – disk markers.
+* [Rectangle](./node-style-rectangle.md) – axis-aligned boxes.
+* [Rounded rectangle](./node-style-rounded-rectangle.md) – rectangles with
+  adjustable corner radius rendered via shader.
+* [Path rounded rectangle](./node-style-path-rounded-rectangle.md) – rectangles
+  with rounded corners generated as polygons (useful for hit testing).
+* [Marker](./node-style-marker.md) – vector markers from the bundled marker set.
+* [Label](./node-style-label.md) – text drawn with `TextLayer`.
+
+Mixing several entries gives you complex node visuals, such as a rounded
+rectangle background with a label on top.
+
+```js
+const nodeStyle = [
+  {
+    type: NODE_TYPE.ROUNDED_RECTANGLE,
+    width: 120,
+    height: 48,
+    cornerRadius: 0.4,
+    fill: {
+      default: '#0F172A',
+      hover: '#1E293B'
+    },
+    stroke: '#38BDF8',
+    strokeWidth: node => (node.state === NODE_STATE.SELECTED ? 4 : 1)
+  },
+  {
+    type: NODE_TYPE.LABEL,
+    text: node => node.label,
+    color: '#F8FAFC',
+    fontSize: 18
+  }
+];
+```
+
+With these building blocks you can express most node visuals declaratively and
+let GraphGL handle the rendering details.

--- a/docs/modules/graph-layers/sidebar.json
+++ b/docs/modules/graph-layers/sidebar.json
@@ -29,10 +29,14 @@
       "type": "category",
       "label": "Node and Edge Styling",
       "items": [
+        "modules/graph-layers/api-reference/styling/node/node-style",
         "modules/graph-layers/api-reference/styling/node/node-style-circle",
         "modules/graph-layers/api-reference/styling/node/node-style-rectangle",
+        "modules/graph-layers/api-reference/styling/node/node-style-rounded-rectangle",
+        "modules/graph-layers/api-reference/styling/node/node-style-path-rounded-rectangle",
         "modules/graph-layers/api-reference/styling/node/node-style-marker",
         "modules/graph-layers/api-reference/styling/node/node-style-label",
+        "modules/graph-layers/api-reference/styling/edge/edge-style",
         "modules/graph-layers/api-reference/styling/edge/edge-style-label",
         "modules/graph-layers/api-reference/styling/edge/edge-style-flow"
       ]


### PR DESCRIPTION
## Summary
- rewrite the graph-layers node and edge styling docs to explain the stylesheet system, interaction selectors, and accessor behavior
- expand every node and edge decorator reference with complete option tables and practical examples, including new rounded rectangle guides
- update the documentation sidebar to surface the new overview pages

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_6904be3c5b2083288bf65dd36b170e00