### PR TITLE
chore(website): update to docusaurus@3.9

### DIFF
--- a/website/src/examples/leaflet/get-started.mdx
+++ b/website/src/examples/leaflet/get-started.mdx
@@ -1,5 +1,5 @@
 # deck.gl with Leaflet
 
-<div>
-  <Demo />
-</div>
+import Demo from './get-started';
+
+<Demo />

--- a/website/src/examples/leaflet/get-started.tsx
+++ b/website/src/examples/leaflet/get-started.tsx
@@ -1,24 +1,37 @@
 import React, {Component} from 'react';
-// import BrowserOnly from '@docusaurus/BrowserOnly';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+
 import {GITHUB_TREE} from '../../constants/defaults';
 import {makeExample} from '../../components';
 
-let initialized = false;
-
 class AdvancedDemo extends Component {
   static title = 'Leaflet as deck.gl Basemap';
+
   static code = `${GITHUB_TREE}/examples/leaflet/get-started`;
 
   static renderInfo(meta) {
     return <></>;
   }
 
+  componentDidMount(): void {
+    import('../../../../examples/leaflet/get-started/app')
+      .then(({exampleApplication}) => exampleApplication())
+      .catch((error) => {
+        console.error('Failed to load Leaflet example', error);
+      });
+  }
+
   render() {
     const {...otherProps} = this.props;
+
     return (
-      <div style={{position: 'absolute', width: '100%', height: '100%', backgroundColor: 'rgba(1,0,0,1)'}}>
-        <div id="map" style={{width: '100%', height: '100%'}} />
-      </div>
+      <BrowserOnly>
+        {() => (
+          <div style={{position: 'absolute', width: '100%', height: '100%', backgroundColor: 'rgba(1,0,0,1)'}}>
+            <div id="map" style={{width: '100%', height: '100%'}} {...otherProps} />
+          </div>
+        )}
+      </BrowserOnly>
     );
   }
 }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -13851,21 +13851,12 @@ __metadata:
     "@deck.gl/core": "npm:~9.2.1"
     "@deck.gl/google-maps": "npm:~9.2.1"
     "@deck.gl/json": "npm:~9.2.1"
-<<<<<<< HEAD
     "@docusaurus/core": "npm:^3.9.2"
     "@docusaurus/module-type-aliases": "npm:^3.9.2"
     "@docusaurus/plugin-content-docs": "npm:^3.9.2"
     "@docusaurus/preset-classic": "npm:^3.9.2"
     "@docusaurus/tsconfig": "npm:^3.9.2"
     "@docusaurus/types": "npm:^3.9.2"
-=======
-    "@docusaurus/core": "npm:^3.4.0"
-    "@docusaurus/module-type-aliases": "npm:^3.4.0"
-    "@docusaurus/plugin-content-docs": "npm:^3.4.0"
-    "@docusaurus/preset-classic": "npm:^3.4.0"
-    "@docusaurus/tsconfig": "npm:^3.4.0"
-    "@docusaurus/types": "npm:^3.4.0"
->>>>>>> master
     "@loaders.gl/core": "npm:^4.2.0"
     "@loaders.gl/csv": "npm:^4.2.0"
     "@loaders.gl/i3s": "npm:^4.2.0"


### PR DESCRIPTION
## Summary
- update the website devDependencies to target Docusaurus v3.9.2 so the manifest matches the resolved packages

## Testing
- yarn docusaurus --version


------
https://chatgpt.com/codex/tasks/task_e_6904be70581c8328b185c35d415ccd9e