### PR TITLE
Fix Docusaurus markdown link warning configuration

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -15,7 +15,11 @@ const config = {
   url: 'https://deck.gl-community',
   baseUrl: '/deck.gl-community/', // process.env.STAGING ? '/deck.gl-community/' : '/',
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'warn'
+    }
+  },
   favicon: '/favicon.ico',
   organizationName: 'visgl', // Usually your GitHub org/user name.
   projectName: 'deck.gl-community', // Usually your repo name.


### PR DESCRIPTION
## Summary
- move the deprecated `onBrokenMarkdownLinks` setting into the new `markdown.hooks` section of the Docusaurus config

## Testing
- `yarn test` *(fails: template module package entry is unresolved during Vitest pre-commit hook; change is configuration-only)*

------
https://chatgpt.com/codex/tasks/task_e_690655f97b1c832898af3300e6b2e376