### PR TITLE
Fix d3 force layout tick updates

### DIFF
--- a/modules/graph-layers/src/layouts/d3-force/d3-force-layout.ts
+++ b/modules/graph-layers/src/layouts/d3-force/d3-force-layout.ts
@@ -82,20 +82,25 @@ export class D3ForceLayout extends GraphLayout<D3ForceLayoutOptions> {
     });
 
     this._worker.onmessage = (event) => {
-      if (event.data.type !== 'end') {
+      if (event.data.type !== 'tick' && event.data.type !== 'end') {
         return;
       }
 
-      event.data.nodes.forEach(({id, ...d3}) =>
-        this._positionsByNodeId.set(id, {
-          ...d3,
-          // precompute so that when we return the node position we do not need to do the conversion
-          coordinates: [d3.x, d3.y]
-        })
-      );
+      if (event.data.nodes) {
+        event.data.nodes.forEach(({id, ...d3}) =>
+          this._positionsByNodeId.set(id, {
+            ...d3,
+            // precompute so that when we return the node position we do not need to do the conversion
+            coordinates: [d3.x, d3.y]
+          })
+        );
 
-      this._onLayoutChange();
-      this._onLayoutDone();
+        this._onLayoutChange();
+      }
+
+      if (event.data.type === 'end') {
+        this._onLayoutDone();
+      }
     };
   }
 

--- a/modules/graph-layers/src/layouts/d3-force/worker.js
+++ b/modules/graph-layers/src/layouts/d3-force/worker.js
@@ -46,6 +46,7 @@ onmessage = function (event) {
     postMessage({
       type: 'tick',
       progress: i / n,
+      nodes,
       options: event.data.options
     });
     simulation.tick();


### PR DESCRIPTION
## Summary
- update the D3ForceLayout to process worker tick messages so layout change events fire during simulation
- include node positions in worker tick messages to keep layout caches in sync while the simulation runs

## Testing
- vitest

------
https://chatgpt.com/codex/tasks/task_e_69069557ab188328b619e5afb98f1c32