### PR TITLE
Handle undefined coordinates in ForceMultiGraphLayout

### DIFF
--- a/modules/graph-layers/src/layouts/experimental/force-multi-graph-layout.ts
+++ b/modules/graph-layers/src/layouts/experimental/force-multi-graph-layout.ts
@@ -6,6 +6,12 @@ import {GraphLayout, GraphLayoutProps} from '../../core/graph-layout';
 import type {Graph, NodeInterface, EdgeInterface} from '../../graph/graph';
 import * as d3 from 'd3-force';
 
+type D3Node = {
+  id: string | number;
+  x?: number;
+  y?: number;
+};
+
 export type ForceMultiGraphLayoutProps = GraphLayoutProps & {
   alpha?: number;
   nBodyStrength?: number;
@@ -27,8 +33,8 @@ export class ForceMultiGraphLayout extends GraphLayout<ForceMultiGraphLayoutProp
 
   // d3 part
   // custom graph data
-  _d3Graph: {nodes: any[]; edges: any[]} = {nodes: [], edges: []};
-  _nodeMap = new Map<string | number, any>();
+  _d3Graph: {nodes: D3Node[]; edges: any[]} = {nodes: [], edges: []};
+  _nodeMap = new Map<string | number, D3Node>();
   _edgeMap = new Map<string | number, any>();
   _simulator: d3.Simulation<any, undefined> | null = null;
 
@@ -102,7 +108,7 @@ export class ForceMultiGraphLayout extends GraphLayout<ForceMultiGraphLayoutProp
     this._graph = graph;
 
     // nodes
-    const newNodeMap = new Map<string | number, any>();
+    const newNodeMap = new Map<string | number, D3Node>();
     const nodes = Array.from(graph.getNodes());
     const newD3Nodes = nodes.map(node => {
       const id = node.getId();
@@ -184,13 +190,15 @@ export class ForceMultiGraphLayout extends GraphLayout<ForceMultiGraphLayoutProp
     this._d3Graph.edges = newD3Edges;
   }
 
-  getNodePosition = (node: NodeInterface): [number, number] => {
-    const d3Node = this._nodeMap.get(node.getId());
-    if (d3Node) {
-      return [d3Node.x, d3Node.y];
+  private _getNodeCoordinates(d3Node: D3Node | undefined): [number, number] {
+    if (!d3Node) {
+      return [0, 0];
     }
-    // default value
-    return [0, 0];
+    return [Number.isFinite(d3Node.x) ? d3Node.x : 0, Number.isFinite(d3Node.y) ? d3Node.y : 0];
+  }
+
+  getNodePosition = (node: NodeInterface): [number, number] => {
+    return this._getNodeCoordinates(this._nodeMap.get(node.getId()));
   };
 
   getEdgePosition = (edge: EdgeInterface) => {
@@ -199,8 +207,8 @@ export class ForceMultiGraphLayout extends GraphLayout<ForceMultiGraphLayoutProp
       if (!d3Edge.isVirtual) {
         return {
           type: 'line',
-          sourcePosition: [d3Edge.source.x, d3Edge.source.y],
-          targetPosition: [d3Edge.target.x, d3Edge.target.y],
+          sourcePosition: this._getNodeCoordinates(d3Edge.source),
+          targetPosition: this._getNodeCoordinates(d3Edge.target),
           controlPoints: []
         };
       }
@@ -211,8 +219,8 @@ export class ForceMultiGraphLayout extends GraphLayout<ForceMultiGraphLayoutProp
       }
       const edgeCount = virtualEdge.edgeCount;
       // get the position of source and target nodes
-      const sourcePosition = [virtualEdge.source.x, virtualEdge.source.y];
-      const targetPosition = [virtualEdge.target.x, virtualEdge.target.y];
+      const sourcePosition = this._getNodeCoordinates(virtualEdge.source);
+      const targetPosition = this._getNodeCoordinates(virtualEdge.target);
       // calculate a symmetric curve
       const distance = Math.hypot(
         sourcePosition[0] - targetPosition[0],
@@ -275,7 +283,7 @@ function computeControlPoint(source, target, direction, offset) {
   const dy = target[1] - source[1];
   const normal = [dy, -dx];
   const length = Math.sqrt(Math.pow(normal[0], 2.0) + Math.pow(normal[1], 2.0));
-  const normalized = [normal[0] / length, normal[1] / length];
+  const normalized = length > 0 ? [normal[0] / length, normal[1] / length] : [0, 0];
   return [
     midPoint[0] + normalized[0] * offset * direction,
     midPoint[1] + normalized[1] * offset * direction

--- a/modules/graph-layers/test/layouts/force-multi-graph-layout.spec.ts
+++ b/modules/graph-layers/test/layouts/force-multi-graph-layout.spec.ts
@@ -1,0 +1,46 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, it, expect} from 'vitest';
+
+import {ClassicGraph} from '../../src/graph/classic-graph';
+import {ForceMultiGraphLayout} from '../../src/layouts/experimental/force-multi-graph-layout';
+import type {PlainGraphData} from '../../src/graph-data/graph-data';
+
+const GRAPH_DATA: PlainGraphData = {
+  shape: 'plain-graph-data',
+  nodes: [{id: 'a'}, {id: 'b'}],
+  edges: [
+    {id: 'ab-1', sourceId: 'a', targetId: 'b'},
+    {id: 'ab-2', sourceId: 'a', targetId: 'b'}
+  ]
+};
+
+describe('ForceMultiGraphLayout', () => {
+  it('returns finite positions before the simulation assigns coordinates', () => {
+    const graph = new ClassicGraph({data: GRAPH_DATA});
+    const layout = new ForceMultiGraphLayout();
+
+    layout.initializeGraph(graph);
+
+    const node = graph.findNode('a');
+    const straightEdge = graph.getEdges()[0];
+    const curvedEdge = graph.getEdges()[1];
+
+    expect(node).toBeDefined();
+    expect(layout.getNodePosition(node!)).toEqual([0, 0]);
+    expect(layout.getEdgePosition(straightEdge)).toEqual({
+      type: 'spline-curve',
+      sourcePosition: [0, 0],
+      targetPosition: [0, 0],
+      controlPoints: [[0, 0]]
+    });
+    expect(layout.getEdgePosition(curvedEdge)).toEqual({
+      type: 'spline-curve',
+      sourcePosition: [0, 0],
+      targetPosition: [0, 0],
+      controlPoints: [[0, 0]]
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- guard `ForceMultiGraphLayout` node coordinates so unset, `NaN`, and non-finite D3 positions return `[0, 0]` instead of leaking invalid values to deck.gl layers
- reuse that coordinate normalization for straight and parallel-edge geometries
- keep coincident parallel-edge control points finite by avoiding division by zero

## Classification
Bug fix / internal rendering guard for graph-layers layout geometry.

## Validation
- `yarn`
- `yarn test-node modules/graph-layers/test/layouts/force-multi-graph-layout.spec.ts`
- `yarn test-node modules/graph-layers/test`
- `yarn lint-fix`
- `yarn lint`
- `yarn build`
- pre-commit `yarn test`

## Visual proof
Not applicable. This change affects internal graph layout position values and is covered by automated layout regression tests; it does not change a rendered example route or user-facing UI directly.

## Residual risk
Low. The fallback preserves the existing missing-node default `[0, 0]` and only normalizes invalid coordinates before returning positions.