### PR TITLE
fix: refine graph stylesheet attribute usage

### DIFF
--- a/docs/modules/graph-layers/api-reference/styling/edge/edge-style.md
+++ b/docs/modules/graph-layers/api-reference/styling/edge/edge-style.md
@@ -1,38 +1,34 @@
 # Edge stylesheets
 
-Edges are styled with a single object passed to the `edgeStyle` prop of
-`GraphLayer`. Similar to nodes, a `GraphStylesheet` definition is normalized by
+Edges are styled via the `stylesheet.edges` prop on
+`GraphLayer` (the legacy `edgeStyle` prop continues to work but is deprecated). Similar to nodes, a `GraphStylesheet` definition is normalized by
 the `GraphStyleEngine`, which resolves colors, accessors, and interaction states
 before feeding them into Deck.gl’s `LineLayer`.
 
 ```js
-const edgeStyle = {
-  stroke: edge => (edge.isCritical ? '#F97316' : '#94A3B8'),
-  strokeWidth: {
-    default: 1,
-    hover: 3,
-    selected: 4
-  },
-  decorators: [
-    {
-      type: 'edge-label',
-      text: edge => edge.id,
-      color: '#000',
-      fontSize: 18,
-
-      // text: edge => edge.weight.toFixed(1),
-      // color: '#1F2937',
-      // offset: [0, 16]
-
+const stylesheet = {
+  edges: {
+    stroke: edge => (edge.isCritical ? '#F97316' : '#94A3B8'),
+    strokeWidth: {
+      default: 1,
+      hover: 3,
+      selected: 4
     },
-    {
-      type: 'arrow',
-      color: '#222',
-      size: 8,
-      offset: [4, 0]
-    }
-  ],
-}}
+    decorators: [
+      {
+        type: 'edge-label',
+        text: edge => edge.id,
+        color: '#000',
+        fontSize: 18
+      },
+      {
+        type: 'arrow',
+        color: '#222',
+        size: 8,
+        offset: [4, 0]
+      }
+    ]
+  }
 };
 ```
 
@@ -52,12 +48,14 @@ Edge styles honor the same selectors as node styles: `:hover`, `:dragging`, and
 `:selected`. Selector blocks can override any property, including decorators.
 
 ```js
-const edgeStyle = {
-  stroke: '#CBD5F5',
-  strokeWidth: 1,
-  ':hover': {
-    stroke: '#2563EB',
-    strokeWidth: 2
+const stylesheet = {
+  edges: {
+    stroke: '#CBD5F5',
+    strokeWidth: 1,
+    ':hover': {
+      stroke: '#2563EB',
+      strokeWidth: 2
+    }
   }
 };
 ```

--- a/docs/modules/graph-layers/api-reference/styling/graph-stylesheet.md
+++ b/docs/modules/graph-layers/api-reference/styling/graph-stylesheet.md
@@ -21,7 +21,7 @@ const circleStyle: GraphStylesheet<'circle'> = {
 The generic parameter narrows the `type` field and surfaces the properties that are valid for that primitive. For example:
 
 - Node primitives: `'circle'`, `'rectangle'`, `'rounded-rectangle'`, `'path-rounded-rectangle'`, `'label'`, `'marker'`, and `'icon'` (an alias for image nodes).
-- Edge primitives: `'Edge'`.
+- Edge primitives: `'edge'`.
 - Edge decorators: `'edge-label'`, `'flow'`, and `'arrow'`.
 
 Refer to the individual [node](./node/node-style.md) and [edge](./edge/edge-style.md) guides for the property lists that each primitive accepts.
@@ -58,22 +58,23 @@ The built-in states are `default`, `hover`, `dragging`, and `selected`. When you
 
 ## Composition
 
-Stylesheets are provided in arrays for nodes and optionally for edges:
+Stylesheets are composed under the `stylesheet` prop on `GraphLayer`. Provide an array of node layers and either a single edge style or an array of edge styles:
 
 ```js
 new GraphLayer({
-  nodeStyle: [
-    {type: 'circle', fill: '#1E293B'},
-    {type: 'label', text: node => node.id}
-  ],
-  edgeStyle: {
-    type: 'Edge',
-    stroke: '#CBD5F5',
-    decorators: [
-      {type: 'edge-label', text: edge => edge.weight.toFixed(2)}
-    ]
+  stylesheet: {
+    nodes: [
+      {type: 'circle', fill: '#1E293B'},
+      {type: 'label', text: '@id'}
+    ],
+    edges: {
+      stroke: '#CBD5F5',
+      decorators: [
+        {type: 'edge-label', text: '@weight'}
+      ]
+    }
   }
 });
 ```
 
-Edge styles can omit the `type` field—`GraphLayer` defaults it to `'Edge'`—but supplying it enables TypeScript to infer the correct decorator and property options.
+Edge styles can omit the `type` field—`GraphLayer` defaults it to `'edge'`—but supplying it enables TypeScript to infer the correct decorator and property options.

--- a/docs/modules/graph-layers/api-reference/styling/node/node-style.md
+++ b/docs/modules/graph-layers/api-reference/styling/node/node-style.md
@@ -1,23 +1,26 @@
 # Node stylesheets
 
 GraphGL renders nodes by stacking one or more *style layers* on top of each
-other. The `nodeStyle` prop accepts an array of style objects. Each object describes one visual layer and is
-compiled into a Deck.gl sublayer by the `GraphStyleEngine` helper from the corresponding `GraphStylesheet` spec.
+other. These definitions live under the `stylesheet.nodes` prop on `GraphLayer`.
+Each entry describes one visual layer and is compiled into a Deck.gl sublayer by
+the `GraphStyleEngine` helper from the corresponding `GraphStylesheet` spec.
 
 ```js
-const nodeStyle = [
-  {
-    type: 'circle',
-    radius: 10,
-    fill: node => (node.degree > 5 ? '#3C9EE7' : '#F06449')
-  },
-  {
-    type: 'label',
-    text: node => node.id,
-    color: '#172B4D',
-    offset: [0, 16]
-  }
-];
+const stylesheet = {
+  nodes: [
+    {
+      type: 'circle',
+      radius: 10,
+      fill: node => (node.degree > 5 ? '#3C9EE7' : '#F06449')
+    },
+    {
+      type: 'label',
+      text: node => node.id,
+      color: '#172B4D',
+      offset: [0, 16]
+    }
+  ]
+};
 ```
 
 The order in the array controls the drawing order: earlier entries are rendered
@@ -101,26 +104,28 @@ Mixing several entries gives you complex node visuals, such as a rounded
 rectangle background with a label on top.
 
 ```js
-const nodeStyle = [
-  {
-    type: 'rounded-rectangle',
-    width: 120,
-    height: 48,
-    cornerRadius: 0.4,
-    fill: {
-      default: '#0F172A',
-      hover: '#1E293B'
+const stylesheet = {
+  nodes: [
+    {
+      type: 'rounded-rectangle',
+      width: 120,
+      height: 48,
+      cornerRadius: 0.4,
+      fill: {
+        default: '#0F172A',
+        hover: '#1E293B'
+      },
+      stroke: '#38BDF8',
+      strokeWidth: node => (node.state === 'selected' ? 4 : 1)
     },
-    stroke: '#38BDF8',
-    strokeWidth: node => (node.state === 'selected' ? 4 : 1)
-  },
-  {
-    type: 'label',
-    text: node => node.label,
-    color: '#F8FAFC',
-    fontSize: 18
-  }
-];
+    {
+      type: 'label',
+      text: node => node.label,
+      color: '#F8FAFC',
+      fontSize: 18
+    }
+  ]
+};
 ```
 
 With these building blocks you can express most node visuals declaratively and

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -7,8 +7,10 @@ Please refer the documentation of each module for detailed upgrade guides.
 
 ## v9.2
 
-### `@deck.gl-community/graph-layers` 
+### `@deck.gl-community/graph-layers`
 
 - Deprecation: Graph style constants are now defined using literals instead of objects
   - Replace deprecated `NODE_TYPE.CIRCLE` with `'circle'`, `EDGE_TYPE.LINE` with `'line'` etc.
+- Deprecation: `GraphLayer` now groups styling under a `stylesheet` prop
+  - Replace `nodeStyle` / `edgeStyle` with `stylesheet.nodes` and `stylesheet.edges`
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -16,6 +16,7 @@ High-level changes
 ### `@deck.gl-community/graph-layers` 
 
 - Graph styling: new edge decorator `'arrow'` that renders arrows on directional edges.
+- Graph styling: unified `stylesheet` prop with shorthand attribute references for node, edge, and decorator styles.
 - Graph style constants are now defined using literals instead of objects
 - New example visualizing DAGs (Directed Acyclic Graphs).
 

--- a/examples/graph-layers/dag-simple/app.tsx
+++ b/examples/graph-layers/dag-simple/app.tsx
@@ -91,34 +91,38 @@ export default function App(): React.ReactElement {
         id: 'dag-layer',
         graph,
         layout,
-        nodeStyle: [
-          {
-            type: 'circle',
-            radius: 18,
-            fill: '#4c6ef520',
-            stroke: '#102a8220',
-            strokeWidth: 2
-          },
-          {
-            type: 'label',
-            text: (node) => node.getPropertyValue('label') as string,
-            fontSize: 16,
-            color: '#102a82',
-            offset: [0, 28],
-            textAnchor: 'middle',
-            alignmentBaseline: 'top'
-          }
-        ],
-        edgeStyle: {
-          stroke: '#8da2fb',
-          strokeWidth: 2,
-          decorators: [
+        stylesheet: {
+          nodes: [
             {
-              type: 'arrow',
-              size: 6,
-              fill: '#8da2fb'
+              type: 'circle',
+              radius: 18,
+              fill: '#4c6ef520',
+              stroke: '#102a8220',
+              strokeWidth: 2
+            },
+            {
+              type: 'label',
+              text: '@label',
+              fontSize: 16,
+              color: '#102a82',
+              offset: [0, 28],
+              textAnchor: 'middle',
+              alignmentBaseline: 'top'
             }
           ],
+          edges: [
+            {
+              stroke: '#8da2fb',
+              strokeWidth: 2,
+              decorators: [
+                {
+                  type: 'arrow',
+                  size: 6,
+                  fill: '#8da2fb'
+                }
+              ]
+            }
+          ]
         }
       })
     ],

--- a/examples/graph-layers/graph-viewer-legacy/app.tsx
+++ b/examples/graph-layers/graph-viewer-legacy/app.tsx
@@ -62,16 +62,18 @@ export class App extends Component {
           <GraphGL
             graph={graph}
             layout={new D3ForceLayout()}
-            nodeStyle={[
-              {
-                type: 'circle',
-                radius: DEFAULT_NODE_SIZE,
-                fill: 'red'
+            stylesheet={{
+              nodes: [
+                {
+                  type: 'circle',
+                  radius: DEFAULT_NODE_SIZE,
+                  fill: 'red'
+                }
+              ],
+              edges: {
+                stroke: '#000',
+                strokeWidth: 1
               }
-            ]}
-            edgeStyle={{
-              stroke: '#000',
-              strokeWidth: 1
             }}
           />
         </div>

--- a/examples/graph-layers/graph-viewer-legacy/react-graph-layers/graph-gl.tsx
+++ b/examples/graph-layers/graph-viewer-legacy/react-graph-layers/graph-gl.tsx
@@ -6,7 +6,14 @@ import React, {useCallback, useEffect, useLayoutEffect, useMemo, useState} from 
 import PropTypes from 'prop-types';
 import DeckGL from '@deck.gl/react';
 import {OrthographicView} from '@deck.gl/core';
-import {GraphLayout, Graph, GraphLayer, log, SimpleLayout} from '@deck.gl-community/graph-layers';
+import {
+  GraphLayout,
+  Graph,
+  GraphLayer,
+  log,
+  SimpleLayout
+} from '@deck.gl-community/graph-layers';
+import type {GraphLayerStylesheet} from '@deck.gl-community/graph-layers';
 import {PositionedViewControl} from '@deck.gl-community/react';
 import {ViewControlWidget} from '@deck.gl-community/graph-layers';
 import '@deck.gl/widgets/stylesheet.css';
@@ -25,11 +32,20 @@ const INITIAL_VIEW_STATE = {
 // the default cursor in the view
 const DEFAULT_CURSOR = 'default';
 
+const DEFAULT_STYLESHEET = {
+  nodes: [],
+  edges: {
+    decorators: [],
+    stroke: 'black',
+    strokeWidth: 1
+  }
+} as const satisfies GraphLayerStylesheet;
+
 export const GraphGL = ({
   graph = new Graph(),
   layout = new SimpleLayout(),
   glOptions = {},
-  nodeStyle = [],
+  stylesheet = DEFAULT_STYLESHEET,
   nodeEvents = {
     onMouseEnter: null,
     onHover: null,
@@ -37,13 +53,6 @@ export const GraphGL = ({
     onClick: null,
     onDrag: null
   },
-  edgeStyle = [
-    {
-      decorators: [],
-      stroke: 'black',
-      strokeWidth: 1
-    }
-  ],
   edgeEvents = {
     onClick: null,
     onHover: null
@@ -193,9 +202,8 @@ export const GraphGL = ({
               () => [
                 new GraphLayer({
                   engine,
-                  nodeStyle,
+                  stylesheet,
                   nodeEvents,
-                  edgeStyle,
                   edgeEvents,
                   enableDragging,
                   resumeLayoutAfterDragging
@@ -204,9 +212,8 @@ export const GraphGL = ({
               [
                 engine,
                 engine.getGraphVersion(),
-                nodeStyle,
+                stylesheet,
                 nodeEvents,
-                edgeStyle,
                 edgeEvents,
                 enableDragging,
                 resumeLayoutAfterDragging
@@ -248,19 +255,11 @@ GraphGL.propTypes = {
     onHover: PropTypes.func,
     onMouseEnter: PropTypes.func
   }).isRequired,
-  /** Declarative node style */
-  nodeStyle: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.bool])),
-  /** Declarative edge style */
-  edgeStyle: PropTypes.oneOfType([
-    PropTypes.object,
-    PropTypes.arrayOf(
-      PropTypes.shape({
-        stroke: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-        strokeWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
-        decorators: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.bool]))
-      })
-    )
-  ]).isRequired,
+  /** Declarative graph stylesheet */
+  stylesheet: PropTypes.shape({
+    nodes: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.bool])),
+    edges: PropTypes.oneOfType([PropTypes.object, PropTypes.arrayOf(PropTypes.object)])
+  }).isRequired,
   /** Edge event callbacks */
   edgeEvents: PropTypes.shape({
     onClick: PropTypes.func,

--- a/examples/graph-layers/graph-viewer/app-hive-plot-wip.ts
+++ b/examples/graph-layers/graph-viewer/app-hive-plot-wip.ts
@@ -64,16 +64,18 @@ export default class HivePlotExample extends Component {
             getNodeAxis: node => node.getPropertyValue('group'),
           })
         }
-        nodeStyle={[
-          {
-            type: 'circle',
-            radius: DEFAULT_NODE_SIZE,
-            fill: this.getNodeColor,
-          },
-        ]}
-        edgeStyle={{
-          stroke: DEFAULT_EDGE_COLOR,
-          strokeWidth: DEFAULT_EDGE_WIDTH,
+        stylesheet={{
+          nodes: [
+            {
+              type: 'circle',
+              radius: DEFAULT_NODE_SIZE,
+              fill: this.getNodeColor,
+            },
+          ],
+          edges: {
+            stroke: DEFAULT_EDGE_COLOR,
+            strokeWidth: DEFAULT_EDGE_WIDTH,
+          }
         }}
       />
     );

--- a/examples/graph-layers/graph-viewer/app-multi-graph-wip.ts
+++ b/examples/graph-layers/graph-viewer/app-multi-graph-wip.ts
@@ -40,41 +40,43 @@ export default class MultiGraphExample extends Component {
             nBodyStrength: -8000,
           })
         }
-        nodeStyle={[
-          this.props.showNodePlaceholder && {
-            type: 'circle',
-            radius: DEFAULT_NODE_PLACEHOLDER_SIZE,
-            fill: DEFAULT_NODE_PLACEHOLDER_COLOR,
-          },
-          this.props.showNodeCircle && {
-            type: 'circle',
-            radius: DEFAULT_NODE_SIZE,
-            fill: this.props.nodeColor,
-          },
-          {
-            type: 'circle',
-            radius: node => (node.getPropertyValue('star') ? 6 : 0),
-            fill: [255, 255, 0],
-            offset: [18, -18],
-          },
-          this.props.showNodeLabel && {
-            type: 'label',
-            text: node => node.getId(),
-            color: Color(this.props.nodeLabelColor).array(),
-            fontSize: this.props.nodeLabelSize,
-          },
-        ]}
-        edgeStyle={{
-          stroke: this.props.edgeColor,
-          strokeWidth: this.props.edgeWidth,
-          decorators: [
-            this.props.showEdgeLabel && {
-              type: 'edge-label',
-              text: edge => edge.getPropertyValue('type'),
-              color: Color(this.props.edgeLabelColor).array(),
-              fontSize: this.props.edgeLabelSize,
+        stylesheet={{
+          nodes: [
+            this.props.showNodePlaceholder && {
+              type: 'circle',
+              radius: DEFAULT_NODE_PLACEHOLDER_SIZE,
+              fill: DEFAULT_NODE_PLACEHOLDER_COLOR,
+            },
+            this.props.showNodeCircle && {
+              type: 'circle',
+              radius: DEFAULT_NODE_SIZE,
+              fill: this.props.nodeColor,
+            },
+            {
+              type: 'circle',
+              radius: node => (node.getPropertyValue('star') ? 6 : 0),
+              fill: [255, 255, 0],
+              offset: [18, -18],
+            },
+            this.props.showNodeLabel && {
+              type: 'label',
+              text: node => node.getId(),
+              color: Color(this.props.nodeLabelColor).array(),
+              fontSize: this.props.nodeLabelSize,
             },
           ],
+          edges: {
+            stroke: this.props.edgeColor,
+            strokeWidth: this.props.edgeWidth,
+            decorators: [
+              this.props.showEdgeLabel && {
+                type: 'edge-label',
+                text: edge => edge.getPropertyValue('type'),
+                color: Color(this.props.edgeLabelColor).array(),
+                fontSize: this.props.edgeLabelSize,
+              },
+            ],
+          }
         }}
       />
     );

--- a/examples/graph-layers/graph-viewer/app-radial-layout-wip.ts
+++ b/examples/graph-layers/graph-viewer/app-radial-layout-wip.ts
@@ -67,28 +67,30 @@ export default class BasicRadialExample extends Component {
             radius: RADIUS,
           })
         }
-        nodeStyle={[
-          {
-            type: 'circle',
-            radius: DEFAULT_NODE_SIZE,
-            fill: this.getNodeColor,
-          },
-          {
-            type: 'label',
-            text: node => node.getPropertyValue('name'),
-            color: DEFAULT_NODE_LABEL_COLOR,
-            textAnchor: 'start',
-            fontSize: 8,
-            // TODO: figure out how to get node position without engine
-            // angle: n => {
-            //   const nodePos = this._engine.getNodePosition(n);
-            //   return (Math.atan2(nodePos[1], nodePos[0]) * -180) / Math.PI;
-            // },
-          },
-        ]}
-        edgeStyle={{
-          stroke: DEFAULT_EDGE_COLOR,
-          strokeWidth: 1,
+        stylesheet={{
+          nodes: [
+            {
+              type: 'circle',
+              radius: DEFAULT_NODE_SIZE,
+              fill: this.getNodeColor,
+            },
+            {
+              type: 'label',
+              text: node => node.getPropertyValue('name'),
+              color: DEFAULT_NODE_LABEL_COLOR,
+              textAnchor: 'start',
+              fontSize: 8,
+              // TODO: figure out how to get node position without engine
+              // angle: n => {
+              //   const nodePos = this._engine.getNodePosition(n);
+              //   return (Math.atan2(nodePos[1], nodePos[0]) * -180) / Math.PI;
+              // },
+            },
+          ],
+          edges: {
+            stroke: DEFAULT_EDGE_COLOR,
+            strokeWidth: 1,
+          }
         }}
       />
     );

--- a/examples/graph-layers/graph-viewer/app.tsx
+++ b/examples/graph-layers/graph-viewer/app.tsx
@@ -283,8 +283,7 @@ export function App(props) {
               ? [
                   new GraphLayer({
                     engine,
-                    nodeStyle: selectedStyles?.nodeStyle,
-                    edgeStyle: selectedStyles?.edgeStyle,
+                    stylesheet: selectedStyles,
                     resumeLayoutAfterDragging
                   })
                 ]

--- a/examples/graph-layers/graph-viewer/control-panel.tsx
+++ b/examples/graph-layers/graph-viewer/control-panel.tsx
@@ -13,7 +13,7 @@ export type LayoutType =
   | 'hive-plot-layout'
   | 'force-multi-graph-layout';
 
-export type ExampleStyles = Pick<GraphLayerProps, 'nodeStyle' | 'edgeStyle'>;
+export type ExampleStyles = NonNullable<GraphLayerProps['stylesheet']>;
 
 export type ExampleDefinition = {
   name: string;

--- a/examples/graph-layers/graph-viewer/examples.ts
+++ b/examples/graph-layers/graph-viewer/examples.ts
@@ -137,7 +137,7 @@ const getWitsNodeRadius = (node: any) => {
 };
 
 const WITS_REGION_STYLE: ExampleStyles = {
-  nodeStyle: [
+  nodes: [
     {
       type: 'circle',
       radius: getWitsNodeRadius,
@@ -147,7 +147,7 @@ const WITS_REGION_STYLE: ExampleStyles = {
       opacity: 0.85
     }
   ],
-  edgeStyle: {
+  edges: {
     stroke: 'rgba(15, 23, 42, 0.2)',
     strokeWidth: 0.4,
     decorators: []
@@ -250,7 +250,7 @@ const LAYOUT_DESCRIPTIONS: Record<LayoutType, string> = {
 };
 
 const LES_MISERABLES_STYLE: ExampleStyles = {
-  nodeStyle: [
+  nodes: [
     {
       type: 'circle',
       radius: 9,
@@ -290,7 +290,7 @@ const LES_MISERABLES_STYLE: ExampleStyles = {
       scaleWithZoom: false
     }
   ],
-  edgeStyle: {
+  edges: {
     stroke: '#bfdbfe',
     strokeWidth: 1,
     decorators: []
@@ -298,7 +298,7 @@ const LES_MISERABLES_STYLE: ExampleStyles = {
 };
 
 const RANDOM_20_40_STYLE: ExampleStyles = {
-  nodeStyle: [
+  nodes: [
     {
       type: 'circle',
       radius: 8,
@@ -308,7 +308,7 @@ const RANDOM_20_40_STYLE: ExampleStyles = {
       opacity: 0.9
     }
   ],
-  edgeStyle: {
+  edges: {
     stroke: '#bbf7d0',
     strokeWidth: 1,
     decorators: []
@@ -316,7 +316,7 @@ const RANDOM_20_40_STYLE: ExampleStyles = {
 };
 
 const RANDOM_100_200_STYLE: ExampleStyles = {
-  nodeStyle: [
+  nodes: [
     {
       type: 'circle',
       radius: 7,
@@ -326,7 +326,7 @@ const RANDOM_100_200_STYLE: ExampleStyles = {
       opacity: 0.9
     }
   ],
-  edgeStyle: {
+  edges: {
     stroke: '#fde68a',
     strokeWidth: 1,
     decorators: []
@@ -334,7 +334,7 @@ const RANDOM_100_200_STYLE: ExampleStyles = {
 };
 
 const RANDOM_1000_2000_STYLE: ExampleStyles = {
-  nodeStyle: [
+  nodes: [
     {
       type: 'circle',
       radius: 6,
@@ -344,7 +344,7 @@ const RANDOM_1000_2000_STYLE: ExampleStyles = {
       opacity: 0.8
     }
   ],
-  edgeStyle: {
+  edges: {
     stroke: '#c7d2fe',
     strokeWidth: 1,
     decorators: []
@@ -352,7 +352,7 @@ const RANDOM_1000_2000_STYLE: ExampleStyles = {
 };
 
 const RANDOM_5000_3000_STYLE: ExampleStyles = {
-  nodeStyle: [
+  nodes: [
     {
       type: 'circle',
       radius: 5,
@@ -362,7 +362,7 @@ const RANDOM_5000_3000_STYLE: ExampleStyles = {
       opacity: 0.7
     }
   ],
-  edgeStyle: {
+  edges: {
     stroke: '#fed7aa',
     strokeWidth: 0.8,
     decorators: []
@@ -370,7 +370,7 @@ const RANDOM_5000_3000_STYLE: ExampleStyles = {
 };
 
 const LADDER_10_STYLE: ExampleStyles = {
-  nodeStyle: [
+  nodes: [
     {
       type: 'circle',
       radius: 7,
@@ -380,7 +380,7 @@ const LADDER_10_STYLE: ExampleStyles = {
       opacity: 0.9
     }
   ],
-  edgeStyle: {
+  edges: {
     stroke: '#fbcfe8',
     strokeWidth: 1,
     decorators: []
@@ -388,7 +388,7 @@ const LADDER_10_STYLE: ExampleStyles = {
 };
 
 const BALANCED_BIN_TREE_5_STYLE: ExampleStyles = {
-  nodeStyle: [
+  nodes: [
     {
       type: 'circle',
       radius: 7,
@@ -398,7 +398,7 @@ const BALANCED_BIN_TREE_5_STYLE: ExampleStyles = {
       opacity: 0.9
     }
   ],
-  edgeStyle: {
+  edges: {
     stroke: '#bae6fd',
     strokeWidth: 1,
     decorators: []
@@ -406,7 +406,7 @@ const BALANCED_BIN_TREE_5_STYLE: ExampleStyles = {
 };
 
 const BALANCED_BIN_TREE_8_STYLE: ExampleStyles = {
-  nodeStyle: [
+  nodes: [
     {
       type: 'circle',
       radius: 6,
@@ -416,7 +416,7 @@ const BALANCED_BIN_TREE_8_STYLE: ExampleStyles = {
       opacity: 0.9
     }
   ],
-  edgeStyle: {
+  edges: {
     stroke: '#a5f3fc',
     strokeWidth: 1,
     decorators: []
@@ -424,7 +424,7 @@ const BALANCED_BIN_TREE_8_STYLE: ExampleStyles = {
 };
 
 const GRID_10_10_STYLE: ExampleStyles = {
-  nodeStyle: [
+  nodes: [
     {
       type: 'circle',
       radius: 6,
@@ -434,7 +434,7 @@ const GRID_10_10_STYLE: ExampleStyles = {
       opacity: 0.9
     }
   ],
-  edgeStyle: {
+  edges: {
     stroke: '#fef3c7',
     strokeWidth: 1,
     decorators: []
@@ -442,7 +442,7 @@ const GRID_10_10_STYLE: ExampleStyles = {
 };
 
 const WATTS_STROGATZ_STYLE: ExampleStyles = {
-  nodeStyle: [
+  nodes: [
     {
       type: 'circle',
       radius: 6,
@@ -452,7 +452,7 @@ const WATTS_STROGATZ_STYLE: ExampleStyles = {
       opacity: 0.9
     }
   ],
-  edgeStyle: {
+  edges: {
     stroke: '#fecaca',
     strokeWidth: 1,
     decorators: []
@@ -460,7 +460,7 @@ const WATTS_STROGATZ_STYLE: ExampleStyles = {
 };
 
 const KNOWLEDGE_GRAPH_STYLE: ExampleStyles = {
-  nodeStyle: [
+  nodes: [
     {
       type: 'circle',
       radius: 7,
@@ -480,7 +480,7 @@ const KNOWLEDGE_GRAPH_STYLE: ExampleStyles = {
       scaleWithZoom: false
     }
   ],
-  edgeStyle: {
+  edges: {
     stroke: DEFAULT_EDGE_COLOR,
     strokeWidth: 1,
     decorators: []
@@ -488,7 +488,7 @@ const KNOWLEDGE_GRAPH_STYLE: ExampleStyles = {
 };
 
 const MULTI_GRAPH_STYLE: ExampleStyles = {
-  nodeStyle: [
+  nodes: [
     {
       type: 'circle',
       radius: 40,
@@ -515,17 +515,17 @@ const MULTI_GRAPH_STYLE: ExampleStyles = {
       scaleWithZoom: false
     }
   ],
-  edgeStyle: {
+  edges: {
     stroke: '#cf4569',
     strokeWidth: 2,
-    decorators: [
-      {
-        type: 'edge-label',
-        text: (edge) => edge?.getPropertyValue?.('type') ?? '',
-        color: [0, 0, 0],
-        fontSize: 14
-      }
-    ]
+      decorators: [
+        {
+          type: 'edge-label',
+          text: {attribute: 'type', fallback: ''},
+          color: [0, 0, 0],
+          fontSize: 14
+        }
+      ]
   }
 };
 

--- a/modules/graph-layers/src/index.ts
+++ b/modules/graph-layers/src/index.ts
@@ -28,7 +28,19 @@ export {GraphLayer} from './layers/graph-layer';
 export {EdgeLayer} from './layers/edge-layer';
 export {StyleEngine} from './style/style-engine';
 export {GraphStyleEngine} from './style/graph-style-engine';
-export type {GraphStylesheet} from './style/graph-style-engine';
+export type {
+  GraphStylesheet,
+  GraphStyleAttributeReference,
+  GraphStyleScale,
+  GraphStyleScaleType,
+  GraphStyleValue
+} from './style/graph-style-engine';
+export {
+  DEFAULT_GRAPH_LAYER_STYLESHEET,
+  type GraphLayerStylesheet,
+  type GraphLayerEdgeStyle,
+  type GraphLayerNodeStyle
+} from './style/graph-layer-stylesheet';
 
 // Widgets
 

--- a/modules/graph-layers/src/style/graph-layer-stylesheet.ts
+++ b/modules/graph-layers/src/style/graph-layer-stylesheet.ts
@@ -1,0 +1,98 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {GraphStylesheet, GraphStyleValue, GraphStyleType} from './graph-style-engine';
+
+export type GraphNodeStyleType = Exclude<
+  GraphStyleType,
+  'Edge' | 'edge' | 'edge-label' | 'flow' | 'arrow'
+>;
+
+export type GraphEdgeDecoratorType = Extract<GraphStyleType, 'edge-label' | 'flow' | 'arrow'>;
+
+export type GraphLayerNodeStyle = GraphStylesheet<GraphNodeStyleType> & {
+  pickable?: boolean;
+  visible?: boolean;
+  data?: (nodes: any[]) => any;
+};
+
+export type GraphLayerEdgeDecoratorStyle = GraphStylesheet<GraphEdgeDecoratorType>;
+
+type EdgeStyleType = Extract<GraphStyleType, 'Edge' | 'edge'>;
+
+export type GraphLayerEdgeStyle = (
+  | GraphStylesheet<EdgeStyleType>
+  | (Omit<GraphStylesheet<EdgeStyleType>, 'type'> & {type?: EdgeStyleType})
+) & {
+  decorators?: GraphLayerEdgeDecoratorStyle[];
+  data?: (edges: any[]) => any;
+  visible?: boolean;
+};
+
+export type GraphLayerStylesheet = {
+  nodes?: GraphLayerNodeStyle[];
+  edges?: GraphLayerEdgeStyle | GraphLayerEdgeStyle[];
+};
+
+export type GraphLayerStylesheetInput = GraphLayerStylesheet | null | undefined;
+
+const DEFAULT_EDGE_STYLE: GraphLayerEdgeStyle = {
+  type: 'edge',
+  stroke: 'black',
+  strokeWidth: 1,
+  decorators: []
+};
+
+export const DEFAULT_GRAPH_LAYER_STYLESHEET: Required<Pick<GraphLayerStylesheet, 'nodes' | 'edges'>> = {
+  nodes: [],
+  edges: [DEFAULT_EDGE_STYLE]
+};
+
+export type GraphLayerStylesheetSources = {
+  stylesheet?: GraphLayerStylesheetInput;
+  nodeStyle?: GraphLayerNodeStyle[];
+  edgeStyle?: GraphLayerEdgeStyle | GraphLayerEdgeStyle[];
+};
+
+export function normalizeGraphLayerStylesheet({
+  stylesheet,
+  nodeStyle,
+  edgeStyle
+}: GraphLayerStylesheetSources): Required<Pick<GraphLayerStylesheet, 'nodes' | 'edges'>> {
+  const resolvedStylesheet = stylesheet ?? {};
+  const resolvedNodeStyles = Array.isArray(resolvedStylesheet.nodes)
+    ? resolvedStylesheet.nodes
+    : nodeStyle;
+
+  const resolvedEdgeStyles = resolvedStylesheet.edges ?? edgeStyle;
+
+  const nodes = Array.isArray(resolvedNodeStyles)
+    ? resolvedNodeStyles.filter(Boolean)
+    : [...DEFAULT_GRAPH_LAYER_STYLESHEET.nodes];
+
+  const edgesArray = Array.isArray(resolvedEdgeStyles)
+    ? resolvedEdgeStyles
+    : resolvedEdgeStyles
+    ? [resolvedEdgeStyles]
+    : DEFAULT_GRAPH_LAYER_STYLESHEET.edges;
+
+  const edges = edgesArray
+    .filter(Boolean)
+    .map((edgeStyleEntry) => ({
+      type: 'edge',
+      decorators: [],
+      ...edgeStyleEntry
+    }));
+
+  return {
+    nodes,
+    edges
+  };
+}
+
+export type {
+  GraphStyleValue,
+  GraphStylesheet,
+  GraphStyleType
+} from './graph-style-engine';

--- a/modules/graph-layers/test/style/style-engine.spec.ts
+++ b/modules/graph-layers/test/style/style-engine.spec.ts
@@ -5,7 +5,11 @@
 import {describe, it, expect, expectTypeOf} from 'vitest';
 
 import {StyleEngine, type DeckGLAccessorMap, type DeckGLUpdateTriggers} from '../../src/style/style-engine';
-import {GraphStyleEngine, type GraphStylesheet} from '../../src/style/graph-style-engine';
+import {
+  GraphStyleEngine,
+  type GraphStylesheet,
+  type GraphStyleAttributeReference
+} from '../../src/style/graph-style-engine';
 
 const TEST_ACCESSOR_MAP: DeckGLAccessorMap = {
   Foo: {
@@ -77,5 +81,51 @@ describe('StyleEngine', () => {
 
     expect(accessors.getFillColor({state: 'default'})).toEqual([255, 255, 255]);
     expect(accessors.getFillColor({state: 'hover'})).toEqual([0, 0, 0]);
+  });
+
+  it('resolves attribute references and scales them', () => {
+    const radiusAttribute: GraphStyleAttributeReference<number> = {
+      attribute: 'size',
+      scale: {type: 'linear', domain: [0, 10], range: [0, 100]},
+      fallback: 4
+    };
+
+    const stylesheet = new GraphStyleEngine(
+      {
+        type: 'circle',
+        radius: radiusAttribute,
+        fill: {
+          default: '@color',
+          hover: '#ffffff'
+        }
+      },
+      {stateUpdateTrigger: 'state-trigger'}
+    );
+
+    const getRadius = stylesheet.getDeckGLAccessor('getRadius');
+    const getFill = stylesheet.getDeckGLAccessor('getFillColor');
+
+    const node = {
+      state: 'default',
+      getPropertyValue: (key: string) => ({size: 5, color: '#ef4444'}[key as 'size' | 'color'])
+    };
+
+    expect(getRadius(node)).toBe(50);
+    expect(getFill(node)).toEqual([239, 68, 68]);
+
+    const hoverNode = {
+      state: 'hover',
+      getPropertyValue: (key: string) => ({size: null, color: '#0f172a'}[key as 'size' | 'color'])
+    };
+
+    expect(getRadius(hoverNode)).toBe(40);
+    expect(getFill(hoverNode)).toEqual([255, 255, 255]);
+
+    const triggers = stylesheet.getDeckGLUpdateTriggers();
+    expect(triggers.getRadius).toMatchObject({attribute: 'size'});
+    expect(triggers.getFillColor).toEqual([
+      'state-trigger',
+      expect.objectContaining({attribute: 'color'})
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- update graph stylesheet docs, upgrade notes, and examples to highlight the new `stylesheet` prop with declarative attribute references
- normalize edge styles around the lowercase `edge` type and expose renamed graph style scale types
- improve attribute reference handling with typed D3 scales and TSDoc, plus doc comments on deprecated GraphLayer props

## Testing
- yarn workspace @deck.gl-community/graph-layers test *(fails: `vitest` not available in this environment)*
- git commit -m "fix: polish graph stylesheet API docs and defaults"


------
https://chatgpt.com/codex/tasks/task_e_69081873cb048328bca9a9d1cdf05418