### PR TITLE
Enable Docusaurus v4 future flags

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -24,6 +24,9 @@ const config = {
   organizationName: 'visgl', // Usually your GitHub org/user name.
   projectName: 'deck.gl-community', // Usually your repo name.
   trailingSlash: false,
+  future: {
+    v4: true
+  },
 
   presets: [
     [


### PR DESCRIPTION
## Summary
- opt the Docusaurus site into the v4 future flags by setting `future.v4 = true`

## Testing
- CI=1 yarn --cwd website build

------
https://chatgpt.com/codex/tasks/task_e_6908c63a470c8328a3f4f79e413358e0