### PR TITLE
Fix horizon graph data texture binding

### DIFF
--- a/modules/infovis-layers/src/layers/horizon-graph-layer/horizon-graph-layer.ts
+++ b/modules/infovis-layers/src/layers/horizon-graph-layer/horizon-graph-layer.ts
@@ -177,8 +177,8 @@ export class HorizonGraphLayer<ExtraProps extends {} = {}> extends Layer<
     const {bands, yAxisScale, positiveColor, negativeColor} = this.props;
 
     model.shaderInputs.setProps({
+      dataTexture: this.state.dataTexture,
       horizonLayer: {
-        dataTexture: this.state.dataTexture,
         dataTextureSize: this.state.dataTextureSize,
         dataTextureSizeInv: 1.0 / this.state.dataTextureSize,
         dataTextureCount: this.state.dataTextureCount,


### PR DESCRIPTION
## Summary
- bind the HorizonGraphLayer data texture outside of the uniform block so the shader receives the sampler

## Testing
- not run (pre-commit hook fails due to missing optional dependency: zod)


------
https://chatgpt.com/codex/tasks/task_e_6908d2229938832894b8caa7bfdd71f8