### PR TITLE
Refine edge attachment helper geometry extraction

### DIFF
--- a/modules/graph-layers/src/layers/edge-attachment-helper.ts
+++ b/modules/graph-layers/src/layers/edge-attachment-helper.ts
@@ -1,0 +1,349 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {InteractionManager} from '../core/interaction-manager';
+import type {GraphEngine} from '../core/graph-engine';
+import type {Node} from '../graph/node';
+
+import {Stylesheet} from '../style/style-sheet';
+import {NODE_TYPE} from '../core/constants';
+import type {ValueOf} from '../core/constants';
+import {getNodeBoundaryIntersection, type NodeGeometry} from '../utils/node-boundary';
+
+const GEOMETRY_NODE_TYPES = new Set<ValueOf<typeof NODE_TYPE>>([
+  NODE_TYPE.CIRCLE,
+  NODE_TYPE.RECTANGLE,
+  NODE_TYPE.ROUNDED_RECTANGLE,
+  NODE_TYPE.PATH_ROUNDED_RECTANGLE,
+  NODE_TYPE.MARKER
+]);
+
+type NumericAccessor = ((node: Node) => number | null | undefined) | null | undefined;
+type OffsetAccessor = ((node: Node) => [number, number] | null | undefined) | null | undefined;
+
+type NodeGeometryAccessors = {
+  type: ValueOf<typeof NODE_TYPE>;
+  getOffset?: OffsetAccessor;
+  getRadius?: NumericAccessor;
+  getWidth?: NumericAccessor;
+  getHeight?: NumericAccessor;
+  getCornerRadius?: NumericAccessor;
+};
+
+type GeometryAccessorMap = Map<string | number, NodeGeometryAccessors>;
+
+type LayoutInfo = ReturnType<GraphEngine['getEdgePosition']>;
+
+type NodeStyleDefinition = {
+  type?: ValueOf<typeof NODE_TYPE>;
+  data?: (nodes: Node[]) => Node[];
+  [key: string]: unknown;
+};
+
+function normalizePosition(value: unknown): [number, number] | null {
+  if (!value) {
+    return null;
+  }
+
+  if (Array.isArray(value) && value.length >= 2) {
+    const x = Number(value[0]);
+    const y = Number(value[1]);
+    if (Number.isFinite(x) && Number.isFinite(y)) {
+      return [x, y];
+    }
+  }
+
+  return null;
+}
+
+function toNumericAccessor(accessor: unknown): NumericAccessor {
+  if (typeof accessor === 'function') {
+    return (node: Node) => {
+      const value = accessor(node);
+      const numeric = Number(value);
+      return Number.isFinite(numeric) ? numeric : null;
+    };
+  }
+
+  const numeric = Number(accessor);
+  if (Number.isFinite(numeric)) {
+    return () => numeric;
+  }
+
+  return null;
+}
+
+function toOffsetAccessor(accessor: unknown): OffsetAccessor {
+  if (typeof accessor === 'function') {
+    return (node: Node) => {
+      const value = accessor(node);
+      if (!Array.isArray(value) || value.length < 2) {
+        return null;
+      }
+      const offsetX = Number(value[0]);
+      const offsetY = Number(value[1]);
+      if (Number.isFinite(offsetX) && Number.isFinite(offsetY)) {
+        return [offsetX, offsetY];
+      }
+      return null;
+    };
+  }
+
+  if (Array.isArray(accessor) && accessor.length >= 2) {
+    const offsetX = Number(accessor[0]);
+    const offsetY = Number(accessor[1]);
+    if (Number.isFinite(offsetX) && Number.isFinite(offsetY)) {
+      return () => [offsetX, offsetY];
+    }
+  }
+
+  return null;
+}
+
+function buildGeometryAccessors(
+  style: NodeStyleDefinition,
+  interactionManager: InteractionManager
+): NodeGeometryAccessors | null {
+  const {type, ...rest} = style;
+  if (!type || !GEOMETRY_NODE_TYPES.has(type)) {
+    return null;
+  }
+
+  const stylesheet = new Stylesheet(rest, {
+    stateUpdateTrigger: (interactionManager as any).getLastInteraction()
+  });
+
+  const accessors: NodeGeometryAccessors = {
+    type,
+    getOffset: toOffsetAccessor(stylesheet.getDeckGLAccessor('getOffset'))
+  };
+
+  switch (type) {
+    case NODE_TYPE.CIRCLE:
+      accessors.getRadius = toNumericAccessor(stylesheet.getDeckGLAccessor('getRadius'));
+      break;
+    case NODE_TYPE.MARKER: {
+      const sizeAccessor = toNumericAccessor(stylesheet.getDeckGLAccessor('getSize'));
+      if (sizeAccessor) {
+        accessors.getRadius = (node) => {
+          const size = sizeAccessor(node);
+          return typeof size === 'number' ? size / 2 : size ?? null;
+        };
+      }
+      break;
+    }
+    case NODE_TYPE.RECTANGLE:
+      accessors.getWidth = toNumericAccessor(stylesheet.getDeckGLAccessor('getWidth'));
+      accessors.getHeight = toNumericAccessor(stylesheet.getDeckGLAccessor('getHeight'));
+      break;
+    case NODE_TYPE.ROUNDED_RECTANGLE:
+      accessors.getWidth = toNumericAccessor(stylesheet.getDeckGLAccessor('getWidth'));
+      accessors.getHeight = toNumericAccessor(stylesheet.getDeckGLAccessor('getHeight'));
+      accessors.getCornerRadius = toNumericAccessor(
+        stylesheet.getDeckGLAccessor('getCornerRadius')
+      );
+      accessors.getRadius = toNumericAccessor(stylesheet.getDeckGLAccessor('getRadius'));
+      break;
+    case NODE_TYPE.PATH_ROUNDED_RECTANGLE:
+      accessors.getWidth = toNumericAccessor(stylesheet.getDeckGLAccessor('getWidth'));
+      accessors.getHeight = toNumericAccessor(stylesheet.getDeckGLAccessor('getHeight'));
+      accessors.getCornerRadius = toNumericAccessor(
+        stylesheet.getDeckGLAccessor('getCornerRadius')
+      );
+      break;
+    default:
+      break;
+  }
+
+  return accessors;
+}
+
+function populateAccessorMap(
+  map: GeometryAccessorMap,
+  nodes: Node[] | undefined,
+  accessors: NodeGeometryAccessors
+): void {
+  if (!nodes || !Array.isArray(nodes)) {
+    return;
+  }
+
+  for (const node of nodes) {
+    const nodeId = node.getId();
+    if (!map.has(nodeId)) {
+      map.set(nodeId, accessors);
+    }
+  }
+}
+
+function resolveOffset(node: Node, accessor?: OffsetAccessor): [number, number] {
+  if (!accessor) {
+    return [0, 0];
+  }
+
+  const value = accessor(node);
+  if (Array.isArray(value) && value.length >= 2) {
+    const x = Number(value[0]);
+    const y = Number(value[1]);
+    if (Number.isFinite(x) && Number.isFinite(y)) {
+      return [x, y];
+    }
+  }
+
+  return [0, 0];
+}
+
+function resolveNumeric(node: Node, accessor?: NumericAccessor): number | null {
+  if (!accessor) {
+    return null;
+  }
+
+  const value = accessor(node);
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  return null;
+}
+
+function computeGeometry(
+  engine: GraphEngine,
+  node: Node,
+  accessors?: NodeGeometryAccessors
+): NodeGeometry | null {
+  const basePosition = engine.getNodePosition(node);
+  if (!basePosition) {
+    return null;
+  }
+
+  const offset = resolveOffset(node, accessors?.getOffset);
+  const center: [number, number] = [basePosition[0] + offset[0], basePosition[1] + offset[1]];
+
+  if (!accessors) {
+    return {center};
+  }
+
+  const geometry: NodeGeometry = {
+    type: accessors.type,
+    center
+  };
+
+  const radius = resolveNumeric(node, accessors.getRadius);
+  if (typeof radius === 'number') {
+    geometry.radius = Math.max(radius, 0);
+  }
+
+  const width = resolveNumeric(node, accessors.getWidth);
+  if (typeof width === 'number') {
+    geometry.width = Math.max(width, 0);
+  }
+
+  const height = resolveNumeric(node, accessors.getHeight);
+  if (typeof height === 'number') {
+    geometry.height = Math.max(height, 0);
+  }
+
+  const cornerRadius = resolveNumeric(node, accessors.getCornerRadius);
+  if (typeof cornerRadius === 'number') {
+    geometry.cornerRadius = Math.max(cornerRadius, 0);
+  }
+
+  return geometry;
+}
+
+export class EdgeAttachmentHelper {
+  getLayoutAccessor({
+    engine,
+    interactionManager,
+    nodeStyle
+  }: {
+    engine: GraphEngine;
+    interactionManager: InteractionManager;
+    nodeStyle?: NodeStyleDefinition | NodeStyleDefinition[];
+  }): GraphEngine['getEdgePosition'] {
+    const styles = Array.isArray(nodeStyle) ? nodeStyle : nodeStyle ? [nodeStyle] : [];
+    if (styles.length === 0) {
+      return (edge) => engine.getEdgePosition(edge);
+    }
+
+    const accessorMap: GeometryAccessorMap = new Map();
+    const nodesById = new Map<string | number, Node>();
+
+    const allNodes = engine.getNodes();
+    for (const node of allNodes) {
+      nodesById.set(node.getId(), node);
+    }
+
+    for (const style of styles) {
+      if (!style) {
+        continue;
+      }
+
+      const {
+        data = (nodes: Node[]) => nodes,
+        pickable: _pickable,
+        visible: _visible,
+        id: _id,
+        ...styleProps
+      } = style as NodeStyleDefinition & {
+        pickable?: unknown;
+        visible?: unknown;
+        id?: unknown;
+      };
+      const accessors = buildGeometryAccessors(
+        styleProps as NodeStyleDefinition,
+        interactionManager
+      );
+      if (!accessors) {
+        continue;
+      }
+
+      const nodes = data(allNodes);
+      populateAccessorMap(accessorMap, nodes, accessors);
+    }
+
+    if (accessorMap.size === 0) {
+      return (edge) => engine.getEdgePosition(edge);
+    }
+
+    return (edge) => {
+      const layoutInfo: LayoutInfo = engine.getEdgePosition(edge);
+      if (!layoutInfo) {
+        return layoutInfo;
+      }
+
+      const sourceNode = nodesById.get(edge.getSourceNodeId());
+      const targetNode = nodesById.get(edge.getTargetNodeId());
+
+      if (!sourceNode || !targetNode) {
+        return layoutInfo;
+      }
+
+      const sourceGeometry = computeGeometry(engine, sourceNode, accessorMap.get(sourceNode.getId()));
+      const targetGeometry = computeGeometry(engine, targetNode, accessorMap.get(targetNode.getId()));
+
+      if (!sourceGeometry && !targetGeometry) {
+        return layoutInfo;
+      }
+
+      const adjusted = {...layoutInfo};
+
+      const targetReference = targetGeometry?.center ?? normalizePosition(layoutInfo.targetPosition);
+      const sourceReference = sourceGeometry?.center ?? normalizePosition(layoutInfo.sourcePosition);
+
+      if (sourceGeometry && targetReference) {
+        adjusted.sourcePosition = getNodeBoundaryIntersection(sourceGeometry, targetReference);
+      } else if (sourceGeometry) {
+        adjusted.sourcePosition = [...sourceGeometry.center];
+      }
+
+      if (targetGeometry && sourceReference) {
+        adjusted.targetPosition = getNodeBoundaryIntersection(targetGeometry, sourceReference);
+      } else if (targetGeometry) {
+        adjusted.targetPosition = [...targetGeometry.center];
+      }
+
+      return adjusted;
+    };
+  }
+}

--- a/modules/graph-layers/src/layers/graph-layer.ts
+++ b/modules/graph-layers/src/layers/graph-layer.ts
@@ -16,6 +16,8 @@ import {InteractionManager} from '../core/interaction-manager';
 
 import {log} from '../utils/log';
 
+import {EdgeAttachmentHelper} from './edge-attachment-helper';
+
 // node layers
 import {CircleLayer} from './node-layers/circle-layer';
 import {ImageLayer} from './node-layers/image-layer';
@@ -121,6 +123,8 @@ export class GraphLayer extends CompositeLayer<GraphLayerProps> {
     interactionManager: InteractionManager;
     graphEngine?: GraphEngine;
   };
+
+  private readonly _edgeAttachmentHelper = new EdgeAttachmentHelper();
 
   forceUpdate = () => {
     if (this.context && this.context.layerManager) {
@@ -235,6 +239,12 @@ export class GraphLayer extends CompositeLayer<GraphLayerProps> {
       return [];
     }
 
+    const getLayoutInfo = this._edgeAttachmentHelper.getLayoutAccessor({
+      engine,
+      interactionManager: this.state.interactionManager,
+      nodeStyle: this.props.nodeStyle
+    });
+
     return (Array.isArray(edgeStyle) ? edgeStyle : [edgeStyle])
       .filter(Boolean)
       .flatMap((style, idx) => {
@@ -253,7 +263,7 @@ export class GraphLayer extends CompositeLayer<GraphLayerProps> {
           ...SHARED_LAYER_PROPS,
           id: `edge-layer-${idx}`,
           data: data(engine.getEdges()),
-          getLayoutInfo: engine.getEdgePosition,
+          getLayoutInfo,
           pickable: true,
           positionUpdateTrigger: [engine.getLayoutLastUpdate(), engine.getLayoutState()].join(),
           stylesheet,
@@ -276,7 +286,7 @@ export class GraphLayer extends CompositeLayer<GraphLayerProps> {
             ...SHARED_LAYER_PROPS,
             id: `edge-decorator-${idx2}`,
             data: data(engine.getEdges()),
-            getLayoutInfo: engine.getEdgePosition,
+            getLayoutInfo,
             pickable: true,
             positionUpdateTrigger: [engine.getLayoutLastUpdate(), engine.getLayoutState()].join(),
             stylesheet: decoratorStylesheet

--- a/modules/graph-layers/src/utils/node-boundary.ts
+++ b/modules/graph-layers/src/utils/node-boundary.ts
@@ -1,0 +1,186 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {NODE_TYPE, type ValueOf} from '../core/constants';
+
+export type NodeGeometry = {
+  type?: ValueOf<typeof NODE_TYPE>;
+  center: [number, number];
+  radius?: number;
+  width?: number;
+  height?: number;
+  cornerRadius?: number;
+};
+
+const EPSILON = 1e-6;
+
+function normalizeDirection(
+  center: [number, number],
+  target: [number, number]
+): {unit: [number, number]; distance: number} | null {
+  const dx = target[0] - center[0];
+  const dy = target[1] - center[1];
+  const length = Math.hypot(dx, dy);
+
+  if (length <= EPSILON) {
+    return null;
+  }
+
+  return {unit: [dx / length, dy / length], distance: length};
+}
+
+function projectToRectangle(
+  center: [number, number],
+  unit: [number, number],
+  halfWidth: number,
+  halfHeight: number
+): [number, number] {
+  const absUx = Math.abs(unit[0]);
+  const absUy = Math.abs(unit[1]);
+
+  let distance = Number.POSITIVE_INFINITY;
+  if (halfWidth > 0 && absUx > EPSILON) {
+    distance = Math.min(distance, halfWidth / absUx);
+  }
+  if (halfHeight > 0 && absUy > EPSILON) {
+    distance = Math.min(distance, halfHeight / absUy);
+  }
+
+  if (!Number.isFinite(distance)) {
+    return [...center] as [number, number];
+  }
+
+  return [center[0] + unit[0] * distance, center[1] + unit[1] * distance];
+}
+
+function resolveCornerRadius(
+  rawCornerRadius: number | undefined,
+  halfWidth: number,
+  halfHeight: number
+): number {
+  if (!Number.isFinite(rawCornerRadius) || rawCornerRadius <= 0) {
+    return 0;
+  }
+
+  let resolved = rawCornerRadius;
+  if (resolved <= 1) {
+    resolved *= Math.min(halfWidth, halfHeight);
+  }
+
+  return Math.min(resolved, halfWidth, halfHeight);
+}
+
+function intersectRoundedRectangle(
+  geometry: NodeGeometry,
+  unit: [number, number],
+  halfWidth: number,
+  halfHeight: number
+): [number, number] {
+  const cornerRadius = resolveCornerRadius(geometry.cornerRadius, halfWidth, halfHeight);
+
+  if (cornerRadius <= EPSILON) {
+    return projectToRectangle(geometry.center, unit, halfWidth, halfHeight);
+  }
+
+  const innerHalfWidth = Math.max(halfWidth - cornerRadius, 0);
+  const innerHalfHeight = Math.max(halfHeight - cornerRadius, 0);
+
+  if (innerHalfWidth <= EPSILON || innerHalfHeight <= EPSILON) {
+    const radius = Math.min(halfWidth, halfHeight);
+    return [
+      geometry.center[0] + unit[0] * radius,
+      geometry.center[1] + unit[1] * radius
+    ];
+  }
+
+  const rectanglePoint = projectToRectangle(geometry.center, unit, halfWidth, halfHeight);
+  const offsetX = rectanglePoint[0] - geometry.center[0];
+  const offsetY = rectanglePoint[1] - geometry.center[1];
+  const absX = Math.abs(offsetX);
+  const absY = Math.abs(offsetY);
+
+  const insideVerticalFace = absX <= innerHalfWidth + EPSILON && absY <= halfHeight + EPSILON;
+  const insideHorizontalFace = absY <= innerHalfHeight + EPSILON && absX <= halfWidth + EPSILON;
+
+  if (absX <= innerHalfWidth + EPSILON || absY <= innerHalfHeight + EPSILON) {
+    if (insideVerticalFace || insideHorizontalFace) {
+      return rectanglePoint;
+    }
+  }
+
+  const cornerCenter: [number, number] = [
+    geometry.center[0] + Math.sign(offsetX || unit[0]) * innerHalfWidth,
+    geometry.center[1] + Math.sign(offsetY || unit[1]) * innerHalfHeight
+  ];
+  const relativeCornerCenter: [number, number] = [
+    cornerCenter[0] - geometry.center[0],
+    cornerCenter[1] - geometry.center[1]
+  ];
+
+  const dot = unit[0] * relativeCornerCenter[0] + unit[1] * relativeCornerCenter[1];
+  const centerDistanceSq =
+    relativeCornerCenter[0] * relativeCornerCenter[0] +
+    relativeCornerCenter[1] * relativeCornerCenter[1];
+  const discriminant = dot * dot - (centerDistanceSq - cornerRadius * cornerRadius);
+
+  if (discriminant < 0) {
+    return rectanglePoint;
+  }
+
+  const distance = dot - Math.sqrt(Math.max(0, discriminant));
+  return [
+    geometry.center[0] + unit[0] * distance,
+    geometry.center[1] + unit[1] * distance
+  ];
+}
+
+export function getNodeBoundaryIntersection(
+  geometry: NodeGeometry,
+  targetCenter: [number, number]
+): [number, number] {
+  const direction = normalizeDirection(geometry.center, targetCenter);
+  if (!direction) {
+    return [...geometry.center];
+  }
+
+  const {unit} = direction;
+
+  switch (geometry.type) {
+    case NODE_TYPE.CIRCLE:
+    case NODE_TYPE.MARKER: {
+      const radius = geometry.radius ?? 0;
+      return [geometry.center[0] + unit[0] * radius, geometry.center[1] + unit[1] * radius];
+    }
+    case NODE_TYPE.RECTANGLE: {
+      const halfWidth = (geometry.width ?? 0) / 2;
+      const halfHeight = (geometry.height ?? 0) / 2;
+      if (halfWidth <= EPSILON || halfHeight <= EPSILON) {
+        return [...geometry.center];
+      }
+      return projectToRectangle(geometry.center, unit, halfWidth, halfHeight);
+    }
+    case NODE_TYPE.ROUNDED_RECTANGLE:
+    case NODE_TYPE.PATH_ROUNDED_RECTANGLE: {
+      const halfWidth = (geometry.width ?? 0) / 2;
+      const halfHeight = (geometry.height ?? 0) / 2;
+      if (halfWidth <= EPSILON || halfHeight <= EPSILON) {
+        const radius = geometry.radius ?? Math.min(halfWidth, halfHeight);
+        return [
+          geometry.center[0] + unit[0] * radius,
+          geometry.center[1] + unit[1] * radius
+        ];
+      }
+      return intersectRoundedRectangle(geometry, unit, halfWidth, halfHeight);
+    }
+    default: {
+      if (geometry.radius && geometry.radius > EPSILON) {
+        return [
+          geometry.center[0] + unit[0] * geometry.radius,
+          geometry.center[1] + unit[1] * geometry.radius
+        ];
+      }
+      return [...geometry.center];
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- streamline the edge attachment helper by modularizing node geometry accessor construction and normalization helpers
- filter node style props when deriving geometry data so non-visual flags do not leak into stylesheet parsing
- retain edge layout adjustments by computing boundary intersections with simplified geometry resolution

## Testing
- git commit *(fails: Vitest pre-commit hook cannot resolve @deck.gl-community/template package entry)*

------
https://chatgpt.com/codex/tasks/task_e_6904bbb89a0c8328921afcee014a74b0