### PR TITLE
examples(graph-layers) Extract collapse controls component for graph viewer

### DIFF
--- a/examples/graph-layers/graph-viewer/app.tsx
+++ b/examples/graph-layers/graph-viewer/app.tsx
@@ -27,6 +27,7 @@ import {
 import {extent} from 'd3-array';
 
 import {ControlPanel, ExampleDefinition, LayoutType} from './control-panel';
+import {CollapseControls} from './collapse-controls';
 import {DEFAULT_EXAMPLE, EXAMPLES} from './examples';
 
 const INITIAL_VIEW_STATE = {
@@ -172,12 +173,6 @@ export function App(props) {
 
   const selectedStyles = selectedExample?.style;
   const isDagLayout = selectedLayout === 'd3-dag-layout';
-  const totalChainCount = dagChainSummary?.chainIds.length ?? 0;
-  const collapsedChainCount = dagChainSummary?.collapsedIds.length ?? 0;
-  const collapseAllDisabled =
-    !collapseEnabled || !dagChainSummary || dagChainSummary.chainIds.length === 0;
-  const expandAllDisabled =
-    !collapseEnabled || !dagChainSummary || dagChainSummary.collapsedIds.length === 0;
 
   useEffect(() => {
     if (isDagLayout) {
@@ -426,84 +421,13 @@ export function App(props) {
           onExampleChange={handleExampleChange}
         >
           {isDagLayout ? (
-            <section style={{marginBottom: '0.5rem', fontSize: '0.875rem', lineHeight: 1.5}}>
-              <h3 style={{margin: '0 0 0.5rem', fontSize: '0.875rem', fontWeight: 600, color: '#0f172a'}}>
-                Collapsed chains
-              </h3>
-              <p style={{margin: '0 0 0.75rem', color: '#334155'}}>
-                Linear chains collapse to a single node marked with plus and minus icons. Use these controls to
-                expand or collapse all chains. Individual chains remain interactive on the canvas.
-              </p>
-              <div style={{display: 'flex', flexDirection: 'column', gap: '0.5rem'}}>
-                <div
-                  style={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    fontSize: '0.8125rem',
-                    color: '#475569'
-                  }}
-                >
-                  <span>Status</span>
-                  <span>
-                    {collapsedChainCount} / {totalChainCount} collapsed
-                  </span>
-                </div>
-                <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap'}}>
-                  <button
-                    type="button"
-                    onClick={handleToggleCollapseEnabled}
-                    style={{
-                      background: collapseEnabled ? '#4c6ef5' : '#1f2937',
-                      color: '#ffffff',
-                      border: 'none',
-                      borderRadius: '0.375rem',
-                      padding: '0.375rem 0.75rem',
-                      cursor: 'pointer',
-                      fontFamily: 'inherit',
-                      fontSize: '0.8125rem'
-                    }}
-                  >
-                    {collapseEnabled ? 'Disable collapse' : 'Enable collapse'}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleCollapseAll}
-                    disabled={collapseAllDisabled}
-                    style={{
-                      background: '#2563eb',
-                      color: '#ffffff',
-                      border: 'none',
-                      borderRadius: '0.375rem',
-                      padding: '0.375rem 0.75rem',
-                      cursor: collapseAllDisabled ? 'not-allowed' : 'pointer',
-                      fontFamily: 'inherit',
-                      fontSize: '0.8125rem',
-                      opacity: collapseAllDisabled ? 0.5 : 1
-                    }}
-                  >
-                    Collapse all
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleExpandAll}
-                    disabled={expandAllDisabled}
-                    style={{
-                      background: '#16a34a',
-                      color: '#ffffff',
-                      border: 'none',
-                      borderRadius: '0.375rem',
-                      padding: '0.375rem 0.75rem',
-                      cursor: expandAllDisabled ? 'not-allowed' : 'pointer',
-                      fontFamily: 'inherit',
-                      fontSize: '0.8125rem',
-                      opacity: expandAllDisabled ? 0.5 : 1
-                    }}
-                  >
-                    Expand all
-                  </button>
-                </div>
-              </div>
-            </section>
+            <CollapseControls
+              enabled={collapseEnabled}
+              summary={dagChainSummary}
+              onToggle={handleToggleCollapseEnabled}
+              onCollapseAll={handleCollapseAll}
+              onExpandAll={handleExpandAll}
+            />
           ) : null}
         </ControlPanel>
       </aside>

--- a/examples/graph-layers/graph-viewer/collapse-controls.spec.tsx
+++ b/examples/graph-layers/graph-viewer/collapse-controls.spec.tsx
@@ -1,0 +1,40 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+
+import React from 'react';
+import {renderToStaticMarkup} from 'react-dom/server';
+import {describe, expect, it, vi} from 'vitest';
+
+import {CollapseControls} from './collapse-controls';
+
+describe('CollapseControls', () => {
+  it('returns null when no summary is provided', () => {
+    const element = CollapseControls({
+      enabled: true,
+      summary: null,
+      onToggle: () => undefined,
+      onCollapseAll: () => undefined,
+      onExpandAll: () => undefined
+    });
+
+    expect(element).toBeNull();
+  });
+
+  it('renders status text derived from the summary', () => {
+    const markup = renderToStaticMarkup(
+      <CollapseControls
+        enabled
+        summary={{chainIds: ['a', 'b', 'c'], collapsedIds: ['a', 'b']}}
+        onToggle={vi.fn()}
+        onCollapseAll={vi.fn()}
+        onExpandAll={vi.fn()}
+      />
+    );
+
+    expect(markup).toContain('Collapsed chains');
+    expect(markup).toContain('2 / 3 collapsed');
+    expect(markup).toContain('Disable collapse');
+    expect(markup).toContain('Collapse all');
+    expect(markup).toContain('Expand all');
+  });
+});

--- a/examples/graph-layers/graph-viewer/collapse-controls.tsx
+++ b/examples/graph-layers/graph-viewer/collapse-controls.tsx
@@ -1,0 +1,132 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import React from 'react';
+
+type DagChainSummary = {
+  chainIds: string[];
+  collapsedIds: string[];
+};
+
+export type CollapseControlsProps = {
+  enabled: boolean;
+  summary: DagChainSummary | null;
+  onToggle: () => void;
+  onCollapseAll: () => void;
+  onExpandAll: () => void;
+};
+
+const sectionStyle: React.CSSProperties = {
+  marginBottom: '0.5rem',
+  fontSize: '0.875rem',
+  lineHeight: 1.5
+};
+
+const headingStyle: React.CSSProperties = {
+  margin: '0 0 0.5rem',
+  fontSize: '0.875rem',
+  fontWeight: 600,
+  color: '#0f172a'
+};
+
+const descriptionStyle: React.CSSProperties = {
+  margin: '0 0 0.75rem',
+  color: '#334155'
+};
+
+const statusRowStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  fontSize: '0.8125rem',
+  color: '#475569'
+};
+
+const controlsContainerStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: '0.5rem',
+  flexWrap: 'wrap'
+};
+
+const buttonBaseStyle: React.CSSProperties = {
+  border: 'none',
+  borderRadius: '0.375rem',
+  padding: '0.375rem 0.75rem',
+  fontFamily: 'inherit',
+  fontSize: '0.8125rem',
+  color: '#ffffff'
+};
+
+function getToggleButtonStyle(enabled: boolean): React.CSSProperties {
+  return {
+    ...buttonBaseStyle,
+    background: enabled ? '#4c6ef5' : '#1f2937',
+    cursor: 'pointer'
+  };
+}
+
+function getActionButtonStyle(disabled: boolean, background: string): React.CSSProperties {
+  return {
+    ...buttonBaseStyle,
+    background,
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    opacity: disabled ? 0.5 : 1
+  };
+}
+
+export function CollapseControls({
+  enabled,
+  summary,
+  onToggle,
+  onCollapseAll,
+  onExpandAll
+}: CollapseControlsProps) {
+  if (!summary) {
+    return null;
+  }
+
+  const totalChainCount = summary.chainIds.length;
+  const collapsedChainCount = summary.collapsedIds.length;
+
+  const collapseAllDisabled = !enabled || totalChainCount === 0;
+  const expandAllDisabled = !enabled || collapsedChainCount === 0;
+
+  return (
+    <section style={sectionStyle}>
+      <h3 style={headingStyle}>Collapsed chains</h3>
+      <p style={descriptionStyle}>
+        Linear chains collapse to a single node marked with plus and minus icons. Use these controls to expand or collapse all
+        chains. Individual chains remain interactive on the canvas.
+      </p>
+      <div style={{display: 'flex', flexDirection: 'column', gap: '0.5rem'}}>
+        <div style={statusRowStyle}>
+          <span>Status</span>
+          <span>
+            {collapsedChainCount} / {totalChainCount} collapsed
+          </span>
+        </div>
+        <div style={controlsContainerStyle}>
+          <button type="button" onClick={onToggle} style={getToggleButtonStyle(enabled)}>
+            {enabled ? 'Disable collapse' : 'Enable collapse'}
+          </button>
+          <button
+            type="button"
+            onClick={onCollapseAll}
+            disabled={collapseAllDisabled}
+            style={getActionButtonStyle(collapseAllDisabled, '#2563eb')}
+          >
+            Collapse all
+          </button>
+          <button
+            type="button"
+            onClick={onExpandAll}
+            disabled={expandAllDisabled}
+            style={getActionButtonStyle(expandAllDisabled, '#16a34a')}
+          >
+            Expand all
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -48,6 +48,14 @@ const CONFIG = defineConfig({
             instances: [{browser: 'chromium'}]
           }
         }
+      },
+      {
+        plugins: [react()],
+        test: {
+          name: 'examples',
+          environment: 'node',
+          include: ['examples/**/*.{test,spec}.{js,ts,jsx,tsx}']
+        }
       }
     ]
     // You can omit top-level include if everyone is scoped in their projects


### PR DESCRIPTION
## Summary
- extract the collapsed chain controls into a dedicated `CollapseControls` component with props-driven styles
- consume the new component from the graph viewer app and keep the DAG handlers in place
- add targeted Vitest coverage for the component and wire the examples workspace into the Vitest project list

## Testing
- yarn vitest run --project examples

------
https://chatgpt.com/codex/tasks/task_e_690a363e4c10832892f98263e3d7da7f