### PR TITLE
Add GraphLayer layout redraw throttling

### DIFF
--- a/docs/modules/graph-layers/api-reference/layers/graph-layer.md
+++ b/docs/modules/graph-layers/api-reference/layers/graph-layer.md
@@ -122,6 +122,13 @@ you need—they are all optional.
 When `true`, nodes can be repositioned by dragging. The interaction manager
 updates the layout and stylesheet state automatically during drags.
 
+#### `layoutUpdateInterval` (number, optional)
+
+Minimum time in milliseconds between layout-driven layer redraws. Defaults to
+`0`, which redraws on every layout change. Increase this value when a rapidly
+iterating layout should update the rendered graph at a steadier cadence while
+still receiving every layout lifecycle callback.
+
 ### Miscellaneous
 
 #### `pickable` (boolean, optional)

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -13,6 +13,10 @@ Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community
 
 - Added generic animation, block, fast-text, UTF8 Arrow string-view, view-layout, and viewport-bounds helpers for trace-style visualizations.
 
+### `@deck.gl-community/graph-layers`
+
+- `GraphLayer` now accepts `layoutUpdateInterval` to throttle layout-driven redraws while preserving layout lifecycle callbacks.
+
 ### `@deck.gl-community/timeline-layers`
 
 - `TimeAxisLayer` now supports adaptive trace-style duration and timestamp grids plus exported tick formatting helpers.

--- a/modules/graph-layers/src/layers/graph-layer.ts
+++ b/modules/graph-layers/src/layers/graph-layer.ts
@@ -169,6 +169,8 @@ export type _GraphLayerProps = {
     onHover: () => void;
   };
   enableDragging?: boolean;
+  /** Minimum time between layout-driven layer updates in milliseconds. */
+  layoutUpdateInterval?: number;
   rankGrid?: boolean | RankGridConfig;
   resumeLayoutAfterDragging?: boolean;
 };
@@ -203,6 +205,7 @@ export class GraphLayer extends CompositeLayer<GraphLayerProps> {
       onHover: () => {}
     },
     enableDragging: false,
+    layoutUpdateInterval: 0,
     rankGrid: false,
     resumeLayoutAfterDragging: true
   };
@@ -218,6 +221,9 @@ export class GraphLayer extends CompositeLayer<GraphLayerProps> {
 
   private readonly _edgeAttachmentHelper = new EdgeAttachmentHelper();
   private _suppressNextDeckDataChange = false;
+  private _lastLayoutUpdateTime = 0;
+  private _pendingLayoutSnapshotEngine: GraphEngine | null | undefined;
+  private _layoutUpdateTimer: ReturnType<typeof setTimeout> | null = null;
 
   forceUpdate = () => {
     if (!this.state) {
@@ -295,6 +301,7 @@ export class GraphLayer extends CompositeLayer<GraphLayerProps> {
   }
 
   finalize() {
+    this._clearLayoutUpdateTimer();
     this._removeGraphEngine();
     this._syncInteractionManager(this.props, null);
   }
@@ -628,8 +635,54 @@ export class GraphLayer extends CompositeLayer<GraphLayerProps> {
   }
 
   private _handleLayoutEvent = () => {
-    this._updateLayoutSnapshot();
+    this._scheduleLayoutSnapshotUpdate();
   };
+
+  private _scheduleLayoutSnapshotUpdate(engine?: GraphEngine | null) {
+    const interval = Math.max(0, this.props.layoutUpdateInterval ?? 0);
+
+    if (interval === 0) {
+      this._clearLayoutUpdateTimer();
+      this._lastLayoutUpdateTime = Date.now();
+      this._updateLayoutSnapshot(engine);
+      return;
+    }
+
+    this._pendingLayoutSnapshotEngine = engine;
+
+    if (this._layoutUpdateTimer) {
+      return;
+    }
+
+    const now = Date.now();
+    const elapsed = this._lastLayoutUpdateTime === 0 ? interval : now - this._lastLayoutUpdateTime;
+    const delay = Math.max(0, interval - elapsed);
+
+    if (delay === 0) {
+      this._flushLayoutSnapshotUpdate(now);
+      return;
+    }
+
+    this._layoutUpdateTimer = setTimeout(() => {
+      this._layoutUpdateTimer = null;
+      this._flushLayoutSnapshotUpdate();
+    }, delay);
+  }
+
+  private _flushLayoutSnapshotUpdate(timestamp = Date.now()) {
+    this._lastLayoutUpdateTime = timestamp;
+    const engine = this._pendingLayoutSnapshotEngine;
+    this._pendingLayoutSnapshotEngine = undefined;
+    this._updateLayoutSnapshot(engine);
+  }
+
+  private _clearLayoutUpdateTimer() {
+    if (this._layoutUpdateTimer) {
+      clearTimeout(this._layoutUpdateTimer);
+      this._layoutUpdateTimer = null;
+    }
+    this._pendingLayoutSnapshotEngine = undefined;
+  }
 
   _setGraphEngine(graphEngine: GraphEngine | null) {
     if (graphEngine === this.state.graphEngine) {
@@ -654,6 +707,7 @@ export class GraphLayer extends CompositeLayer<GraphLayerProps> {
   }
 
   _removeGraphEngine() {
+    this._clearLayoutUpdateTimer();
     const engine = this.state.graphEngine;
     if (engine) {
       engine.setProps({

--- a/modules/graph-layers/test/layers/graph-layer.spec.ts
+++ b/modules/graph-layers/test/layers/graph-layer.spec.ts
@@ -1,0 +1,86 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {GraphLayer} from '../../src/layers/graph-layer';
+
+function makeGraphLayerHarness(layoutUpdateInterval: number) {
+  const layer = Object.create(GraphLayer.prototype) as GraphLayer & {
+    props: {layoutUpdateInterval: number};
+    state: {graphEngine: unknown};
+    _layoutUpdateTimer: ReturnType<typeof setTimeout> | null;
+    _lastLayoutUpdateTime: number;
+    _pendingLayoutSnapshotEngine: unknown;
+    _scheduleLayoutSnapshotUpdate: (engine?: unknown) => void;
+    _clearLayoutUpdateTimer: () => void;
+    _updateLayoutSnapshot: ReturnType<typeof vi.fn>;
+  };
+
+  layer.props = {layoutUpdateInterval};
+  layer.state = {graphEngine: 'current-engine'};
+  layer._layoutUpdateTimer = null;
+  layer._lastLayoutUpdateTime = 0;
+  layer._pendingLayoutSnapshotEngine = undefined;
+  layer._updateLayoutSnapshot = vi.fn();
+
+  return layer;
+}
+
+describe('layers/graph-layer', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('updates layout snapshots immediately by default', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const layer = makeGraphLayerHarness(0);
+
+    layer._scheduleLayoutSnapshotUpdate('first-engine');
+    layer._scheduleLayoutSnapshotUpdate('second-engine');
+
+    expect(layer._updateLayoutSnapshot).toHaveBeenCalledTimes(2);
+    expect(layer._updateLayoutSnapshot).toHaveBeenNthCalledWith(1, 'first-engine');
+    expect(layer._updateLayoutSnapshot).toHaveBeenNthCalledWith(2, 'second-engine');
+  });
+
+  it('coalesces layout snapshots when layoutUpdateInterval is set', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const layer = makeGraphLayerHarness(50);
+
+    layer._scheduleLayoutSnapshotUpdate('first-engine');
+    expect(layer._updateLayoutSnapshot).toHaveBeenCalledTimes(1);
+    expect(layer._updateLayoutSnapshot).toHaveBeenLastCalledWith('first-engine');
+
+    vi.advanceTimersByTime(10);
+    layer._scheduleLayoutSnapshotUpdate('second-engine');
+    layer._scheduleLayoutSnapshotUpdate('third-engine');
+
+    expect(layer._updateLayoutSnapshot).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(39);
+    expect(layer._updateLayoutSnapshot).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1);
+    expect(layer._updateLayoutSnapshot).toHaveBeenCalledTimes(2);
+    expect(layer._updateLayoutSnapshot).toHaveBeenLastCalledWith('third-engine');
+  });
+
+  it('clears pending throttled layout snapshots', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const layer = makeGraphLayerHarness(50);
+
+    layer._scheduleLayoutSnapshotUpdate('first-engine');
+    vi.advanceTimersByTime(10);
+    layer._scheduleLayoutSnapshotUpdate('second-engine');
+    layer._clearLayoutUpdateTimer();
+    vi.advanceTimersByTime(50);
+
+    expect(layer._updateLayoutSnapshot).toHaveBeenCalledTimes(1);
+    expect(layer._updateLayoutSnapshot).toHaveBeenLastCalledWith('first-engine');
+  });
+});


### PR DESCRIPTION
## Summary
- add `GraphLayer.layoutUpdateInterval` to throttle layout-driven redraws without suppressing layout lifecycle callbacks
- clear pending throttled redraw timers when the layer finalizes or swaps graph engines
- document the public prop in the GraphLayer API reference and v9.4 notes

## Classification
Feature / public API addition for graph-layers rendering cadence. It affects internal redraw scheduling, not a rendered docs/example route.

## Validation
- `yarn`
- `yarn test-node modules/graph-layers/test/layers/graph-layer.spec.ts`
- `yarn test-node modules/graph-layers/test`
- `yarn lint-fix`
- `yarn lint`
- `yarn build`
- `cd website && yarn && yarn build`
- pre-commit `yarn test`

## Visual proof
Not applicable. This PR changes `GraphLayer` redraw scheduling and public API docs; it is covered by fake-timer unit tests plus package/website builds rather than a user-visible route or interaction recording.

## Residual risk
Low to medium. The default remains `0`, preserving current every-layout-change redraw behavior. Nonzero intervals coalesce intermediate redraws, so consumers using the new prop should expect visual updates at the requested cadence while lifecycle callbacks still fire.
