### PR TITLE
chore(graph-layers) Refactor collapsed chain utilities

### DIFF
--- a/modules/graph-layers/src/core/interaction-manager.ts
+++ b/modules/graph-layers/src/core/interaction-manager.ts
@@ -7,74 +7,13 @@ import {Edge} from '../graph/edge';
 import {Node} from '../graph/node';
 import {GraphEngine} from './graph-engine';
 import {log} from '../utils/log';
+import {
+  resolveChainInteractionSource,
+  type ChainInteractionSource
+} from '../utils/collapsed-chains';
 
-export type ChainInteractionSource =
-  | 'node'
-  | 'collapsed-marker'
-  | 'expanded-marker'
-  | 'collapsed-outline'
-  | 'expanded-outline';
-
-function resolveLayerId(layer: any): string {
-  if (!layer) {
-    return '';
-  }
-  if (typeof layer.id === 'string') {
-    return layer.id;
-  }
-  if (typeof layer.props?.id === 'string') {
-    return layer.props.id;
-  }
-  return '';
-}
-
-function classifyLayer(layer: any): ChainInteractionSource | null {
-  let current = layer ?? null;
-  while (current) {
-    const layerId = resolveLayerId(current);
-    if (layerId.includes('collapsed-chain-markers')) {
-      return 'collapsed-marker';
-    }
-    if (layerId.includes('expanded-chain-markers')) {
-      return 'expanded-marker';
-    }
-    if (layerId.includes('collapsed-chain-outlines')) {
-      return 'collapsed-outline';
-    }
-    if (layerId.includes('expanded-chain-outlines')) {
-      return 'expanded-outline';
-    }
-    current = current.parent ?? null;
-  }
-  return null;
-}
-
-export function resolveChainInteractionSource(info: any): ChainInteractionSource {
-  if (!info) {
-    return 'node';
-  }
-
-  const layersToCheck = [] as any[];
-  if (info.layer || info.sourceLayer) {
-    if (info.layer) {
-      layersToCheck.push(info.layer);
-    }
-    if (info.sourceLayer && info.sourceLayer !== info.layer) {
-      layersToCheck.push(info.sourceLayer);
-    }
-  } else {
-    layersToCheck.push(info);
-  }
-
-  for (const layer of layersToCheck) {
-    const classification = classifyLayer(layer);
-    if (classification) {
-      return classification;
-    }
-  }
-
-  return 'node';
-}
+export {resolveChainInteractionSource};
+export type {ChainInteractionSource};
 
 export function shouldToggleCollapsedChain(
   isCollapsed: boolean,
@@ -201,15 +140,16 @@ export class InteractionManager {
           // eslint-disable-next-line max-depth
           if (shouldToggleCollapsedChain(isCollapsed, interactionSource)) {
             const action = isCollapsed ? 'expand' : 'collapse';
+            const chainIdStr = String(chainId);
             log.log(
               0,
-              `InteractionManager: ${action} chain ${chainId} via ${interactionSource}`
+              `InteractionManager: ${action} chain ${chainIdStr} via ${interactionSource}`
             );
             // eslint-disable-next-line no-console
             console.log(
-              `InteractionManager: ${action} chain ${chainId} via ${interactionSource}`
+              `InteractionManager: ${action} chain ${chainIdStr} via ${interactionSource}`
             );
-            layout.toggleCollapsedChain(String(chainId));
+            layout.toggleCollapsedChain(chainIdStr);
             this._lastInteraction = Date.now();
             this.notifyCallback();
             // eslint-disable-next-line max-depth

--- a/modules/graph-layers/src/utils/collapsed-chains.ts
+++ b/modules/graph-layers/src/utils/collapsed-chains.ts
@@ -1,0 +1,261 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {GraphEngine} from '../core/graph-engine';
+import type {Node} from '../graph/node';
+
+const OUTLINE_PADDING = 24;
+const OUTLINE_CORNER_RADIUS = 16;
+const OUTLINE_CORNER_SEGMENTS = 6;
+
+export type ChainInteractionSource =
+  | 'node'
+  | 'collapsed-marker'
+  | 'expanded-marker'
+  | 'collapsed-outline'
+  | 'expanded-outline';
+
+function resolveLayerId(layer: any): string {
+  if (!layer) {
+    return '';
+  }
+  if (typeof layer.id === 'string') {
+    return layer.id;
+  }
+  if (typeof layer.props?.id === 'string') {
+    return layer.props.id;
+  }
+  return '';
+}
+
+function classifyChainLayer(layer: any): ChainInteractionSource | null {
+  let current = layer ?? null;
+  while (current) {
+    const layerId = resolveLayerId(current);
+    if (layerId.includes('collapsed-chain-markers')) {
+      return 'collapsed-marker';
+    }
+    if (layerId.includes('expanded-chain-markers')) {
+      return 'expanded-marker';
+    }
+    if (layerId.includes('collapsed-chain-outlines')) {
+      return 'collapsed-outline';
+    }
+    if (layerId.includes('expanded-chain-outlines')) {
+      return 'expanded-outline';
+    }
+    current = current.parent ?? null;
+  }
+  return null;
+}
+
+export function resolveChainInteractionSource(info: any): ChainInteractionSource {
+  if (!info) {
+    return 'node';
+  }
+
+  const layersToCheck = [] as any[];
+  if (info.layer || info.sourceLayer) {
+    if (info.layer) {
+      layersToCheck.push(info.layer);
+    }
+    if (info.sourceLayer && info.sourceLayer !== info.layer) {
+      layersToCheck.push(info.sourceLayer);
+    }
+  } else {
+    layersToCheck.push(info);
+  }
+
+  for (const layer of layersToCheck) {
+    const classification = classifyChainLayer(layer);
+    if (classification) {
+      return classification;
+    }
+  }
+
+  return 'node';
+}
+
+function isChainRepresentative(node: Node): boolean {
+  const chainId = node.getPropertyValue('collapsedChainId');
+  const nodeIds = node.getPropertyValue('collapsedNodeIds');
+  const representativeId = node.getPropertyValue('collapsedChainRepresentativeId');
+
+  return (
+    Boolean(chainId) &&
+    Array.isArray(nodeIds) &&
+    nodeIds.length > 1 &&
+    representativeId === node.getId()
+  );
+}
+
+export function getRepresentativeNodes(engine: GraphEngine | null | undefined): Node[] {
+  if (!engine) {
+    return [];
+  }
+
+  return engine.getNodes().filter((node) => isChainRepresentative(node));
+}
+
+export type ChainOutlineGetter = (node: Node) => [number, number][] | null;
+
+export function createChainOutlineGetter(engine: GraphEngine | null | undefined): ChainOutlineGetter {
+  if (!engine) {
+    return () => null;
+  }
+
+  const graph = engine.props.graph;
+  const cache = new Map<string, [number, number][] | null>();
+
+  // eslint-disable-next-line max-statements, complexity
+  return (node: Node): [number, number][] | null => {
+    const chainId = node.getPropertyValue('collapsedChainId');
+    if (!chainId) {
+      return null;
+    }
+
+    const cacheKey = String(chainId);
+    if (cache.has(cacheKey)) {
+      return cache.get(cacheKey) ?? null;
+    }
+
+    if (!graph) {
+      cache.set(cacheKey, null);
+      return null;
+    }
+
+    const collapsedNodeIds = node.getPropertyValue('collapsedNodeIds');
+    if (!Array.isArray(collapsedNodeIds) || collapsedNodeIds.length === 0) {
+      cache.set(cacheKey, null);
+      return null;
+    }
+
+    let minX = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let minY = Number.POSITIVE_INFINITY;
+    let maxY = Number.NEGATIVE_INFINITY;
+
+    for (const nodeId of collapsedNodeIds) {
+      const chainNode = graph.findNode(nodeId);
+      if (chainNode) {
+        const position = engine.getNodePosition(chainNode);
+        if (position) {
+          const [x, y] = position;
+          minX = Math.min(minX, x);
+          maxX = Math.max(maxX, x);
+          minY = Math.min(minY, y);
+          maxY = Math.max(maxY, y);
+        }
+      }
+    }
+
+    if (
+      !Number.isFinite(minX) ||
+      !Number.isFinite(maxX) ||
+      !Number.isFinite(minY) ||
+      !Number.isFinite(maxY)
+    ) {
+      cache.set(cacheKey, null);
+      return null;
+    }
+
+    const paddedMinX = minX - OUTLINE_PADDING;
+    const paddedMaxX = maxX + OUTLINE_PADDING;
+    const paddedMinY = minY - OUTLINE_PADDING;
+    const paddedMaxY = maxY + OUTLINE_PADDING;
+
+    const width = paddedMaxX - paddedMinX;
+    const height = paddedMaxY - paddedMinY;
+
+    if (width <= 0 || height <= 0) {
+      cache.set(cacheKey, null);
+      return null;
+    }
+
+    const radius = Math.min(OUTLINE_CORNER_RADIUS, width / 2, height / 2);
+
+    if (radius <= 0) {
+      const polygon: [number, number][] = [
+        [paddedMinX, paddedMinY],
+        [paddedMinX, paddedMaxY],
+        [paddedMaxX, paddedMaxY],
+        [paddedMaxX, paddedMinY],
+        [paddedMinX, paddedMinY]
+      ];
+      cache.set(cacheKey, polygon);
+      return polygon;
+    }
+
+    const left = paddedMinX;
+    const right = paddedMaxX;
+    const top = paddedMinY;
+    const bottom = paddedMaxY;
+
+    const polygon: [number, number][] = [];
+    const pushArc = (cx: number, cy: number, startAngle: number, endAngle: number) => {
+      const step = (endAngle - startAngle) / OUTLINE_CORNER_SEGMENTS;
+      for (let i = 1; i <= OUTLINE_CORNER_SEGMENTS; i++) {
+        const angle = startAngle + step * i;
+        polygon.push([cx + radius * Math.cos(angle), cy + radius * Math.sin(angle)]);
+      }
+    };
+
+    polygon.push([right - radius, top]);
+    pushArc(right - radius, top + radius, -Math.PI / 2, 0);
+    polygon.push([right, bottom - radius]);
+    pushArc(right - radius, bottom - radius, 0, Math.PI / 2);
+    polygon.push([left + radius, bottom]);
+    pushArc(left + radius, bottom - radius, Math.PI / 2, Math.PI);
+    polygon.push([left, top + radius]);
+    pushArc(left + radius, top + radius, Math.PI, (3 * Math.PI) / 2);
+    polygon.push(polygon[0]);
+
+    cache.set(cacheKey, polygon);
+    return polygon;
+  };
+}
+
+export interface CollapsedChainLayerData {
+  representativeNodes: Node[];
+  collapsedNodes: Node[];
+  collapsedOutlineNodes: Node[];
+  expandedNodes: Node[];
+  expandedOutlineNodes: Node[];
+  getChainOutlinePolygon: ChainOutlineGetter;
+  outlineUpdateTrigger: string;
+}
+
+export function buildCollapsedChainLayers(
+  engine: GraphEngine | null | undefined
+): CollapsedChainLayerData | null {
+  if (!engine) {
+    return null;
+  }
+
+  const representativeNodes = getRepresentativeNodes(engine);
+  if (representativeNodes.length === 0) {
+    return null;
+  }
+
+  const getChainOutlinePolygon = createChainOutlineGetter(engine);
+  const outlineUpdateTrigger = [engine.getLayoutLastUpdate(), engine.getLayoutState()].join();
+
+  const collapsedNodes = representativeNodes.filter((node) =>
+    Boolean(node.getPropertyValue('isCollapsedChain'))
+  );
+  const collapsedOutlineNodes = collapsedNodes.filter((node) => getChainOutlinePolygon(node));
+
+  const expandedNodes = representativeNodes.filter((node) => !node.getPropertyValue('isCollapsedChain'));
+  const expandedOutlineNodes = expandedNodes.filter((node) => getChainOutlinePolygon(node));
+
+  return {
+    representativeNodes,
+    collapsedNodes,
+    collapsedOutlineNodes,
+    expandedNodes,
+    expandedOutlineNodes,
+    getChainOutlinePolygon,
+    outlineUpdateTrigger
+  };
+}


### PR DESCRIPTION
## Summary
- centralize collapsed chain node filtering, outline geometry, and interaction helpers
- refactor GraphLayer to use the new utility data when creating overlay layers
- reuse the shared interaction source resolver within InteractionManager

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_690a364568f88328bedafb007fd4c212