### PR TITLE
Limit graph viewer sidebar height

### DIFF
--- a/examples/graph-layers/graph-viewer/app.tsx
+++ b/examples/graph-layers/graph-viewer/app.tsx
@@ -336,6 +336,7 @@ export function App(props) {
       style={{
         display: 'flex',
         height: '100%',
+        minHeight: '100vh',
         width: '100%',
         boxSizing: 'border-box',
         fontFamily: 'Inter, "Helvetica Neue", Arial, sans-serif'
@@ -411,6 +412,7 @@ export function App(props) {
           boxSizing: 'border-box',
           borderLeft: '1px solid #e2e8f0',
           background: '#f1f5f9',
+          maxHeight: '100vh',
           overflowY: 'auto',
           fontFamily: 'inherit'
         }}


### PR DESCRIPTION
## Summary
- ensure the graph viewer root layout stretches to the viewport height
- cap the sidebar to the viewport so its contents scroll instead of exceeding the screen

## Testing
- yarn lint *(fails: missing cached dependencies due to offline registry access)*

------
https://chatgpt.com/codex/tasks/task_e_690a3edd9eb083288329c7a9adf98e58