### PR TITLE
Extract DAG toggle shortcut effect into hook

### DIFF
--- a/examples/graph-layers/graph-viewer/collapse-controls.spec.tsx
+++ b/examples/graph-layers/graph-viewer/collapse-controls.spec.tsx
@@ -36,5 +36,7 @@ describe('CollapseControls', () => {
     expect(markup).toContain('Disable collapse');
     expect(markup).toContain('Collapse all');
     expect(markup).toContain('Expand all');
+    expect(markup).toContain('Keyboard shortcuts');
+    expect(markup).toContain('Toggle focused chain');
   });
 });

--- a/examples/graph-layers/graph-viewer/collapse-controls.tsx
+++ b/examples/graph-layers/graph-viewer/collapse-controls.tsx
@@ -4,6 +4,9 @@
 
 import React from 'react';
 
+import {COLLAPSE_CONTROLS_SHORTCUTS, type ShortcutHint} from './shortcuts';
+import {ShortcutHints} from './shortcut-hints';
+
 type DagChainSummary = {
   chainIds: string[];
   collapsedIds: string[];
@@ -15,6 +18,7 @@ export type CollapseControlsProps = {
   onToggle: () => void;
   onCollapseAll: () => void;
   onExpandAll: () => void;
+  shortcutHints?: ShortcutHint[];
 };
 
 const sectionStyle: React.CSSProperties = {
@@ -79,7 +83,8 @@ export function CollapseControls({
   summary,
   onToggle,
   onCollapseAll,
-  onExpandAll
+  onExpandAll,
+  shortcutHints
 }: CollapseControlsProps) {
   if (!summary) {
     return null;
@@ -87,6 +92,8 @@ export function CollapseControls({
 
   const totalChainCount = summary.chainIds.length;
   const collapsedChainCount = summary.collapsedIds.length;
+
+  const shortcuts = shortcutHints ?? COLLAPSE_CONTROLS_SHORTCUTS;
 
   const collapseAllDisabled = !enabled || totalChainCount === 0;
   const expandAllDisabled = !enabled || collapsedChainCount === 0;
@@ -126,6 +133,7 @@ export function CollapseControls({
             Expand all
           </button>
         </div>
+        <ShortcutHints hints={shortcuts} />
       </div>
     </section>
   );

--- a/examples/graph-layers/graph-viewer/node-classification.ts
+++ b/examples/graph-layers/graph-viewer/node-classification.ts
@@ -1,0 +1,115 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {MutableRefObject} from 'react';
+
+import type {Edge, EdgeState, Node, NodeState} from '@deck.gl-community/graph-layers';
+
+const TEXT_INPUT_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
+
+const NODE_TO_EDGE_STATE_MAP: Record<NodeState, EdgeState> = {
+  default: 'default',
+  hover: 'hover',
+  dragging: 'dragging',
+  selected: 'selected'
+};
+
+function shouldEdgeBeSelected(edge: Edge): boolean {
+  return edge
+    .getConnectedNodes()
+    .some((node) => node.getState() === 'selected' && node.shouldHighlightConnectedEdges());
+}
+
+export function isEditableElement(target: EventTarget | null): target is HTMLElement {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  if (target.isContentEditable) {
+    return true;
+  }
+  if (TEXT_INPUT_TAGS.has(target.tagName)) {
+    return true;
+  }
+  const role = target.getAttribute('role');
+  return role === 'textbox' || role === 'combobox' || role === 'searchbox' || role === 'spinbutton';
+}
+
+export function isRepresentativeNode(node: Node): boolean {
+  const chainId = node.getPropertyValue('collapsedChainId');
+  const collapsedNodeIds = node.getPropertyValue('collapsedNodeIds');
+  const representativeId = node.getPropertyValue('collapsedChainRepresentativeId');
+  return (
+    chainId !== null &&
+    chainId !== undefined &&
+    Array.isArray(collapsedNodeIds) &&
+    collapsedNodeIds.length > 1 &&
+    representativeId === node.getId()
+  );
+}
+
+export function getRepresentativeChainId(node: Node): string | null {
+  if (!isRepresentativeNode(node)) {
+    return null;
+  }
+  const chainId = node.getPropertyValue('collapsedChainId');
+  if (chainId === null || chainId === undefined) {
+    return null;
+  }
+  return String(chainId);
+}
+
+export function setNodeInteractionState(node: Node, state: NodeState): void {
+  node.setState(state);
+  if (node.shouldHighlightConnectedEdges()) {
+    for (const edge of node.getConnectedEdges()) {
+      let nextEdgeState = NODE_TO_EDGE_STATE_MAP[state];
+      if (shouldEdgeBeSelected(edge)) {
+        nextEdgeState = 'selected';
+      }
+      edge.setState(nextEdgeState);
+    }
+  }
+}
+
+export function updateSelectedChain(
+  engine: {getNodes(): Node[]} | null,
+  chainId: string | null,
+  selectedNodeIdRef: MutableRefObject<string | null>
+): void {
+  if (!engine) {
+    selectedNodeIdRef.current = null;
+    return;
+  }
+
+  const nodes = engine.getNodes();
+  let targetNode: Node | null = null;
+  if (chainId) {
+    for (const node of nodes) {
+      if (!node.isSelectable()) {
+        continue;
+      }
+      const nodeChainId = getRepresentativeChainId(node);
+      if (nodeChainId === chainId) {
+        targetNode = node;
+        break;
+      }
+    }
+  }
+
+  const nextSelectedId = targetNode ? String(targetNode.getId()) : null;
+  if (selectedNodeIdRef.current === nextSelectedId) {
+    return;
+  }
+
+  for (const node of nodes) {
+    if (!node.isSelectable()) {
+      continue;
+    }
+    const nodeId = String(node.getId());
+    const nextState: NodeState = nextSelectedId && nodeId === nextSelectedId ? 'selected' : 'default';
+    setNodeInteractionState(node, nextState);
+  }
+
+  selectedNodeIdRef.current = nextSelectedId;
+}

--- a/examples/graph-layers/graph-viewer/shortcut-hints.tsx
+++ b/examples/graph-layers/graph-viewer/shortcut-hints.tsx
@@ -1,0 +1,79 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import React from 'react';
+
+import type {ShortcutHint} from './shortcuts';
+
+const shortcutsSectionStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.25rem',
+  padding: '0.75rem 0 0',
+  borderTop: '1px solid #cbd5f5',
+  marginTop: '0.75rem'
+};
+
+const shortcutHeadingStyle: React.CSSProperties = {
+  fontSize: '0.75rem',
+  fontWeight: 600,
+  color: '#0f172a'
+};
+
+const shortcutListStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.25rem',
+  margin: 0,
+  padding: 0,
+  listStyle: 'none',
+  fontSize: '0.75rem',
+  color: '#475569'
+};
+
+const shortcutItemStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem'
+};
+
+const shortcutKeyStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minWidth: '1.75rem',
+  padding: '0.125rem 0.5rem',
+  borderRadius: '0.25rem',
+  border: '1px solid #cbd5f5',
+  background: '#e2e8f0',
+  color: '#0f172a',
+  fontSize: '0.75rem',
+  fontFamily: 'inherit',
+  lineHeight: 1.2
+};
+
+export type ShortcutHintsProps = {
+  hints: ShortcutHint[];
+  heading?: string;
+};
+
+export function ShortcutHints({hints, heading = 'Keyboard shortcuts'}: ShortcutHintsProps) {
+  if (!hints.length) {
+    return null;
+  }
+
+  return (
+    <div style={shortcutsSectionStyle}>
+      <span style={shortcutHeadingStyle}>{heading}</span>
+      <ul style={shortcutListStyle}>
+        {hints.map(({key, description}) => (
+          <li key={`${key}-${description}`} style={shortcutItemStyle}>
+            <kbd style={shortcutKeyStyle}>{key}</kbd>
+            <span>{description}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/examples/graph-layers/graph-viewer/shortcuts.ts
+++ b/examples/graph-layers/graph-viewer/shortcuts.ts
@@ -1,0 +1,18 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export type ShortcutHint = {
+  key: string;
+  description: string;
+};
+
+export const TOGGLE_CHAIN_SHORTCUT = {
+  key: 't',
+  label: 'T',
+  description: 'Toggle focused chain'
+} as const;
+
+export const COLLAPSE_CONTROLS_SHORTCUTS: ShortcutHint[] = [
+  {key: TOGGLE_CHAIN_SHORTCUT.label, description: TOGGLE_CHAIN_SHORTCUT.description}
+];

--- a/examples/graph-layers/graph-viewer/use-toggle-chain-shortcut.ts
+++ b/examples/graph-layers/graph-viewer/use-toggle-chain-shortcut.ts
@@ -1,0 +1,70 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {useEffect} from 'react';
+
+import type {D3DagLayout} from '@deck.gl-community/graph-layers';
+
+import {isEditableElement} from './node-classification';
+import {TOGGLE_CHAIN_SHORTCUT} from './shortcuts';
+
+type DagChainSummary = {chainIds: string[]; collapsedIds: string[]};
+
+type UseToggleChainShortcutProps = {
+  enabled: boolean;
+  layout: D3DagLayout | null;
+  summary: DagChainSummary | null;
+  focusedChainId: string | null;
+};
+
+const TOGGLE_CHAIN_SHORTCUT_KEY = TOGGLE_CHAIN_SHORTCUT.key.toLowerCase();
+
+export function useToggleChainShortcut({
+  enabled,
+  layout,
+  summary,
+  focusedChainId
+}: UseToggleChainShortcutProps): void {
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return () => undefined;
+    }
+    if (!enabled || !layout) {
+      return () => undefined;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.repeat || event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+      if (event.key.toLowerCase() !== TOGGLE_CHAIN_SHORTCUT_KEY) {
+        return;
+      }
+      if (isEditableElement(event.target)) {
+        return;
+      }
+      const availableChainIds = summary?.chainIds ?? [];
+      if (availableChainIds.length === 0) {
+        return;
+      }
+
+      const activeChainId =
+        focusedChainId && availableChainIds.includes(focusedChainId)
+          ? focusedChainId
+          : availableChainIds[0] ?? null;
+
+      if (!activeChainId) {
+        return;
+      }
+
+      layout.toggleCollapsedChain(activeChainId);
+      event.preventDefault();
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [enabled, layout, summary, focusedChainId]);
+}


### PR DESCRIPTION
## Summary
- move the DAG chain toggle keyboard listener into a dedicated `useToggleChainShortcut` hook
- wire the graph viewer app to consume the hook and drop the inline shortcut effect

## Testing
- yarn lint
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_690a44aeb0f083288b779d33a26efc85