### PR TITLE
feat: integrate cosmos gpu layout

### DIFF
--- a/docs/modules/graph-layers/api-reference/layouts/experimental-layouts.md
+++ b/docs/modules/graph-layers/api-reference/layouts/experimental-layouts.md
@@ -2,11 +2,40 @@
 
 `@deck.gl-community/graph-layers` ships a set of experimental layouts that extend the base `GraphLayout` API. These layouts are
 ported from the archived [graph.gl](https://graph.gl) project and remain under active development. They are exported from the
-package as `RadialLayout`, `HivePlotLayout`, and `ForceMultiGraphLayout`.
+package as `CosmosLayout`, `RadialLayout`, `HivePlotLayout`, and `ForceMultiGraphLayout`.
 
 > **Note**
 > Experimental layouts may change between releases. They are provided to unblock migration work from graph.gl and to showcase
 > alternative ways of arranging dense graphs.
+
+## CosmosLayout
+
+`CosmosLayout` adapts the [cosmos.gl](https://cosmos.gl/) GPU simulation so it can be consumed through the standard `GraphLayout`
+interface. The adapter keeps the deck.gl graph in sync with the Cosmos controller, firing layout lifecycle events as the GPU
+simulation starts, ticks, and cools.
+
+> Install `cosmos.gl` alongside `@deck.gl-community/graph-layers` to use this adapter:
+>
+> ```bash
+> yarn add cosmos.gl
+> ```
+
+### Options
+
+- `cosmos` (`Record<string, unknown>`, default `{}`) – configuration object forwarded to `createCosmosLayout` from `cosmos.gl`.
+  Refer to the Cosmos documentation for supported knobs such as `cooldownTicks`, `springLength`, `repulsion`, and `gravity`.
+
+```tsx
+import {CosmosLayout} from '@deck.gl-community/graph-layers';
+
+const layout = new CosmosLayout({
+  cosmos: {
+    cooldownTicks: 240,
+    repulsion: 0.35,
+    springLength: 160
+  }
+});
+```
 
 ## RadialLayout
 

--- a/examples/graph-layers/graph-viewer/app.tsx
+++ b/examples/graph-layers/graph-viewer/app.tsx
@@ -29,7 +29,8 @@ import {
   RadialLayout,
   HivePlotLayout,
   ForceMultiGraphLayout,
-  D3DagLayout
+  D3DagLayout,
+  CosmosLayout
 } from '@deck.gl-community/graph-layers';
 
 import {extent} from 'd3-array';
@@ -61,6 +62,7 @@ const LAYOUT_FACTORIES: Record<LayoutType, LayoutFactory> = {
   'hive-plot-layout': (options) => new HivePlotLayout(options),
   'force-multi-graph-layout': (options) => new ForceMultiGraphLayout(options),
   'd3-dag-layout': (options) => new D3DagLayout(options),
+  'cosmos-layout': (options) => new CosmosLayout(options),
 };
 
 

--- a/examples/graph-layers/graph-viewer/control-panel.tsx
+++ b/examples/graph-layers/graph-viewer/control-panel.tsx
@@ -13,7 +13,8 @@ export type LayoutType =
   | 'radial-layout'
   | 'hive-plot-layout'
   | 'force-multi-graph-layout'
-  | 'd3-dag-layout';
+  | 'd3-dag-layout'
+  | 'cosmos-layout';
 
 export type ExampleStyles = NonNullable<GraphLayerProps['stylesheet']>;
 
@@ -46,6 +47,7 @@ const LAYOUT_LABELS: Record<LayoutType, string> = {
   'hive-plot-layout': 'Hive Plot Layout',
   'force-multi-graph-layout': 'Force Multi-Graph Layout',
   'd3-dag-layout': 'D3 DAG Layout',
+  'cosmos-layout': 'Cosmos GPU Layout'
 };
 
 export function ControlPanel({

--- a/examples/graph-layers/graph-viewer/examples.ts
+++ b/examples/graph-layers/graph-viewer/examples.ts
@@ -155,6 +155,26 @@ const WITS_REGION_STYLE: ExampleStyles = {
   }
 };
 
+const WITS_COSMOS_EXAMPLE: ExampleDefinition = {
+  name: 'World trade (Cosmos GPU layout)',
+  description:
+    'Applies the Cosmos GPU layout from cosmos.gl to the WITS trade network so the forces iterate entirely on the GPU.',
+  data: () => cloneGraphData(WITS_GRAPH_DATA),
+  layouts: ['cosmos-layout'],
+  layoutDescriptions: LAYOUT_DESCRIPTIONS,
+  style: WITS_REGION_STYLE,
+  getLayoutOptions: (layout, _data) =>
+    layout === 'cosmos-layout'
+      ? {
+          cosmos: {
+            cooldownTicks: 240,
+            repulsion: 0.35,
+            springLength: 160
+          }
+        }
+      : undefined
+};
+
 const KNOWLEDGE_GRAPH = {
   nodes: [
     {id: 'University', name: 'University', group: 'Overview'},
@@ -244,7 +264,9 @@ const LAYOUT_DESCRIPTIONS: Record<LayoutType, string> = {
   'force-multi-graph-layout':
     'Runs a tailored force simulation that keeps parallel edges legible by introducing virtual edges and spacing overlapping links.',
   'd3-dag-layout':
-    'Builds a directed acyclic graph layout using layered sugiyama algorithms with automatic edge routing and arrow decoration.'
+    'Builds a directed acyclic graph layout using layered sugiyama algorithms with automatic edge routing and arrow decoration.',
+  'cosmos-layout':
+    'Invokes the Cosmos GPU simulation from cosmos.gl to iterate the graph entirely on the GPU with configurable cooling and force strengths.'
 };
 
 const LES_MISERABLES_STYLE: ExampleStyles = {
@@ -692,7 +714,7 @@ export const EXAMPLES: ExampleDefinition[] = [
     name: 'Les Miserable',
     description: 'Social network of co-occurring characters in Les Miserables by Victor Hugo.',
     data: SAMPLE_GRAPH_DATASETS['Les Miserable'],
-    layouts: ['d3-force-layout', 'gpu-force-layout', 'simple-layout'],
+    layouts: ['d3-force-layout', 'gpu-force-layout', 'cosmos-layout', 'simple-layout'],
     layoutDescriptions: LAYOUT_DESCRIPTIONS,
     style: LES_MISERABLES_STYLE
   },
@@ -835,6 +857,7 @@ export const EXAMPLES: ExampleDefinition[] = [
           }
         : undefined
   },
+  WITS_COSMOS_EXAMPLE,
   {
     name: 'Community multi-graph',
     description:

--- a/modules/graph-layers/package.json
+++ b/modules/graph-layers/package.json
@@ -67,6 +67,12 @@
     "zod-to-json-schema": "^3.22.5"
   },
   "peerDependencies": {
+    "cosmos.gl": ">=0.5.0",
     "zod": "^3.23.8 || ^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "cosmos.gl": {
+      "optional": true
+    }
   }
 }

--- a/modules/graph-layers/src/index.ts
+++ b/modules/graph-layers/src/index.ts
@@ -20,6 +20,7 @@ export {GPUForceLayout} from './layouts/gpu-force/gpu-force-layout';
 export {RadialLayout} from './layouts/experimental/radial-layout';
 export {ForceMultiGraphLayout} from './layouts/experimental/force-multi-graph-layout';
 export {HivePlotLayout} from './layouts/experimental/hive-plot-layout';
+export {CosmosLayout} from './layouts/experimental/cosmos-layout';
 
 export type {Marker, NodeState, NodeType, EdgeType, EdgeDecoratorType, LayoutState} from './core/constants';
 

--- a/modules/graph-layers/src/layouts/experimental/cosmos-layout.ts
+++ b/modules/graph-layers/src/layouts/experimental/cosmos-layout.ts
@@ -1,0 +1,274 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Graph} from '../../graph/graph';
+import type {Node} from '../../graph/node';
+import type {Edge} from '../../graph/edge';
+import {GraphLayout, type GraphLayoutOptions} from '../../core/graph-layout';
+
+/* eslint-disable import/no-unresolved */
+import {
+  createCosmosLayout,
+  type CosmosLayoutConfig,
+  type CosmosLayoutController,
+  type CosmosGraph,
+  type CosmosNode,
+  type CosmosEdge
+} from 'cosmos.gl';
+/* eslint-enable import/no-unresolved */
+
+export type CosmosLayoutOptions = GraphLayoutOptions & {
+  /** Options forwarded to the cosmos.gl GPU layout implementation. */
+  cosmos?: CosmosLayoutConfig;
+};
+
+type EdgePosition = {
+  type: 'line';
+  sourcePosition: [number, number];
+  targetPosition: [number, number];
+  controlPoints: [number, number][];
+};
+
+/**
+ * Adapter that wraps the cosmos.gl GPU layout and exposes it through the GraphLayout interface.
+ */
+export class CosmosLayout extends GraphLayout<CosmosLayoutOptions> {
+  static defaultOptions: Required<CosmosLayoutOptions> = {
+    cosmos: {}
+  };
+
+  protected readonly _name = 'CosmosLayout';
+
+  private _graph: Graph | null = null;
+  private _cosmos: CosmosLayoutController | null = null;
+  private _nodePositions = new Map<string | number, [number, number]>();
+  private _edgePositions = new Map<string | number, EdgePosition>();
+  private _nodesById = new Map<string | number, Node>();
+  private _edgesById = new Map<string | number, Edge>();
+
+  private _handleStart = () => {
+    this._onLayoutStart();
+  };
+
+  private _handleTick = () => {
+    this._refreshPositionsFromCosmos();
+    this._onLayoutChange();
+  };
+
+  private _handleEnd = () => {
+    this._refreshPositionsFromCosmos();
+    this._onLayoutDone();
+  };
+
+  constructor(options: CosmosLayoutOptions = {}) {
+    super({...CosmosLayout.defaultOptions, ...options});
+  }
+
+  initializeGraph(graph: Graph): void {
+    this._graph = graph;
+    this._updateGraphCache(graph);
+    const cosmos = this._ensureCosmos();
+    cosmos.setOptions?.(this._options.cosmos ?? {});
+    cosmos.setGraph(this._toCosmosGraph(graph));
+    this._refreshPositionsFromCosmos();
+  }
+
+  updateGraph(graph: Graph): void {
+    this._graph = graph;
+    this._updateGraphCache(graph);
+    if (!this._cosmos) {
+      return;
+    }
+
+    this._cosmos.setOptions?.(this._options.cosmos ?? {});
+    this._cosmos.setGraph(this._toCosmosGraph(graph));
+    this._refreshPositionsFromCosmos();
+  }
+
+  start(): void {
+    this._ensureCosmos().start();
+  }
+
+  update(): void {
+    this._cosmos?.start();
+  }
+
+  resume(): void {
+    if (this._cosmos?.resume) {
+      this._cosmos.resume();
+      return;
+    }
+    this._cosmos?.start();
+  }
+
+  stop(): void {
+    this._cosmos?.stop?.();
+  }
+
+  getNodePosition(node: Node): [number, number] | null {
+    return this._nodePositions.get(node.getId()) ?? null;
+  }
+
+  getEdgePosition(edge: Edge): EdgePosition | null {
+    return this._edgePositions.get(edge.getId()) ?? null;
+  }
+
+  lockNodePosition(node: Node, x: number, y: number): void {
+    const id = node.getId();
+    this._nodePositions.set(id, [x, y]);
+    node.setDataProperty?.('x', x);
+    node.setDataProperty?.('y', y);
+    if (this._cosmos) {
+      if ('lockNode' in this._cosmos && typeof this._cosmos.lockNode === 'function') {
+        this._cosmos.lockNode(id, {x, y});
+      } else if ('pinNode' in this._cosmos && typeof (this._cosmos as any).pinNode === 'function') {
+        (this._cosmos as any).pinNode(id, {x, y});
+      }
+    }
+    this._refreshEdgePositions();
+    this._onLayoutChange();
+    this._onLayoutDone();
+  }
+
+  unlockNodePosition(node: Node): void {
+    const id = node.getId();
+    if (this._cosmos) {
+      if ('unlockNode' in this._cosmos && typeof this._cosmos.unlockNode === 'function') {
+        this._cosmos.unlockNode(id);
+      } else if ('unpinNode' in this._cosmos && typeof (this._cosmos as any).unpinNode === 'function') {
+        (this._cosmos as any).unpinNode(id);
+      }
+    }
+  }
+
+  destroy(): void {
+    if (this._cosmos) {
+      this._detachCosmosEventHandlers(this._cosmos);
+      this._cosmos.destroy?.();
+      this._cosmos = null;
+    }
+
+    this._nodePositions.clear();
+    this._edgePositions.clear();
+    this._nodesById.clear();
+    this._edgesById.clear();
+    this._graph = null;
+  }
+
+  private _ensureCosmos(): CosmosLayoutController {
+    if (this._cosmos) {
+      return this._cosmos;
+    }
+
+    const cosmos = createCosmosLayout(this._options.cosmos ?? {});
+    this._attachCosmosEventHandlers(cosmos);
+    this._cosmos = cosmos;
+    return cosmos;
+  }
+
+  private _attachCosmosEventHandlers(cosmos: CosmosLayoutController) {
+    cosmos.on?.('start', this._handleStart);
+    cosmos.on?.('tick', this._handleTick);
+    cosmos.on?.('end', this._handleEnd);
+
+    if (!cosmos.on && 'addEventListener' in cosmos) {
+      (cosmos as any).addEventListener?.('start', this._handleStart);
+      (cosmos as any).addEventListener?.('tick', this._handleTick);
+      (cosmos as any).addEventListener?.('end', this._handleEnd);
+    }
+  }
+
+  private _detachCosmosEventHandlers(cosmos: CosmosLayoutController) {
+    cosmos.off?.('start', this._handleStart);
+    cosmos.off?.('tick', this._handleTick);
+    cosmos.off?.('end', this._handleEnd);
+
+    if (!cosmos.off && 'removeEventListener' in cosmos) {
+      (cosmos as any).removeEventListener?.('start', this._handleStart);
+      (cosmos as any).removeEventListener?.('tick', this._handleTick);
+      (cosmos as any).removeEventListener?.('end', this._handleEnd);
+    }
+  }
+
+  private _updateGraphCache(graph: Graph) {
+    const nodes = graph.getNodes();
+    const edges = graph.getEdges();
+    this._nodesById = new Map(nodes.map((node) => [node.getId(), node]));
+    this._edgesById = new Map(edges.map((edge) => [edge.getId(), edge]));
+
+    const validNodeIds = new Set(this._nodesById.keys());
+    const validEdgeIds = new Set(this._edgesById.keys());
+    this._nodePositions = new Map(
+      Array.from(this._nodePositions.entries()).filter(([id]) => validNodeIds.has(id))
+    );
+    this._edgePositions = new Map(
+      Array.from(this._edgePositions.entries()).filter(([id]) => validEdgeIds.has(id))
+    );
+  }
+
+  private _toCosmosGraph(graph: Graph): CosmosGraph {
+    const nodes: CosmosNode[] = graph.getNodes().map((node) => {
+      const id = node.getId();
+      const x = Number(node.getPropertyValue('x'));
+      const y = Number(node.getPropertyValue('y'));
+      if (Number.isFinite(x) && Number.isFinite(y)) {
+        this._nodePositions.set(id, [x, y]);
+      }
+      return {
+        id,
+        position: Number.isFinite(x) && Number.isFinite(y) ? {x, y} : undefined,
+        locked: Boolean(node.getPropertyValue('locked'))
+      };
+    });
+
+    const edges: CosmosEdge[] = graph.getEdges().map((edge) => {
+      const rawWeight = (edge as any)?._data?.weight ?? (edge as any)?.weight;
+      const weight = Number(rawWeight);
+
+      return {
+        id: edge.getId(),
+        source: edge.getSourceNodeId(),
+        target: edge.getTargetNodeId(),
+        weight: Number.isFinite(weight) ? weight : undefined
+      };
+    });
+
+    return {nodes, edges};
+  }
+
+  private _refreshPositionsFromCosmos(): void {
+    if (!this._cosmos || !this._graph) {
+      return;
+    }
+
+    for (const [id, node] of this._nodesById) {
+      const position = this._cosmos.getNodePosition?.(id);
+      if (position && Number.isFinite(position.x) && Number.isFinite(position.y)) {
+        const coordinates: [number, number] = [position.x, position.y];
+        this._nodePositions.set(id, coordinates);
+        node.setDataProperty?.('x', position.x);
+        node.setDataProperty?.('y', position.y);
+      }
+    }
+
+    this._refreshEdgePositions();
+  }
+
+  private _refreshEdgePositions(): void {
+    for (const [edgeId, edge] of this._edgesById) {
+      const source = this._nodePositions.get(edge.getSourceNodeId());
+      const target = this._nodePositions.get(edge.getTargetNodeId());
+      if (source && target) {
+        this._edgePositions.set(edgeId, {
+          type: 'line',
+          sourcePosition: source,
+          targetPosition: target,
+          controlPoints: []
+        });
+      } else {
+        this._edgePositions.delete(edgeId);
+      }
+    }
+  }
+}

--- a/modules/graph-layers/src/types/cosmos-gl.d.ts
+++ b/modules/graph-layers/src/types/cosmos-gl.d.ts
@@ -1,0 +1,46 @@
+declare module 'cosmos.gl' {
+  export type CosmosLayoutConfig = Record<string, unknown>;
+
+  export type CosmosNode = {
+    id: string | number;
+    position?: {x: number; y: number; z?: number};
+    locked?: boolean;
+    [key: string]: unknown;
+  };
+
+  export type CosmosEdge = {
+    id: string | number;
+    source: string | number;
+    target: string | number;
+    weight?: number;
+    [key: string]: unknown;
+  };
+
+  export type CosmosGraph = {
+    nodes: CosmosNode[];
+    edges: CosmosEdge[];
+  };
+
+  export type CosmosEvent = 'start' | 'tick' | 'end';
+
+  export type CosmosEventHandler = () => void;
+
+  export interface CosmosLayoutController {
+    setOptions?(options: CosmosLayoutConfig): void;
+    setGraph(graph: CosmosGraph): void;
+    start(): void;
+    update?(): void;
+    resume?(): void;
+    stop?(): void;
+    destroy?(): void;
+    on?(event: CosmosEvent, handler: CosmosEventHandler): void;
+    off?(event: CosmosEvent, handler: CosmosEventHandler): void;
+    addEventListener?(event: CosmosEvent, handler: CosmosEventHandler): void;
+    removeEventListener?(event: CosmosEvent, handler: CosmosEventHandler): void;
+    getNodePosition?(id: string | number): {x: number; y: number; z?: number} | null | undefined;
+    lockNode?(id: string | number, position?: {x: number; y: number}): void;
+    unlockNode?(id: string | number): void;
+  }
+
+  export function createCosmosLayout(options?: CosmosLayoutConfig): CosmosLayoutController;
+}

--- a/modules/graph-layers/test/layouts/cosmos-layout.spec.ts
+++ b/modules/graph-layers/test/layouts/cosmos-layout.spec.ts
@@ -1,0 +1,177 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {Graph} from '../../src/graph/graph';
+import {Node} from '../../src/graph/node';
+import {Edge} from '../../src/graph/edge';
+import {CosmosLayout} from '../../src/layouts/experimental/cosmos-layout';
+
+vi.mock('cosmos.gl', () => {
+  type Handler = () => void;
+  type HandlerMap = Record<'start' | 'tick' | 'end', Set<Handler>>;
+
+  const instances: any[] = [];
+
+  class MockCosmos {
+    handlers: HandlerMap = {
+      start: new Set(),
+      tick: new Set(),
+      end: new Set()
+    };
+    graph = {nodes: [], edges: []} as any;
+    options: Record<string, unknown> = {};
+    locked = new Map<string | number, {x: number; y: number}>();
+
+    constructor(options?: Record<string, unknown>) {
+      if (options) {
+        this.options = {...options};
+      }
+      instances.push(this);
+    }
+
+    setOptions(options?: Record<string, unknown>) {
+      this.options = {...(options ?? {})};
+    }
+
+    setGraph(graph: any) {
+      this.graph = {
+        nodes: graph.nodes.map((node: any) => ({...node})),
+        edges: graph.edges.map((edge: any) => ({...edge}))
+      };
+    }
+
+    start() {
+      this.handlers.start.forEach((handler) => handler());
+      this._simulateTick();
+      this.handlers.tick.forEach((handler) => handler());
+      this.handlers.end.forEach((handler) => handler());
+    }
+
+    resume() {
+      this.start();
+    }
+
+    stop() {}
+
+    destroy() {}
+
+    on(event: 'start' | 'tick' | 'end', handler: Handler) {
+      this.handlers[event].add(handler);
+    }
+
+    off(event: 'start' | 'tick' | 'end', handler: Handler) {
+      this.handlers[event].delete(handler);
+    }
+
+    getNodePosition(id: string | number) {
+      const node = this.graph.nodes.find((candidate: any) => candidate.id === id);
+      return node?.position ?? null;
+    }
+
+    lockNode(id: string | number, position?: {x: number; y: number}) {
+      const coords = position ?? {x: 0, y: 0};
+      this.locked.set(id, {...coords});
+      const node = this.graph.nodes.find((candidate: any) => candidate.id === id);
+      if (node) {
+        node.position = {...coords};
+      }
+    }
+
+    unlockNode(id: string | number) {
+      this.locked.delete(id);
+    }
+
+    private _simulateTick() {
+      this.graph.nodes.forEach((node: any, index: number) => {
+        const locked = this.locked.get(node.id);
+        if (locked) {
+          node.position = {...locked};
+          return;
+        }
+        const x = index * 12;
+        const y = index === 0 ? 0 : -index * 7;
+        node.position = {x, y};
+      });
+    }
+  }
+
+  return {
+    createCosmosLayout: (options?: Record<string, unknown>) => new MockCosmos(options),
+    __getMockInstances: () => instances,
+    __resetMockInstances: () => {
+      instances.splice(0, instances.length);
+    }
+  };
+});
+
+async function loadMockCosmosModule() {
+  return (await import('cosmos.gl')) as any;
+}
+
+beforeEach(async () => {
+  const cosmosModule = await loadMockCosmosModule();
+  cosmosModule.__resetMockInstances();
+});
+
+describe('CosmosLayout', () => {
+  it('runs the cosmos.gl layout and exposes updated positions', async () => {
+    const nodes = ['a', 'b', 'c'].map((id) => new Node({id}));
+    const edges = [
+      new Edge({id: 'ab', sourceId: 'a', targetId: 'b'}),
+      new Edge({id: 'bc', sourceId: 'b', targetId: 'c'})
+    ];
+    const graph = new Graph({nodes, edges});
+
+    const layout = new CosmosLayout({cosmos: {cooldownTicks: 42}});
+    const onStart = vi.fn();
+    const onUpdate = vi.fn();
+    const onDone = vi.fn();
+
+    layout.addEventListener('onLayoutStart', onStart);
+    layout.addEventListener('onLayoutChange', onUpdate);
+    layout.addEventListener('onLayoutDone', onDone);
+
+    layout.initializeGraph(graph);
+    layout.start();
+
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onDone).toHaveBeenCalledTimes(1);
+
+    expect(layout.getNodePosition(nodes[0])).toEqual([0, 0]);
+    expect(layout.getNodePosition(nodes[1])).toEqual([12, -7]);
+    expect(layout.getNodePosition(nodes[2])).toEqual([24, -14]);
+
+    const edgeAB = layout.getEdgePosition(edges[0]);
+    expect(edgeAB).toEqual({
+      type: 'line',
+      sourcePosition: [0, 0],
+      targetPosition: [12, -7],
+      controlPoints: []
+    });
+
+    const cosmosModule = await loadMockCosmosModule();
+    const mockInstance = cosmosModule.__getMockInstances().at(-1);
+    expect(mockInstance.options).toEqual({cooldownTicks: 42});
+  });
+
+  it('locks nodes through the cosmos controller', async () => {
+    const nodes = ['p', 'q'].map((id) => new Node({id}));
+    const edges = [new Edge({id: 'pq', sourceId: 'p', targetId: 'q'})];
+    const graph = new Graph({nodes, edges});
+
+    const layout = new CosmosLayout();
+    layout.initializeGraph(graph);
+    layout.start();
+
+    layout.lockNodePosition(nodes[0], 120, -36);
+
+    expect(layout.getNodePosition(nodes[0])).toEqual([120, -36]);
+
+    const cosmosModule = await loadMockCosmosModule();
+    const mockInstance = cosmosModule.__getMockInstances().at(-1);
+    expect(mockInstance.locked.get('p')).toEqual({x: 120, y: -36});
+  });
+});


### PR DESCRIPTION
## Summary
- add a CosmosLayout adapter that wraps cosmos.gl, exports it from graph-layers, and declare the module typing
- document the new layout and expose it through the graph viewer example with cosmos-specific presets
- cover the integration with a vitest suite that mocks cosmos.gl

## Testing
- yarn lint
- yarn vitest run --project node modules/graph-layers/test/layouts/cosmos-layout.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_690a5b999db88328a86a1cff71bdf03c