### PR TITLE
Normalize text max width before rendering

### DIFF
--- a/modules/graph-layers/src/layers/common-layers/zoomable-text-layer/zoomable-text-layer.ts
+++ b/modules/graph-layers/src/layers/common-layers/zoomable-text-layer/zoomable-text-layer.ts
@@ -5,6 +5,23 @@
 import {CompositeLayer} from '@deck.gl/core';
 import {TextLayer} from '@deck.gl/layers';
 
+const TEXT_LAYER_MAX_SAFE_WIDTH = 32767;
+
+const clampMaxWidth = (value: unknown) => {
+  const width = Number(value);
+  if (!Number.isFinite(width) || width <= 0) {
+    return TEXT_LAYER_MAX_SAFE_WIDTH;
+  }
+  return Math.min(width, TEXT_LAYER_MAX_SAFE_WIDTH);
+};
+
+export const normalizeTextMaxWidth = (value: unknown) => {
+  if (typeof value === 'function') {
+    return (d: unknown) => clampMaxWidth((value as (arg0: unknown) => unknown)(d));
+  }
+  return clampMaxWidth(value);
+};
+
 export class ZoomableTextLayer extends CompositeLayer {
   static layerName = 'ZoomableTextLayer';
 
@@ -39,6 +56,7 @@ export class ZoomableTextLayer extends CompositeLayer {
     const sizeUpdateTrigger = scaleWithZoom ? [getSize, this.context.viewport.zoom] : false;
     // getText only expects function not plain value (string)
     const newGetText = typeof getText === 'function' ? getText : () => getText;
+    const resolvedMaxWidth = normalizeTextMaxWidth(textMaxWidth);
 
     // Filter data to items that have non-empty text to avoid deck.gl 9.3
     // MultiIconLayer attribute validation errors with undefined/empty labels
@@ -72,7 +90,7 @@ export class ZoomableTextLayer extends CompositeLayer {
           getAlignmentBaseline,
           getAngle,
           getText: safeGetText,
-          maxWidth: textMaxWidth ?? 12,
+          maxWidth: resolvedMaxWidth,
           wordBreak: textWordBreak ?? 'break-all',
           fontFamily: fontFamily ?? 'sans-serif',
           wordUnits: textWordUnits ?? 'pixels',

--- a/modules/graph-layers/test/layers/zoomable-text-layer.spec.ts
+++ b/modules/graph-layers/test/layers/zoomable-text-layer.spec.ts
@@ -1,0 +1,33 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, it, expect} from 'vitest';
+
+import {normalizeTextMaxWidth} from '../../src/layers/common-layers/zoomable-text-layer/zoomable-text-layer';
+
+const TEXT_LAYER_MAX_SAFE_WIDTH = 32767;
+
+describe('ZoomableTextLayer helpers', () => {
+  it('normalizes invalid max width values to a safe TextLayer width', () => {
+    expect(normalizeTextMaxWidth(undefined)).toBe(TEXT_LAYER_MAX_SAFE_WIDTH);
+    expect(normalizeTextMaxWidth(Number.NaN)).toBe(TEXT_LAYER_MAX_SAFE_WIDTH);
+    expect(normalizeTextMaxWidth(0)).toBe(TEXT_LAYER_MAX_SAFE_WIDTH);
+    expect(normalizeTextMaxWidth(-1)).toBe(TEXT_LAYER_MAX_SAFE_WIDTH);
+  });
+
+  it('clamps large max width values to TextLayer attribute limits', () => {
+    expect(normalizeTextMaxWidth(100)).toBe(100);
+    expect(normalizeTextMaxWidth('120')).toBe(120);
+    expect(normalizeTextMaxWidth(50000)).toBe(TEXT_LAYER_MAX_SAFE_WIDTH);
+  });
+
+  it('normalizes max width accessors per datum', () => {
+    const getMaxWidth = normalizeTextMaxWidth((d: {width?: unknown}) => d.width);
+
+    expect(getMaxWidth({width: 32})).toBe(32);
+    expect(getMaxWidth({width: '64'})).toBe(64);
+    expect(getMaxWidth({width: Number.NaN})).toBe(TEXT_LAYER_MAX_SAFE_WIDTH);
+    expect(getMaxWidth({width: 50000})).toBe(TEXT_LAYER_MAX_SAFE_WIDTH);
+  });
+});


### PR DESCRIPTION
## Summary
- refresh this stale PR onto current `master` as a focused graph-layers fix
- normalize `ZoomableTextLayer` `textMaxWidth` values before passing them to `TextLayer`
- clamp invalid, zero, negative, `NaN`, and overly large scalar/accessor widths to a TextLayer-safe max width
- add unit coverage for scalar and accessor normalization

## Classification
Bug fix / internal rendering guard.

## Visual proof
Not applicable: this does not add or change an example route or user-facing UI flow. The changed behavior is covered by focused unit tests plus package/repo validation.

## Validation
- `yarn`
- `yarn test-node modules/graph-layers/test/layers/zoomable-text-layer.spec.ts`
- `yarn test-node modules/graph-layers/test`
- `yarn lint`
- `yarn build`
- pre-commit `yarn test`

## Notes
- Dropped the old removed graph-viewer panel edit from the stale branch so the PR now contains only the still-applicable `ZoomableTextLayer` fix.
- `yarn build` still prints the existing `import.meta` CJS warnings in graph-layers/panels.