### PR TITLE
chore: add update-release-branch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test-node": "vitest --project node",
     "test-browser": "vitest --project browser",
     "test-headless": "vitest run --project headless",
-    "metrics": "ocular-metrics"
+    "metrics": "ocular-metrics",
+    "update-release-branch": "scripts/update-release-branch.sh"
   },
   "devDependencies": {
     "@deck.gl/aggregation-layers": "~9.2.1",

--- a/scripts/update-release-branch.sh
+++ b/scripts/update-release-branch.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Example:
+# update-release-branch.sh 9.2
+
+set -e
+
+BRANCH=`echo "$1-release"`
+VERSION=`echo "$1.0"`
+WEBSITE_PAGES=website/src/constants/defaults.js
+
+echo "Updating branch to ${BRANCH}..."
+
+# Replace source links in docs
+find docs -iname "*.md" -type f -exec sed -i '' -E "s/deck.gl-community\/(tree|blob)\/master\/modules/deck.gl-community\/tree\/${BRANCH}\/modules/g" {} \;
+find docs -iname "*.md" -type f -exec sed -i '' -E "s/deck.gl-community\/(tree|blob)\/master\/examples/deck.gl-community\/tree\/${BRANCH}\/examples/g" {} \;
+
+# Replace source links in website
+sed -i '' -E "s/deck.gl-community\/tree\/master/deck.gl-community\/tree\/${BRANCH}/g" "${WEBSITE_PAGES}"
+
+# Bump dependencies in examples
+update_dep() {
+  FILE=$1
+  VERSION=$2
+  cat $FILE | jq ".dependencies |= . + \
+  with_entries(select(.key | match(\"@deck.gl-community\")) | .value |= \"~${VERSION}\")" > temp
+  mv temp $FILE
+}
+
+# https://stackoverflow.com/questions/4321456/find-exec-a-shell-function-in-linux
+export -f update_dep
+find examples/*/*/package.json -exec bash -c 'update_dep "$0" $1' {} $VERSION \;


### PR DESCRIPTION
The deck.gl repo has a [script](https://github.com/visgl/deck.gl/blob/master/scripts/update-release-branch.sh) for updating which is referenced in the [release process](https://github.com/visgl/tsc/blob/master/developer-process/publish-checklist.md#cut-the-release-branch).

I'm proposing we add this script also to the community repo for consistency and cut a `9.2-release` branch to do the release like we do on the deck.gl repo (in the past we've published directly from `master` on deck.gl-community).