### PR TITLE
Mark geo-layers as public for npm publishing

### DIFF
--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -3,6 +3,9 @@
   "version": "9.2.0-beta.2",
   "description": "Add-0n geospatial layers for deck.gl",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "layers",
     "visualization",


### PR DESCRIPTION
The CI release failed for the new `geo-layers` package, my best guess is becuase the `publishConfig` is missing: https://github.com/visgl/deck.gl-community/actions/runs/19171290337/job/54804293153

@ibgreen is it your intention to have this be published? If not we should mark it as private

