### PR TITLE
Publish leaflet package

### DIFF
--- a/modules/leaflet/package.json
+++ b/modules/leaflet/package.json
@@ -1,9 +1,8 @@
 {
   "name": "@deck.gl-community/leaflet",
-  "private": true,
   "description": "deck.gl integration with Leaflet",
   "license": "MIT",
-  "version": "9.2.0",
+  "version": "9.2.0-beta.2",
   "publishConfig": {
     "access": "public"
   },
@@ -14,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/visgl/deck.gl-community.gl.git"
+    "url": "https://github.com/visgl/deck.gl-community"
   },
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
As discussed a while back, we want to publish the leaflet package from deck.gl-community going forward. Please confirm