### PR TITLE
Stream D3 force layout tick updates

### DIFF
--- a/modules/graph-layers/src/layouts/d3-force/d3-force-layout.ts
+++ b/modules/graph-layers/src/layouts/d3-force/d3-force-layout.ts
@@ -97,20 +97,14 @@ export class D3ForceLayout extends GraphLayout<D3ForceLayoutOptions> {
 
     this._worker.onmessage = event => {
       log.log(0, 'D3ForceLayout: worker message', event.data?.type, event.data);
-      if (event.data.type !== 'end') {
-        return;
+      if (event.data.type === 'tick') {
+        this._applyWorkerNodes(event.data.nodes);
+        this._onLayoutChange();
+      } else if (event.data.type === 'end') {
+        this._applyWorkerNodes(event.data.nodes);
+        this._onLayoutChange();
+        this._onLayoutDone();
       }
-
-      event.data.nodes.forEach(({id, ...d3}) =>
-        this._positionsByNodeId.set(id, {
-          ...d3,
-          // precompute so that when we return the node position we do not need to do the conversion
-          coordinates: [d3.x, d3.y]
-        })
-      );
-
-      this._onLayoutChange();
-      this._onLayoutDone();
     };
   }
 
@@ -195,5 +189,25 @@ export class D3ForceLayout extends GraphLayout<D3ForceLayoutOptions> {
       data => data?.coordinates as [number, number] | null | undefined
     );
     this._bounds = this._calculateBounds(positions);
+  }
+
+  private _applyWorkerNodes(nodes: unknown): void {
+    if (!Array.isArray(nodes)) {
+      return;
+    }
+
+    for (const item of nodes) {
+      if (!item || typeof item !== 'object') {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
+      const {id, ...d3} = item as {id: string | number; x?: number; y?: number};
+      this._positionsByNodeId.set(id, {
+        ...d3,
+        // Precompute so getNodePosition does not need to convert every lookup.
+        coordinates: [d3.x, d3.y]
+      });
+    }
   }
 }

--- a/modules/graph-layers/src/layouts/d3-force/worker.js
+++ b/modules/graph-layers/src/layouts/d3-force/worker.js
@@ -37,18 +37,16 @@ onmessage = function (event) {
     // @ts-expect-error TODO
     .force('collision', d3.forceCollide().radius(getCollisionRadius))
     .stop();
-  for (
-    let i = 0,
-      n = Math.ceil(Math.log(simulation.alphaMin()) / Math.log(1 - simulation.alphaDecay()));
-    i < n;
-    ++i
-  ) {
+  const n = Math.ceil(Math.log(simulation.alphaMin()) / Math.log(1 - simulation.alphaDecay()));
+  for (let i = 0; i < n; ++i) {
+    simulation.tick();
     postMessage({
       type: 'tick',
-      progress: i / n,
+      progress: n === 0 ? 1 : (i + 1) / n,
+      nodes,
+      edges,
       options: event.data.options
     });
-    simulation.tick();
   }
   postMessage({
     type: 'end',

--- a/modules/graph-layers/test/layouts/d3-force-layout.spec.ts
+++ b/modules/graph-layers/test/layouts/d3-force-layout.spec.ts
@@ -1,0 +1,98 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {D3ForceLayout} from '../../src/layouts/d3-force/d3-force-layout';
+import {ClassicGraph} from '../../src/graph/classic-graph';
+
+class FakeWorker {
+  static latest: FakeWorker | null = null;
+
+  onmessage: ((event: {data: unknown}) => void) | null = null;
+  postMessage = vi.fn();
+  terminate = vi.fn();
+
+  constructor(_url: string) {
+    FakeWorker.latest = this;
+  }
+
+  emit(data: unknown): void {
+    this.onmessage?.({data});
+  }
+}
+
+function createGraph(): ClassicGraph {
+  return new ClassicGraph({
+    data: {
+      shape: 'plain-graph-data',
+      nodes: [{id: 'a'}, {id: 'b'}],
+      edges: [{id: 'ab', sourceId: 'a', targetId: 'b'}]
+    }
+  });
+}
+
+describe('D3ForceLayout', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    FakeWorker.latest = null;
+  });
+
+  it('streams worker tick positions before the final layout event', () => {
+    vi.stubGlobal('Worker', FakeWorker);
+
+    const events: string[] = [];
+    const graph = createGraph();
+    const layout = new D3ForceLayout({
+      onLayoutStart: () => events.push('start'),
+      onLayoutChange: () => events.push('change'),
+      onLayoutDone: () => events.push('done')
+    });
+
+    layout.initializeGraph(graph);
+    layout.start();
+
+    const worker = FakeWorker.latest;
+    expect(worker).not.toBeNull();
+    expect(events).toEqual(['start']);
+
+    worker?.emit({
+      type: 'tick',
+      nodes: [
+        {id: 'a', x: 1, y: 2},
+        {id: 'b', x: 3, y: 4}
+      ]
+    });
+
+    const nodeA = graph.findNode('a');
+    const nodeB = graph.findNode('b');
+    const edge = Array.from(graph.getEdges())[0];
+
+    expect(events).toEqual(['start', 'change']);
+    expect(layout.getNodePosition(nodeA ?? null)).toEqual([1, 2]);
+    expect(layout.getNodePosition(nodeB ?? null)).toEqual([3, 4]);
+    expect(layout.getEdgePosition(edge)?.sourcePosition).toEqual([1, 2]);
+    expect(layout.getEdgePosition(edge)?.targetPosition).toEqual([3, 4]);
+    expect(layout.getBounds()).toEqual([
+      [1, 2],
+      [3, 4]
+    ]);
+
+    worker?.emit({
+      type: 'end',
+      nodes: [
+        {id: 'a', x: 5, y: 6},
+        {id: 'b', x: 7, y: 8}
+      ]
+    });
+
+    expect(events).toEqual(['start', 'change', 'change', 'done']);
+    expect(layout.getNodePosition(nodeA ?? null)).toEqual([5, 6]);
+    expect(layout.getNodePosition(nodeB ?? null)).toEqual([7, 8]);
+    expect(layout.getBounds()).toEqual([
+      [5, 6],
+      [7, 8]
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- refreshes this stale branch onto current `master` as a focused D3 force layout streaming fix
- sends mutated node/edge snapshots with each worker `tick` message after simulation advances
- updates `D3ForceLayout` cached node positions on both `tick` and `end`, so layout-change callbacks expose current positions and bounds before final completion
- adds mocked-worker regression coverage for tick-time node/edge positions, bounds, and lifecycle events

## Classification
Refactor/internal behavior fix for graph-layers layout streaming. Visual proof is not applicable because this changes internal D3 force layout worker callback timing and is covered by automated layout tests, not a rendered UI or example route.

## Validation
- `yarn`
- `yarn test-node modules/graph-layers/test/layouts/d3-force-layout.spec.ts`
- `yarn test-node modules/graph-layers/test`
- `yarn lint-fix`
- `yarn lint`
- `yarn build` (passes with existing `import.meta` CJS warnings in graph-layers/panels)
- pre-commit `yarn test` (164 files passed, 1380 tests passed, 9 skipped)

## Residual risk
Low. The branch deliberately drops the old TypeScript-worker rewrite and keeps the current worker structure; each tick now emits full node/edge snapshots, which matches the existing final-message payload shape and avoids introducing a new serialization contract.
