### PR TITLE
Skip Playwright downloads in restricted environments

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+playwright_skip_browser_download=true

--- a/README.md
+++ b/README.md
@@ -41,6 +41,25 @@ An awesome list of community-driven modules, integrations, and tools built with 
 
 ---
 
+## Troubleshooting
+
+### Playwright browser dependencies
+
+In restricted or offline environments, `playwright` can fail during `yarn install` when it tries
+to download Chromium binaries. The repository `.npmrc` sets
+`playwright_skip_browser_download=true` so installs can proceed without fetching browsers.
+
+When network access is available, install the Chromium browser binary before running the browser or
+headless Vitest projects:
+
+```bash
+npx playwright install --with-deps chromium
+```
+
+This is the same command used by CI and provides the runtime required by Playwright-powered tests.
+
+---
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md). New modules, bug fixes, and ecosystem additions are all welcome.


### PR DESCRIPTION
## Summary

Updates the existing restricted-install PR against current `master`.

- adds a root `.npmrc` with `playwright_skip_browser_download=true` so `yarn install` does not try to download Playwright browser binaries in restricted/offline environments
- documents how to install Chromium manually before running the browser or headless Vitest projects
- preserves the current README module catalog while adding the troubleshooting note

## Classification

Dependency/infra + documentation. Visual proof is not applicable because this changes package-manager install behavior and README guidance, not rendered docs, examples, UI, or interaction behavior.

## Validation

- `yarn`
- `yarn lint`
- `git diff --check origin/master...HEAD`

`yarn` completed with the repo's existing peer-dependency warnings for Vitest/Zod packages and no lockfile changes.

## Residual Risk

Developers who need Playwright browser tests locally must run `npx playwright install --with-deps chromium` once after install, as documented. CI already installs browsers explicitly.
