### PR TITLE
Ensure GPUForceLayout start events fire reliably

### DIFF
--- a/modules/graph-layers/src/layouts/gpu-force/gpu-force-layout.ts
+++ b/modules/graph-layers/src/layouts/gpu-force/gpu-force-layout.ts
@@ -87,6 +87,7 @@ export class GPUForceLayout extends GraphLayout<GPUForceLayoutOptions> {
   }
 
   start() {
+    this._onLayoutStart();
     this._engageWorker();
   }
 
@@ -95,9 +96,9 @@ export class GPUForceLayout extends GraphLayout<GPUForceLayoutOptions> {
   }
 
   _engageWorker() {
-    // prevent multiple start
     if (this._worker) {
       this._worker.terminate();
+      this._worker = null;
     }
 
     this._worker = new Worker(new URL('./worker.js', import.meta.url).href);
@@ -127,17 +128,34 @@ export class GPUForceLayout extends GraphLayout<GPUForceLayoutOptions> {
       }
     };
   }
-  ticked(data) {}
+  ticked(data) {
+    const nodesUpdated = this._applyWorkerNodes(data?.nodes);
+    if (!nodesUpdated) {
+      return;
+    }
+
+    if (Array.isArray(data?.edges) && data.edges.length > 0) {
+      this._applyWorkerEdges(data.edges);
+    }
+
+    this._graph?.triggerUpdate?.();
+    this._onLayoutChange();
+  }
   ended(data) {
     const {nodes, edges} = data;
     this.updateD3Graph({nodes, edges});
     this._onLayoutChange();
     this._onLayoutDone();
+    this._disengageWorker();
   }
   resume() {
     throw new Error('Resume unavailable');
   }
   stop() {
+    this._disengageWorker();
+  }
+
+  private _disengageWorker() {
     if (this._worker) {
       this._worker.terminate();
       this._worker = null;
@@ -219,6 +237,73 @@ export class GPUForceLayout extends GraphLayout<GPUForceLayoutOptions> {
     this._graph?.triggerUpdate?.();
     this._edgeMap = newEdgeMap;
     this._d3Graph.edges = newD3Edges;
+  }
+
+  private _applyWorkerNodes(nodes: any[] | undefined): boolean {
+    if (!Array.isArray(nodes) || nodes.length === 0) {
+      return false;
+    }
+
+    for (const node of nodes) {
+      const existingNode = this._nodeMap.get(node.id);
+      if (existingNode) {
+        existingNode.x = node.x;
+        existingNode.y = node.y;
+        if ('fx' in node) {
+          existingNode.fx = node.fx;
+        }
+        if ('fy' in node) {
+          existingNode.fy = node.fy;
+        }
+        if ('locked' in node) {
+          existingNode.locked = node.locked;
+        }
+        if ('collisionRadius' in node) {
+          existingNode.collisionRadius = node.collisionRadius;
+        }
+      } else {
+        const newNode = {...node};
+        this._nodeMap.set(node.id, newNode);
+        this._d3Graph.nodes.push(newNode);
+      }
+    }
+
+    return true;
+  }
+
+  private _applyWorkerEdges(edges: any[]): void {
+    for (const edge of edges) {
+      const sourceId = this._resolveNodeId(edge.source);
+      const targetId = this._resolveNodeId(edge.target);
+      const source = sourceId === undefined ? undefined : this._nodeMap.get(sourceId);
+      const target = targetId === undefined ? undefined : this._nodeMap.get(targetId);
+
+      if (!source || !target) {
+        continue;
+      }
+
+      const existingEdge = this._edgeMap.get(edge.id);
+      if (existingEdge) {
+        existingEdge.source = source;
+        existingEdge.target = target;
+      } else {
+        const newEdge = {
+          ...edge,
+          source,
+          target
+        };
+        this._edgeMap.set(edge.id, newEdge);
+        this._d3Graph.edges.push(newEdge);
+      }
+    }
+  }
+
+  private _resolveNodeId(node: any): string | number | undefined {
+    if (node && typeof node === 'object') {
+      return node.id;
+    }
+
+    return node;
   }
 
   getNodePosition = (node: NodeInterface): [number, number] => {

--- a/modules/graph-layers/test/core/graph-engine.spec.ts
+++ b/modules/graph-layers/test/core/graph-engine.spec.ts
@@ -2,10 +2,102 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {describe, it, expect} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import type {GraphLayoutEventDetail} from '../../src/core/graph-layout';
+import {GraphEngine} from '../../src/core/graph-engine';
+import {ClassicGraph} from '../../src/graph/classic-graph';
+import {Edge} from '../../src/graph/edge';
+import {Node} from '../../src/graph/node';
+import {GPUForceLayout} from '../../src/layouts/gpu-force/gpu-force-layout';
+
+class MockWorker {
+  static lastInstance: MockWorker | null = null;
+
+  onmessage: ((event: {data: any}) => void) | null = null;
+
+  constructor(_url: string) {
+    MockWorker.lastInstance = this;
+  }
+
+  postMessage(_data: unknown) {}
+
+  terminate() {}
+}
 
 describe('core/graph-engine', () => {
-  it('nothing', () => {
-    expect(1).toBe(1);
+  const originalWorker = globalThis.Worker;
+
+  beforeEach(() => {
+    globalThis.Worker = MockWorker as unknown as typeof Worker;
+  });
+
+  afterEach(() => {
+    globalThis.Worker = originalWorker;
+    MockWorker.lastInstance = null;
+  });
+
+  it('fires onLayoutStart when GPUForceLayout starts', () => {
+    const layout = new GPUForceLayout();
+    const graph = createGraph();
+    const onLayoutStart = vi.fn();
+    const engine = new GraphEngine({graph, layout, onLayoutStart});
+
+    engine.run();
+
+    expect(onLayoutStart).toHaveBeenCalledTimes(1);
+
+    MockWorker.lastInstance?.onmessage?.({
+      data: {type: 'end', nodes: [], edges: []}
+    });
+
+    engine.stop();
+    engine.clear();
+  });
+
+  it('updates bounds on each GPUForceLayout tick event', () => {
+    const layout = new GPUForceLayout();
+    const graph = createGraph();
+    const onLayoutChange = vi.fn();
+    const engine = new GraphEngine({graph, layout, onLayoutChange});
+
+    engine.run();
+
+    const tickNodes = [
+      {id: 'a', x: 10, y: 5, fx: null, fy: null, locked: false, collisionRadius: 0},
+      {id: 'b', x: 110, y: 105, fx: null, fy: null, locked: false, collisionRadius: 0}
+    ];
+    const tickEdges = [
+      {
+        id: 'edge-a-b',
+        source: tickNodes[0],
+        target: tickNodes[1]
+      }
+    ];
+
+    MockWorker.lastInstance?.onmessage?.({
+      data: {type: 'tick', nodes: tickNodes, edges: tickEdges}
+    });
+
+    expect(onLayoutChange).toHaveBeenCalled();
+    const lastEvent = onLayoutChange.mock.calls.at(-1)?.[0] as GraphLayoutEventDetail;
+    expect(lastEvent?.bounds).toEqual([
+      [10, 5],
+      [110, 105]
+    ]);
+
+    MockWorker.lastInstance?.onmessage?.({
+      data: {type: 'end', nodes: tickNodes, edges: tickEdges}
+    });
+
+    engine.stop();
+    engine.clear();
   });
 });
+
+function createGraph(): ClassicGraph {
+  return new ClassicGraph({
+    nodes: [new Node({id: 'a'}), new Node({id: 'b'})],
+    edges: [new Edge({id: 'edge-a-b', sourceId: 'a', targetId: 'b'})]
+  });
+}


### PR DESCRIPTION
## Summary
- refresh the stale GPUForceLayout lifecycle fix on current `master`
- emit `onLayoutStart` when GPU layout work starts and clean up the worker when runs finish or stop
- apply worker `tick` node/edge updates immediately so GraphEngine bounds and layout-change callbacks reflect in-progress GPU positions
- replace the placeholder GraphEngine test with GPUForceLayout worker lifecycle and tick-bound regression coverage

## Classification
Refactor/internal behavior fix for graph-layers layout lifecycle callbacks. Visual proof is not applicable because the change affects internal worker callbacks and automated layout bounds, not a rendered UI/example route.

## Validation
- `yarn`
- `yarn test-node modules/graph-layers/test/core/graph-engine.spec.ts`
- `yarn test-node modules/graph-layers/test/core`
- `yarn test-node modules/graph-layers/test`
- `yarn lint`
- `yarn build`
- pre-commit `yarn test`

## Residual risk
- GPUForceLayout still depends on worker execution in consuming apps; this PR covers the GraphEngine lifecycle contract with a mocked worker rather than browser/GPU runtime media.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f439856588328a93bda0cab73c08a)