### PR TITLE
Fix layout lifecycle events for hive and radial layouts

### DIFF
--- a/modules/graph-layers/src/layouts/experimental/hive-plot-layout.ts
+++ b/modules/graph-layers/src/layouts/experimental/hive-plot-layout.ts
@@ -89,6 +89,7 @@ export class HivePlotLayout extends GraphLayout<HivePlotLayoutProps> {
   }
 
   start() {
+    this._onLayoutStart();
     this._onLayoutChange();
     this._onLayoutDone();
   }

--- a/modules/graph-layers/src/layouts/experimental/radial-layout.ts
+++ b/modules/graph-layers/src/layouts/experimental/radial-layout.ts
@@ -87,6 +87,8 @@ export class RadialLayout extends GraphLayout<RadialLayoutProps> {
       return;
     }
 
+    this._onLayoutStart();
+
     const {radius} = this.props;
     const unitAngle = 360 / nodeCount;
 

--- a/modules/graph-layers/test/core/graph-engine-layout-events.spec.ts
+++ b/modules/graph-layers/test/core/graph-engine-layout-events.spec.ts
@@ -1,0 +1,79 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, it, expect} from 'vitest';
+
+import type {Bounds2D} from '@math.gl/types';
+
+import {GraphEngine} from '../../src/core/graph-engine';
+import type {GraphLayoutEventDetail} from '../../src/core/graph-layout';
+import {Graph} from '../../src/graph/graph';
+import {Node} from '../../src/graph/node';
+import {HivePlotLayout} from '../../src/layouts/experimental/hive-plot-layout';
+import {RadialLayout} from '../../src/layouts/experimental/radial-layout';
+
+type CapturedEvent = {
+  type: 'start' | 'change' | 'done';
+  bounds?: Bounds2D | null;
+};
+
+function recordEngineEvents(engine: GraphEngine): CapturedEvent[] {
+  const events: CapturedEvent[] = [];
+  const handler = (type: CapturedEvent['type']) => (event: Event) => {
+    const detail = event instanceof CustomEvent ? (event.detail as GraphLayoutEventDetail) : undefined;
+    events.push({type, bounds: detail?.bounds});
+  };
+
+  engine.addEventListener('onLayoutStart', handler('start'));
+  engine.addEventListener('onLayoutChange', handler('change'));
+  engine.addEventListener('onLayoutDone', handler('done'));
+
+  return events;
+}
+
+describe('GraphEngine layout lifecycle events', () => {
+  it('emits start/change/done in order for HivePlotLayout', () => {
+    const nodes = [
+      new Node({id: 'a', data: {group: 0}}),
+      new Node({id: 'b', data: {group: 1}}),
+      new Node({id: 'c', data: {group: 0}})
+    ];
+    const graph = new Graph({nodes});
+    const layout = new HivePlotLayout();
+    const engine = new GraphEngine({graph, layout});
+
+    const events = recordEngineEvents(engine);
+
+    engine.run();
+
+    expect(events.map((event) => event.type)).toEqual(['start', 'change', 'done']);
+    expect(events[0]?.bounds).not.toBeNull();
+    expect(events[1]?.bounds).toEqual(events[2]?.bounds);
+    expect(events[2]?.bounds).toEqual(layout.getBounds());
+  });
+
+  it('emits start/change/done in order for RadialLayout', () => {
+    const nodes = ['root', 'child-1', 'child-2', 'leaf-1', 'leaf-2'].map((id) => new Node({id}));
+    const graph = new Graph({nodes});
+    const layout = new RadialLayout({
+      tree: [
+        {id: 'root', children: ['child-1', 'child-2']},
+        {id: 'child-1', children: ['leaf-1']},
+        {id: 'child-2', children: ['leaf-2']},
+        {id: 'leaf-1', children: []},
+        {id: 'leaf-2', children: []}
+      ]
+    });
+    const engine = new GraphEngine({graph, layout});
+
+    const events = recordEngineEvents(engine);
+
+    engine.run();
+
+    expect(events.map((event) => event.type)).toEqual(['start', 'change', 'done']);
+    expect(events[0]?.bounds).toBeNull();
+    expect(events[1]?.bounds).toEqual(events[2]?.bounds);
+    expect(events[2]?.bounds).toEqual(layout.getBounds());
+  });
+});


### PR DESCRIPTION
## Summary
- ensure HivePlotLayout and RadialLayout trigger layout start before raising change/done events
- keep layout bounds fresh across lifecycle callbacks
- add GraphEngine unit tests that verify observers receive start/change/done for both layouts

## Testing
- yarn test-node *(fails: install blocked in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f43aaa3e8832885bff1be568dae38)