### PR TITLE
examples: add marker layer example app

### DIFF
--- a/docs/modules/graph-layers/api-reference/layers/marker-layer.md
+++ b/docs/modules/graph-layers/api-reference/layers/marker-layer.md
@@ -2,6 +2,55 @@
 
 This layer provides the basic marker functionality. This marker layer provided by Deck.gl only has one marker (circle) while this layer provides numerous markers.
 
+## Example
+
+```ts
+import {Deck} from '@deck.gl/core';
+import {MarkerLayer} from '@deck.gl-community/graph-layers';
+
+const markers = [
+  {
+    position: [-122.4, 37.78],
+    marker: 'pin-filled',
+    color: [220, 38, 38, 255],
+    size: 32
+  },
+  {
+    position: [-73.98, 40.75],
+    marker: 'star-filled',
+    color: [37, 99, 235, 255],
+    size: 36
+  },
+  {
+    position: [-87.62, 41.88],
+    marker: 'location-marker-filled',
+    color: [16, 185, 129, 255],
+    size: 28
+  }
+];
+
+const markerLayer = new MarkerLayer({
+  id: 'marker-layer',
+  data: markers,
+  getPosition: d => d.position,
+  getMarker: d => d.marker,
+  getColor: d => d.color,
+  getSize: d => d.size
+});
+
+new Deck({
+  initialViewState: {
+    longitude: -98,
+    latitude: 39,
+    zoom: 3
+  },
+  controller: true,
+  layers: [markerLayer]
+});
+```
+
+A runnable version of this example is available in the repository under [`examples/graph-layers/marker-layer`](https://github.com/visgl/deck.gl-community/tree/main/examples/graph-layers/marker-layer).
+
 ## Properties
 
 Inherits from all [Icon Layer](http://deck.gl/#/documentation/deckgl-api-reference/layers/icon-layer) properties.
@@ -25,8 +74,8 @@ location-marker-filled, bell-filled, bookmark-filled, bookmark, cd-filled, cd, c
 
 Or you can import the marker list file:
 
-```
-  import {Markers} from '@uber/mlvis-layers';
+```ts
+import {MarkerList} from '@deck.gl-community/graph-layers/src/layers/common-layers/marker-layer/marker-list';
 ```
 
 ##### `getSize` (Function|Number, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
@@ -55,6 +104,6 @@ The rgba color of each object, in `r, g, b, [a]`. Each component is in the 0-255
 
 - Go to folder 'scripts' and run `sh scripts/packing.sh` to generate four files: `marker-atlas.png`, `atlas-data-url.js`, `marker-list.js`, and `marker-mapping.js`.
 
-- Go back to the root level of this repo (mlvis-toolkit), and run `yarn prettier` to fix the linter errors.
+- Go back to the root level of this repo and run `yarn prettier` to fix the linter errors.
 
-- Commit changes and create a diff for review (reviewer: `#mlvis`)
+- Commit changes and create a diff for review.

--- a/examples/graph-layers/marker-layer/app.tsx
+++ b/examples/graph-layers/marker-layer/app.tsx
@@ -1,0 +1,80 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+
+import React, {useMemo} from 'react';
+import DeckGL from '@deck.gl/react';
+import {MarkerLayer} from '@deck.gl-community/graph-layers';
+import StaticMap from 'react-map-gl/maplibre';
+
+const INITIAL_VIEW_STATE = {
+  longitude: -98,
+  latitude: 39,
+  zoom: 3,
+  pitch: 0,
+  bearing: 0
+};
+
+const MAP_STYLE = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
+
+type CityMarker = {
+  position: [number, number];
+  marker: string;
+  color: [number, number, number, number];
+  size: number;
+  label: string;
+};
+
+const CITY_MARKERS: CityMarker[] = [
+  {
+    position: [-122.4, 37.78],
+    marker: 'pin-filled',
+    color: [220, 38, 38, 255],
+    size: 32,
+    label: 'San Francisco, CA'
+  },
+  {
+    position: [-73.98, 40.75],
+    marker: 'star-filled',
+    color: [37, 99, 235, 255],
+    size: 36,
+    label: 'New York, NY'
+  },
+  {
+    position: [-87.62, 41.88],
+    marker: 'location-marker-filled',
+    color: [16, 185, 129, 255],
+    size: 28,
+    label: 'Chicago, IL'
+  }
+];
+
+export default function App(): React.ReactElement {
+  const layers = useMemo(
+    () => [
+      new MarkerLayer({
+        id: 'marker-layer',
+        data: CITY_MARKERS,
+        getPosition: (d) => d.position,
+        getMarker: (d) => d.marker,
+        getColor: (d) => d.color,
+        getSize: (d) => d.size
+      })
+    ],
+    []
+  );
+
+  return (
+    <DeckGL
+      initialViewState={INITIAL_VIEW_STATE}
+      controller={{dragPan: true, scrollZoom: true}}
+      layers={layers}
+      style={{width: '100vw', height: '100vh'}}
+      getTooltip={(info) => {
+        const {object} = info;
+        return object ? object.label : null;
+      }}
+    >
+      <StaticMap mapStyle={MAP_STYLE} />
+    </DeckGL>
+  );
+}

--- a/examples/graph-layers/marker-layer/index.html
+++ b/examples/graph-layers/marker-layer/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>MarkerLayer Example</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@^4.1.3/dist/maplibre-gl.css" />
+  </head>
+  <body></body>
+  <script type="module" src="./index.tsx"></script>
+</html>

--- a/examples/graph-layers/marker-layer/index.tsx
+++ b/examples/graph-layers/marker-layer/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import {createRoot} from 'react-dom/client';
+import App from './app';
+
+const container = document.body.appendChild(document.createElement('div'));
+container.style.margin = '0';
+container.style.height = '100vh';
+container.style.width = '100vw';
+
+createRoot(container).render(<App />);

--- a/examples/graph-layers/marker-layer/package.json
+++ b/examples/graph-layers/marker-layer/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "graph-marker-layer-example",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "start": "vite --open",
+    "start-local": "vite --config ../../vite.config.local.mjs"
+  },
+  "dependencies": {
+    "@deck.gl-community/graph-layers": "~9.2.0",
+    "@deck.gl/core": "~9.2.1",
+    "@deck.gl/layers": "~9.2.1",
+    "@deck.gl/react": "~9.2.1",
+    "maplibre-gl": "^4.1.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-map-gl": "^7.1.7"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "vite": "7.1.1"
+  }
+}

--- a/examples/graph-layers/marker-layer/tsconfig.json
+++ b/examples/graph-layers/marker-layer/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./*.tsx", "./*.ts"]
+}


### PR DESCRIPTION
## Summary
- add a runnable MarkerLayer example under examples/graph-layers
- update the MarkerLayer documentation example to match the new demo and link to its source

## Testing
- no tests (example only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690a297714648328824e97041f7da283)