### PR TITLE
docs(geo-layers): document global grid helpers

### DIFF
--- a/docs/modules/geo-layers/api-reference/a5-grid.md
+++ b/docs/modules/geo-layers/api-reference/a5-grid.md
@@ -1,0 +1,27 @@
+# A5Grid
+
+## Purpose
+
+`A5Grid` wraps the [A5 discrete global grid system](https://www.ogc.org/standards/dggs) and exposes it through the shared `GlobalGrid` contract. It bridges the `a5-js` utilities used by deck.gl into a uniform API so the `GlobalGridLayer` can fetch cell centers and polygon boundaries for A5 indices.
+
+## Usage
+
+```ts
+import {GlobalGridLayer, A5Grid} from '@deck.gl/geo-layers';
+
+const layer = new GlobalGridLayer({
+  id: 'a5-grid',
+  data: dataset,
+  globalGrid: A5Grid,
+  getCellId: d => d.a5Token,
+  extruded: true
+});
+```
+
+Use `A5Grid.lngLatToCell(lngLat, resolution)` when you need to derive cell identifiers from coordinates. The helper accepts either a hexadecimal string or a bigint identifier, automatically performing conversions through `tokenToCell`/`cellToToken`.
+
+## Shared conventions
+
+- `hasNumericRepresentation` is `true`; bigint identifiers are supported alongside hexadecimal tokens.
+- `tokenToCell` and `cellToToken` convert between hexadecimal string tokens and bigint IDs.
+- `cellToLngLat` and `cellToBoundary` both accept either representation and dispatch through `a5-js` to return longitude/latitude values.

--- a/docs/modules/geo-layers/api-reference/geohash-grid.md
+++ b/docs/modules/geo-layers/api-reference/geohash-grid.md
@@ -1,0 +1,27 @@
+# GeohashGrid
+
+## Purpose
+
+`GeohashGrid` decodes Geohash strings into the center points and boundary polygons required by `GlobalGridLayer`. It provides a lightweight bridge between Geohash tokens and deck.gl geometry without introducing bigint handling.
+
+## Usage
+
+```ts
+import {GlobalGridLayer, GeohashGrid} from '@deck.gl/geo-layers';
+
+const layer = new GlobalGridLayer({
+  id: 'geohash-grid',
+  data: dataset,
+  globalGrid: GeohashGrid,
+  getCellId: d => d.geohash,
+  filled: true
+});
+```
+
+Use `GeohashGrid.cellToLngLat(token)` or `GeohashGrid.cellToBoundary(token)` whenever you need to precompute values outside the layer. All helpers require a string token; bigint arguments throw an error to prevent ambiguous conversions.
+
+## Shared conventions
+
+- `hasNumericRepresentation` is `false`; only string Geohash tokens are supported.
+- Boundaries are returned in longitude/latitude order and close the polygon by repeating the first vertex.
+- The helper exposes a `getGeohashBounds` utility for computing bounding boxes when needed.

--- a/docs/modules/geo-layers/api-reference/global-grid-layer.md
+++ b/docs/modules/geo-layers/api-reference/global-grid-layer.md
@@ -9,6 +9,14 @@ The `GlobalGridLayer` renders filled and/or stroked polygons based on the specif
 
 `GlobalGridLayer` is a [CompositeLayer](https://deck.gl/docs/api-reference/core/composite-layer).
 
+This layer consumes implementations of the [GlobalGrid](./global-grid) interface. The package includes prebuilt helpers for common DGGS formats:
+
+- [A5Grid](./a5-grid)
+- [H3Grid](./h3-grid)
+- [S2Grid](./s2-grid)
+- [GeohashGrid](./geohash-grid)
+- [QuadkeyGrid](./quadkey-grid)
+
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/docs/modules/geo-layers/api-reference/global-grid.md
+++ b/docs/modules/geo-layers/api-reference/global-grid.md
@@ -1,0 +1,39 @@
+# GlobalGrid
+
+## Purpose
+
+`GlobalGrid` defines the shared interface that the `GlobalGridLayer` expects when it works with Discrete Global Grid System (DGGS) helpers. Implementations expose common capabilities—converting between string tokens and numeric cell identifiers, retrieving center coordinates, and generating boundary polygons—so different grid systems can be rendered with the same layer contract.
+
+## Usage
+
+Implement the `GlobalGrid` contract when wiring up a custom DGGS helper:
+
+```ts
+import type {GlobalGrid} from '@deck.gl/geo-layers';
+import {GlobalGridLayer} from '@deck.gl/geo-layers';
+
+const CustomGrid: GlobalGrid = {
+  name: 'custom',
+  hasNumericRepresentation: false,
+  cellToLngLat: cell => lookupCenter(cell),
+  cellToBoundary: cell => lookupBoundary(cell)
+};
+
+const layer = new GlobalGridLayer({
+  id: 'custom-grid',
+  data: dataset,
+  globalGrid: CustomGrid,
+  getCellId: d => d.cellId
+});
+```
+
+Every optional method on the interface—such as `initialize`, `tokenToCell`, `cellToToken`, or `lngLatToCell`—can be supplied when a grid supports those operations. The layer automatically calls `globalGrid.initialize()` during `initializeState` and uses `cellToBoundary` to build the polygon geometry.
+
+## Shared conventions
+
+- `cellToLngLat` must return an array `[longitude, latitude]`.
+- `cellToBoundary` must return an array of `[longitude, latitude]` vertices; the layer will append the first vertex to close the polygon.
+- `hasNumericRepresentation` communicates whether a bigint representation is available alongside the string token.
+- `GlobalGridLayer` reads the DGGS identifier through `getCellId` (defaulting to the `cellId` property) and forwards the value directly to the helper.
+
+Refer to the specific helper pages below for grid-specific behavior and caveats.

--- a/docs/modules/geo-layers/api-reference/h3-grid.md
+++ b/docs/modules/geo-layers/api-reference/h3-grid.md
@@ -1,0 +1,27 @@
+# H3Grid
+
+## Purpose
+
+`H3Grid` exposes deck.gl's bigint-aware integration with the H3 DGGS. It wraps the helper utilities that convert between H3 index strings, bigint identifiers, and polygon geometry so the `GlobalGridLayer` can render H3 cells without additional glue code.
+
+## Usage
+
+```ts
+import {GlobalGridLayer, H3Grid} from '@deck.gl/geo-layers';
+
+const layer = new GlobalGridLayer({
+  id: 'h3-grid',
+  data: dataset,
+  globalGrid: H3Grid,
+  getCellId: d => d.h3Index,
+  stroked: false
+});
+```
+
+`H3Grid` supports both string tokens and bigint IDs. Call `H3Grid.lngLatToCell([lng, lat], resolution)` to build indices from coordinates, or `H3Grid.lngLatToToken` when you specifically need the string representation. Its `cellsToBoundaryMultiPolygon` helper mirrors the upstream H3 multi-polygon utilities and is useful when combining multiple cells into a single outline.
+
+## Shared conventions
+
+- `hasNumericRepresentation` is `true`; bigint indices are derived through `h3IndexToBigInt`.
+- `initialize` exists to make sure the `h3-js` bridge is loaded; the `GlobalGridLayer` invokes it automatically.
+- `cellToLngLat` and `cellToBoundary` return `[longitude, latitude]` pairs compatible with deck.gl geometry helpers.

--- a/docs/modules/geo-layers/api-reference/quadkey-grid.md
+++ b/docs/modules/geo-layers/api-reference/quadkey-grid.md
@@ -1,0 +1,27 @@
+# QuadkeyGrid
+
+## Purpose
+
+`QuadkeyGrid` turns Bing-style Quadkey tiles into the center coordinates and polygon outlines consumed by `GlobalGridLayer`. It provides a thin wrapper around quadkey-to-world math, exposing a unified API for string tiles and experimental bigint encodings.
+
+## Usage
+
+```ts
+import {GlobalGridLayer, QuadkeyGrid} from '@deck.gl/geo-layers';
+
+const layer = new GlobalGridLayer({
+  id: 'quadkey-grid',
+  data: dataset,
+  globalGrid: QuadkeyGrid,
+  getCellId: d => d.quadkey,
+  opacity: 0.6
+});
+```
+
+`QuadkeyGrid.cellToLngLat(token)` returns the tile center in `[longitude, latitude]` order, and `cellToBoundary(token)` produces a polygon suitable for deck.gl layers. Helpers such as `quadkeyCellToBounds` and `quadkeyToWorldBounds` remain available from the underlying module when you need additional metadata.
+
+## Shared conventions
+
+- `hasNumericRepresentation` is `true`; while the primary API works with strings, experimental bigint helpers (`quadKeyToBigint`, `bigintToQuadKey`) are exported alongside the grid.
+- Boundaries are returned as `[longitude, latitude]` pairs and already include the closing vertex.
+- All public helpers expect Quadkey strings; pass values such as `"0231"` that match the Web Mercator tile scheme.

--- a/docs/modules/geo-layers/api-reference/s2-grid.md
+++ b/docs/modules/geo-layers/api-reference/s2-grid.md
@@ -1,0 +1,27 @@
+# S2Grid
+
+## Purpose
+
+`S2Grid` adapts S2 cell utilities so that the `GlobalGridLayer` can consume S2 tokens and numeric cell IDs directly. It exposes conversion helpers for tokens, center coordinates, and polygon boundaries built from the math.gl S2 geometry utilities.
+
+## Usage
+
+```ts
+import {GlobalGridLayer, S2Grid} from '@deck.gl/geo-layers';
+
+const layer = new GlobalGridLayer({
+  id: 's2-grid',
+  data: dataset,
+  globalGrid: S2Grid,
+  getCellId: d => d.s2Token,
+  pickable: true
+});
+```
+
+You can convert between token strings and bigint IDs through `S2Grid.tokenToCell` and `S2Grid.cellToToken`. When you only have a bigint, `S2Grid.cellToLngLat` and `S2Grid.cellToBoundary` will still accept it, normalizing inputs internally.
+
+## Shared conventions
+
+- `hasNumericRepresentation` is `true`; tokens resolve to bigint IDs before further processing.
+- Boundary polygons are returned as `[longitude, latitude]` points that include the starting vertex again to close the loop.
+- Additional helpers such as `getS2Bounds` are available in the underlying module when you need bounding boxes for a cell.

--- a/docs/modules/geo-layers/sidebar.json
+++ b/docs/modules/geo-layers/sidebar.json
@@ -4,6 +4,12 @@
   "items": [
     "modules/geo-layers/README",
     "modules/geo-layers/api-reference/global-grid-layer",
+    "modules/geo-layers/api-reference/global-grid",
+    "modules/geo-layers/api-reference/a5-grid",
+    "modules/geo-layers/api-reference/h3-grid",
+    "modules/geo-layers/api-reference/s2-grid",
+    "modules/geo-layers/api-reference/geohash-grid",
+    "modules/geo-layers/api-reference/quadkey-grid",
     "modules/geo-layers/api-reference/tile-source-layer"
   ]
 }


### PR DESCRIPTION
## Summary
- add API reference pages for the GlobalGrid interface and the built-in grid helpers
- update the geo-layers sidebar navigation and link the helpers from the GlobalGridLayer docs

## Testing
- git commit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911ecca58ec832881a6a401e9014fc3)