### PR TITLE
feat(editable-layers): Experimental edit mode widget + example

### DIFF
--- a/examples/editable-layers/widget/app.tsx
+++ b/examples/editable-layers/widget/app.tsx
@@ -1,0 +1,17 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as React from 'react';
+import {createRoot} from 'react-dom/client';
+import {Example} from './example';
+
+const container = document.createElement('div');
+
+if (document.body) {
+  document.body.style.margin = '0';
+
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  root.render(<Example />);
+}

--- a/examples/editable-layers/widget/example.tsx
+++ b/examples/editable-layers/widget/example.tsx
@@ -1,0 +1,341 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import DeckGL from '@deck.gl/react';
+import {
+  ViewMode,
+  DrawPointMode,
+  DrawLineStringMode,
+  DrawPolygonMode,
+  DrawRectangleMode,
+  DrawCircleFromCenterMode,
+  MeasureDistanceMode,
+  MeasureAngleMode,
+  MeasureAreaMode,
+  EditableGeoJsonLayer,
+  EditModeTrayWidget,
+  type EditModeTrayWidgetModeOption,
+  type GeoJsonEditModeConstructor,
+  type GeoJsonEditModeType
+} from '@deck.gl-community/editable-layers';
+import StaticMap from 'react-map-gl/maplibre';
+import type {FeatureCollection} from 'geojson';
+
+import '@deck.gl/widgets/dist/stylesheet.css';
+
+export function getDefaultGeoJSON(): FeatureCollection {
+  return {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        properties: {},
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [-122.46212548792364, 37.79026033616934],
+              [-122.48435831844807, 37.77160302698496],
+              [-122.45884849905971, 37.74414218845571],
+              [-122.42863676726826, 37.76266965836386],
+              [-122.46212548792364, 37.79026033616934]
+            ]
+          ]
+        }
+      },
+      {
+        type: 'Feature',
+        properties: {},
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [-122.4136573004723, 37.78826678755718],
+              [-122.44875601708893, 37.782670574261324],
+              [-122.43793598592286, 37.74322062447909],
+              [-122.40836932539945, 37.75125290412125],
+              [-122.4136573004723, 37.78826678755718]
+            ]
+          ]
+        }
+      }
+    ]
+  } as FeatureCollection;
+}
+
+const initialViewState = {
+  longitude: -122.43,
+  latitude: 37.775,
+  zoom: 12
+};
+
+const MODE_OPTIONS: EditModeTrayWidgetModeOption[] = [
+  {id: 'view', mode: ViewMode, icon: '👆', title: 'View mode', label: 'View'},
+  {id: 'draw-point', mode: DrawPointMode, icon: '•', title: 'Draw point', label: 'Point'},
+  {id: 'draw-line', mode: DrawLineStringMode, icon: '╱', title: 'Draw line string', label: 'Line'},
+  {id: 'draw-polygon', mode: DrawPolygonMode, icon: '⬠', title: 'Draw polygon', label: 'Polygon'},
+  {
+    id: 'draw-rectangle',
+    mode: DrawRectangleMode,
+    icon: '▭',
+    title: 'Draw rectangle',
+    label: 'Rectangle'
+  },
+  {id: 'draw-circle', mode: DrawCircleFromCenterMode, icon: '◯', title: 'Draw circle', label: 'Circle'},
+  {
+    id: 'measure-distance',
+    mode: MeasureDistanceMode,
+    icon: '📏',
+    title: 'Measure distance',
+    label: 'Distance'
+  },
+  {id: 'measure-angle', mode: MeasureAngleMode, icon: '∠', title: 'Measure angle', label: 'Angle'},
+  {id: 'measure-area', mode: MeasureAreaMode, icon: '▢', title: 'Measure area', label: 'Area'}
+];
+
+const CONTROL_PANEL_STYLE: React.CSSProperties = {
+  position: 'absolute',
+  top: 16,
+  left: 116,
+  maxWidth: 320,
+  padding: '12px 16px 16px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '12px',
+  background: 'rgba(26, 32, 44, 0.9)',
+  color: '#f8fafc',
+  borderRadius: '12px',
+  fontFamily: 'var(--ifm-font-family-base, sans-serif)'
+};
+
+const CONTROL_SECTION_STYLE: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px'
+};
+
+const CONTROL_BUTTON_GROUP_STYLE: React.CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '8px'
+};
+
+const CONTROL_BUTTON_STYLE: React.CSSProperties = {
+  appearance: 'none',
+  border: '1px solid rgba(148, 163, 184, 0.5)',
+  borderRadius: '999px',
+  background: 'rgba(15, 23, 42, 0.4)',
+  color: '#e2e8f0',
+  padding: '6px 12px',
+  fontSize: '13px',
+  lineHeight: 1.2,
+  cursor: 'pointer',
+  transition: 'background 0.15s ease, color 0.15s ease, border-color 0.15s ease'
+};
+
+const CONTROL_BUTTON_ACTIVE_STYLE: React.CSSProperties = {
+  background: '#2563eb',
+  color: '#f8fafc',
+  borderColor: '#2563eb'
+};
+
+type ControlPanelProps = {
+  modeConfig: Record<string, unknown>;
+  onSetModeConfig: (config: Record<string, unknown>) => void;
+  onClear: () => void;
+  onReset: () => void;
+};
+
+function ControlPanel({modeConfig, onSetModeConfig, onClear, onReset}: ControlPanelProps) {
+  const booleanOperation =
+    typeof modeConfig?.['booleanOperation'] === 'string'
+      ? (modeConfig['booleanOperation'] as string)
+      : null;
+
+  const buttons: {id: string; label: string; description: string; value: string | null}[] = [
+    {id: 'none', label: 'Edit geometries', description: 'Use edit handles to modify shapes.', value: null},
+    {
+      id: 'difference',
+      label: 'Subtract',
+      description: 'Cut selected features from each other.',
+      value: 'difference'
+    },
+    {
+      id: 'union',
+      label: 'Union',
+      description: 'Merge overlapping polygons together.',
+      value: 'union'
+    },
+    {
+      id: 'intersection',
+      label: 'Intersect',
+      description: 'Keep only the overlapping regions.',
+      value: 'intersection'
+    }
+  ];
+
+  return (
+    <aside style={CONTROL_PANEL_STYLE}>
+      <div>
+        <h2 style={{margin: '0 0 4px', fontSize: '18px', fontWeight: 600}}>Editable layers editor</h2>
+        <p style={{margin: 0, fontSize: '14px', lineHeight: 1.5}}>
+          Select a tool from the mode tray to draw new geometries, measure features, or adjust existing
+          shapes in the scene.
+        </p>
+      </div>
+
+      <section style={CONTROL_SECTION_STYLE}>
+        <h3 style={{margin: 0, fontSize: '15px', fontWeight: 600}}>Boolean operations</h3>
+        <p style={{margin: 0, fontSize: '13px', color: '#cbd5f5'}}>Apply when drawing overlapping polygons.</p>
+        <div style={CONTROL_BUTTON_GROUP_STYLE}>
+          {buttons.map((button) => {
+            const active = button.value === booleanOperation;
+            return (
+              <button
+                key={button.id}
+                type="button"
+                style={{
+                  ...CONTROL_BUTTON_STYLE,
+                  ...(active ? CONTROL_BUTTON_ACTIVE_STYLE : {})
+                }}
+                onClick={() => {
+                  if (button.value) {
+                    onSetModeConfig({booleanOperation: button.value});
+                  } else {
+                    onSetModeConfig({});
+                  }
+                }}
+                aria-pressed={active}
+                title={button.description}
+              >
+                {button.label}
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      <section style={{...CONTROL_SECTION_STYLE, marginTop: '4px'}}>
+        <h3 style={{margin: 0, fontSize: '15px', fontWeight: 600}}>Dataset</h3>
+        <div style={CONTROL_BUTTON_GROUP_STYLE}>
+          <button
+            type="button"
+            style={CONTROL_BUTTON_STYLE}
+            onClick={onReset}
+          >
+            Reset example
+          </button>
+          <button
+            type="button"
+            style={{...CONTROL_BUTTON_STYLE, color: '#fecaca', borderColor: 'rgba(239, 68, 68, 0.7)'}}
+            onClick={onClear}
+          >
+            Clear features
+          </button>
+        </div>
+      </section>
+    </aside>
+  );
+}
+
+type ModeType = GeoJsonEditModeConstructor | GeoJsonEditModeType;
+
+export function Example() {
+  const [geoJson, setGeoJson] = useState<FeatureCollection>(getDefaultGeoJSON());
+  const [selectedFeatureIndexes, setSelectedFeatureIndexes] = useState([0]);
+  const [mode, setMode] = useState<ModeType>(() => ViewMode);
+  const [modeConfig, setModeConfig] = useState<Record<string, unknown>>({});
+
+  const trayWidgetRef = useRef<EditModeTrayWidget | null>(null);
+  if (!trayWidgetRef.current) {
+    trayWidgetRef.current = new EditModeTrayWidget({
+      placement: 'top-left',
+      layout: 'vertical',
+      style: {margin: '16px 0 0 16px'}
+    });
+  }
+  const trayWidget = trayWidgetRef.current!;
+
+  const widgets = useMemo(() => [trayWidget], [trayWidget]);
+
+  const trayModeOptions = useMemo(() => MODE_OPTIONS, []);
+
+  const handleSetMode = useCallback(
+    (nextMode: ModeType) => {
+      setMode(() => nextMode);
+      setModeConfig({});
+    },
+    [setMode, setModeConfig]
+  );
+
+  const handleReset = useCallback(() => {
+    const reset = getDefaultGeoJSON();
+    setGeoJson(reset);
+    setSelectedFeatureIndexes([0]);
+    handleSetMode(ViewMode);
+  }, [handleSetMode, setGeoJson, setSelectedFeatureIndexes]);
+
+  const handleClear = useCallback(() => {
+    setGeoJson({type: 'FeatureCollection', features: []});
+    setSelectedFeatureIndexes([]);
+  }, [setGeoJson, setSelectedFeatureIndexes]);
+
+  useEffect(() => {
+    const selected = trayModeOptions.find((option) => option.mode === mode)?.id ?? null;
+    trayWidget.setProps({
+      modes: trayModeOptions,
+      activeMode: mode,
+      selectedModeId: selected,
+      onSelectMode: ({mode: selectedMode}) => {
+        if (mode !== selectedMode) {
+          handleSetMode(selectedMode);
+        }
+      }
+    });
+  }, [handleSetMode, mode, trayModeOptions, trayWidget]);
+
+  const layer = new EditableGeoJsonLayer({
+    data: geoJson,
+    mode,
+    modeConfig,
+    selectedFeatureIndexes,
+    onEdit: ({ updatedData }) => {
+      setGeoJson(updatedData);
+    }
+  });
+
+  return (
+    <>
+      <DeckGL
+        initialViewState={initialViewState}
+        controller={{
+          doubleClickZoom: false
+        }}
+        layers={[layer]}
+        getCursor={layer.getCursor.bind(layer)}
+        onClick={(info) => {
+          if (mode === ViewMode) {
+            const index = typeof info?.index === 'number' && info.index >= 0 ? info.index : null;
+            if (index !== null) {
+              setSelectedFeatureIndexes([index]);
+            } else {
+              setSelectedFeatureIndexes([]);
+            }
+          }
+        }}
+        widgets={widgets}
+      >
+        <StaticMap mapStyle={'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json'} />
+      </DeckGL>
+
+      <ControlPanel
+        modeConfig={modeConfig}
+        onSetModeConfig={setModeConfig}
+        onClear={handleClear}
+        onReset={handleReset}
+      />
+    </>
+  );
+}

--- a/examples/editable-layers/widget/index.html
+++ b/examples/editable-layers/widget/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>deck.gl Community Example</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link href="https://unpkg.com/maplibre-gl@^4.1.3/dist/maplibre-gl.css" rel="stylesheet" />
+    </head>
+    <body></body>
+    <script type="module" src="./app.tsx"></script>
+</html>

--- a/examples/editable-layers/widget/package.json
+++ b/examples/editable-layers/widget/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "editable-layers-widget",
+  "version": "9.2.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "vite",
+    "start-local": "vite --config ../../vite.config.local.mjs"
+  },
+  "dependencies": {
+    "@deck.gl-community/editable-layers": "workspace:*",
+    "@deck.gl-community/layers": "workspace:*",
+    "@deck.gl-community/react": "workspace:*",
+    "@deck.gl/core": "~9.2.1",
+    "@deck.gl/extensions": "~9.2.1",
+    "@deck.gl/geo-layers": "~9.2.1",
+    "@deck.gl/layers": "~9.2.1",
+    "@deck.gl/mesh-layers": "~9.2.1",
+    "@deck.gl/react": "~9.2.1",
+    "@deck.gl/widgets": "~9.2.1",
+    "@loaders.gl/core": "^4.2.0",
+    "@loaders.gl/wkt": "^4.2.0",
+    "@luma.gl/constants": "~9.2.0",
+    "@luma.gl/core": "~9.2.0",
+    "@luma.gl/engine": "~9.2.0",
+    "@luma.gl/shadertools": "~9.2.0",
+    "@maphubs/tokml": "^0.6.1",
+    "@math.gl/core": "^4.0.0",
+    "@tmcw/togeojson": "^3.2.0",
+    "@turf/helpers": "^6.5.0",
+    "@types/downloadjs": "1.4.3",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@types/wellknown": "0.5.4",
+    "boxicons": "^2.1.4",
+    "clipboard-copy": "^3.2.0",
+    "downloadjs": "^1.4.7",
+    "maplibre-gl": "^4.1.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-dropzone": "^10.2.2",
+    "react-map-gl": "^7.1.7",
+    "styled-components": "^6.1.9",
+    "wellknown": "^0.5.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.4",
+    "vite": "7.1.1"
+  }
+}

--- a/examples/editable-layers/widget/svg.d.ts
+++ b/examples/editable-layers/widget/svg.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg?url' {
+  const src: string;
+  export default src;
+}

--- a/examples/editable-layers/widget/tsconfig.json
+++ b/examples/editable-layers/widget/tsconfig.json
@@ -1,0 +1,4 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["./*.tsx"]
+}

--- a/modules/editable-layers/package.json
+++ b/modules/editable-layers/package.json
@@ -67,6 +67,7 @@
     "eventemitter3": "^5.0.0",
     "lodash.omit": "^4.1.1",
     "lodash.throttle": "^4.1.1",
+    "preact": "^10.17.0",
     "uuid": "9.0.0",
     "viewport-mercator-project": ">=6.2.3"
   },

--- a/modules/editable-layers/src/index.ts
+++ b/modules/editable-layers/src/index.ts
@@ -29,6 +29,14 @@ export {EditableH3ClusterLayer} from './editable-layers/editable-h3-cluster-laye
 export {SelectionLayer} from './editable-layers/selection-layer';
 export {ElevatedEditHandleLayer} from './editable-layers/elevated-edit-handle-layer';
 
+// Widgets
+export {EditModeTrayWidget} from './widgets/edit-mode-tray-widget';
+export type {
+  EditModeTrayWidgetProps,
+  EditModeTrayWidgetModeOption,
+  EditModeTrayWidgetSelectEvent
+} from './widgets/edit-mode-tray-widget';
+
 // Layers move to deck.gl-community/layers?
 export {JunctionScatterplotLayer} from './editable-layers/junction-scatterplot-layer';
 

--- a/modules/editable-layers/src/widgets/edit-mode-tray-widget.tsx
+++ b/modules/editable-layers/src/widgets/edit-mode-tray-widget.tsx
@@ -1,0 +1,342 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {render} from 'preact';
+import type {ComponentChild, JSX} from 'preact';
+import {
+  Widget,
+  type WidgetProps,
+  type WidgetPlacement,
+  type Deck
+} from '@deck.gl/core';
+import type {
+  GeoJsonEditModeConstructor,
+  GeoJsonEditModeType
+} from '../edit-modes/geojson-edit-mode';
+
+export type EditModeTrayWidgetModeOption = {
+  /**
+   * Optional identifier for the mode button.
+   * If not provided, one will be inferred from the supplied mode.
+   */
+  id?: string;
+  /** Edit mode constructor or instance that the button should activate. */
+  mode: GeoJsonEditModeConstructor | GeoJsonEditModeType;
+  /**
+   * The icon or element rendered inside the button.
+   * A simple string can also be supplied for text labels.
+   */
+  icon?: ComponentChild;
+  /** Optional text label rendered below the icon when provided. */
+  label?: string;
+  /** Optional tooltip text applied to the button element. */
+  title?: string;
+};
+
+export type EditModeTrayWidgetSelectEvent = {
+  id: string;
+  mode: GeoJsonEditModeConstructor | GeoJsonEditModeType;
+  option: EditModeTrayWidgetModeOption;
+};
+
+export type EditModeTrayWidgetProps = WidgetProps & {
+  /** Placement for the widget root element. */
+  placement?: WidgetPlacement;
+  /** Layout direction for mode buttons. */
+  layout?: 'vertical' | 'horizontal';
+  /** Collection of modes rendered in the tray. */
+  modes?: EditModeTrayWidgetModeOption[];
+  /** Identifier of the currently active mode. */
+  selectedModeId?: string | null;
+  /** Currently active mode instance/constructor. */
+  activeMode?: GeoJsonEditModeConstructor | GeoJsonEditModeType | null;
+  /** Callback fired when the user selects a mode. */
+  onSelectMode?: (event: EditModeTrayWidgetSelectEvent) => void;
+};
+
+const ROOT_STYLE: Partial<CSSStyleDeclaration> = {
+  position: 'absolute',
+  display: 'flex',
+  pointerEvents: 'auto',
+  userSelect: 'none',
+  zIndex: '99'
+};
+
+const TRAY_BASE_STYLE: JSX.CSSProperties = {
+  display: 'flex',
+  gap: '6px',
+  background: 'rgba(36, 40, 41, 0.88)',
+  borderRadius: '999px',
+  padding: '6px',
+  alignItems: 'center',
+  justifyContent: 'center',
+  boxShadow: '0 4px 12px rgba(0, 0, 0, 0.25)'
+};
+
+const BUTTON_BASE_STYLE: JSX.CSSProperties = {
+  appearance: 'none',
+  background: 'transparent',
+  border: 'none',
+  color: '#f0f0f0',
+  width: '34px',
+  height: '34px',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: '50%',
+  cursor: 'pointer',
+  padding: '0',
+  transition: 'background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease'
+};
+
+const BUTTON_ACTIVE_STYLE: JSX.CSSProperties = {
+  background: '#0071e3',
+  color: '#ffffff',
+  boxShadow: '0 0 0 2px rgba(255, 255, 255, 0.35)'
+};
+
+const BUTTON_LABEL_STYLE: JSX.CSSProperties = {
+  fontSize: '10px',
+  marginTop: '2px',
+  lineHeight: '12px'
+};
+
+export class EditModeTrayWidget extends Widget<EditModeTrayWidgetProps> {
+  static override defaultProps = {
+    id: 'edit-mode-tray',
+    placement: 'top-left',
+    layout: 'vertical',
+    modes: [],
+    style: {},
+    className: ''
+  } satisfies Required<WidgetProps> &
+    Required<Pick<EditModeTrayWidgetProps, 'placement' | 'layout'>> &
+    EditModeTrayWidgetProps;
+
+  placement: WidgetPlacement = 'top-left';
+  className = 'deck-widget-edit-mode-tray';
+  layout: 'vertical' | 'horizontal' = 'vertical';
+  selectedModeId: string | null = null;
+  deck?: Deck | null = null;
+  private appliedCustomClassName: string | null = null;
+
+  constructor(props: EditModeTrayWidgetProps = {}) {
+    super({...EditModeTrayWidget.defaultProps, ...props});
+    this.placement = props.placement ?? EditModeTrayWidget.defaultProps.placement;
+    this.layout = props.layout ?? EditModeTrayWidget.defaultProps.layout;
+    this.selectedModeId = this.resolveSelectedModeId(props.modes ?? [], props);
+  }
+
+  override setProps(props: Partial<EditModeTrayWidgetProps>): void {
+    if (props.placement !== undefined) {
+      this.placement = props.placement;
+    }
+    if (props.layout !== undefined) {
+      this.layout = props.layout;
+    }
+
+    const modes = props.modes ?? this.props.modes ?? [];
+    this.selectedModeId = this.resolveSelectedModeId(modes, props);
+
+    super.setProps(props);
+    this.renderTray();
+  }
+
+  override onAdd({deck}: {deck: Deck}): void {
+    this.deck = deck;
+  }
+
+  override onRemove(): void {
+    this.deck = null;
+    const root = this.rootElement;
+    if (root) {
+      render(null, root);
+    }
+    this.rootElement = null;
+  }
+
+  override onRenderHTML(rootElement: HTMLElement): void {
+    const style = {...ROOT_STYLE, ...this.props.style};
+    Object.assign(rootElement.style, style);
+    if (this.appliedCustomClassName && this.appliedCustomClassName !== this.props.className) {
+      rootElement.classList.remove(this.appliedCustomClassName);
+      this.appliedCustomClassName = null;
+    }
+    if (this.props.className) {
+      rootElement.classList.add(this.props.className);
+      this.appliedCustomClassName = this.props.className;
+    }
+    rootElement.classList.add(this.className);
+
+    this.renderTray();
+  }
+
+  private renderTray() {
+    const root = this.rootElement;
+    if (!root) {
+      return;
+    }
+
+    const modes = this.props.modes ?? [];
+    const selectedId = this.selectedModeId;
+    const direction = this.layout === 'horizontal' ? 'row' : 'column';
+
+    const trayStyle: JSX.CSSProperties = {
+      ...TRAY_BASE_STYLE,
+      flexDirection: direction
+    };
+
+    const stopEvent = (event: Event) => {
+      event.stopPropagation();
+      if (typeof (event as any).stopImmediatePropagation === 'function') {
+        (event as any).stopImmediatePropagation();
+      }
+    };
+
+    const ui = (
+      <div
+        style={trayStyle}
+        onPointerDown={stopEvent}
+        onPointerMove={stopEvent}
+        onPointerUp={stopEvent}
+        onMouseDown={stopEvent}
+        onMouseMove={stopEvent}
+        onMouseUp={stopEvent}
+        onTouchStart={stopEvent}
+        onTouchMove={stopEvent}
+        onTouchEnd={stopEvent}
+      >
+        {modes.map((option, index) => {
+          const id = this.getModeId(option, index);
+          const active = id === selectedId;
+          const label = option.label ?? '';
+          const title = option.title ?? label;
+
+          const buttonStyle: JSX.CSSProperties = {
+            ...BUTTON_BASE_STYLE,
+            ...(active ? BUTTON_ACTIVE_STYLE : {})
+          };
+
+          return (
+            <button
+              key={id}
+              type="button"
+              title={title || undefined}
+              aria-pressed={active}
+              style={buttonStyle}
+              onClick={(event) => {
+                stopEvent(event);
+                this.handleSelect(option, id);
+              }}
+            >
+              {option.icon}
+              {label ? <span style={BUTTON_LABEL_STYLE}>{label}</span> : null}
+            </button>
+          );
+        })}
+      </div>
+    );
+
+    render(ui, root);
+  }
+
+  private handleSelect(option: EditModeTrayWidgetModeOption, id: string) {
+    if (this.selectedModeId !== id) {
+      this.selectedModeId = id;
+      this.renderTray();
+    }
+
+    this.props.onSelectMode?.({
+      id,
+      mode: option.mode,
+      option
+    });
+  }
+
+  private resolveSelectedModeId(
+    modes: EditModeTrayWidgetModeOption[],
+    props: Partial<EditModeTrayWidgetProps>
+  ): string | null {
+    if (props.selectedModeId !== undefined) {
+      return props.selectedModeId;
+    }
+
+    const activeMode = props.activeMode ?? this.props?.activeMode ?? null;
+    if (activeMode) {
+      const match = this.findOptionByMode(modes, activeMode);
+      if (match) {
+        return this.getModeId(match.option, match.index);
+      }
+    }
+
+    if (this.selectedModeId) {
+      const existing = this.findOptionById(modes, this.selectedModeId);
+      if (existing) {
+        return this.selectedModeId;
+      }
+    }
+
+    const first = modes[0];
+    return first ? this.getModeId(first, 0) : null;
+  }
+
+  private findOptionByMode(
+    modes: EditModeTrayWidgetModeOption[],
+    activeMode: GeoJsonEditModeConstructor | GeoJsonEditModeType
+  ): {option: EditModeTrayWidgetModeOption; index: number} | null {
+    for (let index = 0; index < modes.length; index++) {
+      const option = modes[index];
+      if (option.mode === activeMode) {
+        return {option, index};
+      }
+      if (this.isSameMode(option.mode, activeMode)) {
+        return {option, index};
+      }
+    }
+    return null;
+  }
+
+  private findOptionById(
+    modes: EditModeTrayWidgetModeOption[],
+    id: string
+  ): {option: EditModeTrayWidgetModeOption; index: number} | null {
+    for (let index = 0; index < modes.length; index++) {
+      if (this.getModeId(modes[index], index) === id) {
+        return {option: modes[index], index};
+      }
+    }
+    return null;
+  }
+
+  private getModeId(option: EditModeTrayWidgetModeOption, index: number): string {
+    if (option.id) {
+      return option.id;
+    }
+
+    const mode = option.mode as any;
+    if (mode) {
+      if (typeof mode === 'function' && mode.name) {
+        return mode.name;
+      }
+      if (mode && mode.constructor && mode.constructor.name) {
+        return mode.constructor.name;
+      }
+    }
+
+    return `mode-${index}`;
+  }
+
+  private isSameMode(
+    modeA: GeoJsonEditModeConstructor | GeoJsonEditModeType,
+    modeB: GeoJsonEditModeConstructor | GeoJsonEditModeType
+  ): boolean {
+    if (modeA === modeB) {
+      return true;
+    }
+    const constructorA = (modeA as GeoJsonEditModeType)?.constructor;
+    const constructorB = (modeB as GeoJsonEditModeType)?.constructor;
+    return Boolean(constructorA && constructorB && constructorA === constructorB);
+  }
+}

--- a/modules/editable-layers/tsconfig.json
+++ b/modules/editable-layers/tsconfig.json
@@ -6,7 +6,9 @@
     "composite": true,
     "rootDir": "src",
     "outDir": "dist",
-    "noEmit": false
+    "noEmit": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact"
   },
   "references": [
     {"path": "../layers"}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1384,6 +1384,7 @@ __metadata:
     eventemitter3: "npm:^5.0.0"
     lodash.omit: "npm:^4.1.1"
     lodash.throttle: "npm:^4.1.1"
+    preact: "npm:^10.17.0"
     uuid: "npm:9.0.0"
     viewport-mercator-project: "npm:>=6.2.3"
   peerDependencies:
@@ -10345,6 +10346,49 @@ __metadata:
 "editable-layers-editor@workspace:examples/editable-layers/editor":
   version: 0.0.0-use.local
   resolution: "editable-layers-editor@workspace:examples/editable-layers/editor"
+  dependencies:
+    "@deck.gl-community/editable-layers": "workspace:*"
+    "@deck.gl-community/layers": "workspace:*"
+    "@deck.gl-community/react": "workspace:*"
+    "@deck.gl/core": "npm:~9.2.1"
+    "@deck.gl/extensions": "npm:~9.2.1"
+    "@deck.gl/geo-layers": "npm:~9.2.1"
+    "@deck.gl/layers": "npm:~9.2.1"
+    "@deck.gl/mesh-layers": "npm:~9.2.1"
+    "@deck.gl/react": "npm:~9.2.1"
+    "@deck.gl/widgets": "npm:~9.2.1"
+    "@loaders.gl/core": "npm:^4.2.0"
+    "@loaders.gl/wkt": "npm:^4.2.0"
+    "@luma.gl/constants": "npm:~9.2.0"
+    "@luma.gl/core": "npm:~9.2.0"
+    "@luma.gl/engine": "npm:~9.2.0"
+    "@luma.gl/shadertools": "npm:~9.2.0"
+    "@maphubs/tokml": "npm:^0.6.1"
+    "@math.gl/core": "npm:^4.0.0"
+    "@tmcw/togeojson": "npm:^3.2.0"
+    "@turf/helpers": "npm:^6.5.0"
+    "@types/downloadjs": "npm:1.4.3"
+    "@types/react": "npm:^18.3.3"
+    "@types/react-dom": "npm:^18.3.0"
+    "@types/wellknown": "npm:0.5.4"
+    boxicons: "npm:^2.1.4"
+    clipboard-copy: "npm:^3.2.0"
+    downloadjs: "npm:^1.4.7"
+    maplibre-gl: "npm:^4.1.3"
+    react: "npm:^18.3.1"
+    react-dom: "npm:^18.3.1"
+    react-dropzone: "npm:^10.2.2"
+    react-map-gl: "npm:^7.1.7"
+    styled-components: "npm:^6.1.9"
+    typescript: "npm:^5.4.4"
+    vite: "npm:7.1.1"
+    wellknown: "npm:^0.5.0"
+  languageName: unknown
+  linkType: soft
+
+"editable-layers-widget@workspace:examples/editable-layers/widget":
+  version: 0.0.0-use.local
+  resolution: "editable-layers-widget@workspace:examples/editable-layers/widget"
   dependencies:
     "@deck.gl-community/editable-layers": "workspace:*"
     "@deck.gl-community/layers": "workspace:*"


### PR DESCRIPTION
## Summary
- integrate the EditModeTrayWidget into the editable-layers editor example and expose quick mode toggles
- keep the widget selection in sync with DeckGL state so toolbox changes reflect on the tray

## Testing
- yarn lint (reports existing warning in modules/react/src/components/modal.tsx)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691114231c3083289d50e0f950d2fc27)