### PR TITLE
Fix Vite resolution for deck.gl widget stylesheet

### DIFF
--- a/examples/graph-layers/graph-viewer-legacy/react-graph-layers/graph-gl.tsx
+++ b/examples/graph-layers/graph-viewer-legacy/react-graph-layers/graph-gl.tsx
@@ -16,7 +16,6 @@ import {
 import type {GraphLayerStylesheet} from '@deck.gl-community/graph-layers';
 import {PanWidget, ZoomRangeWidget} from '@deck.gl-community/widgets';
 import '@deck.gl/widgets/stylesheet.css';
-import '@deck.gl/widgets/stylesheet.css';
 
 import {extent} from 'd3-array';
 import {useGraphEngine} from './use-graph-engine';

--- a/examples/graph-layers/graph-viewer/app.tsx
+++ b/examples/graph-layers/graph-viewer/app.tsx
@@ -11,7 +11,7 @@ import DeckGL from '@deck.gl/react';
 
 import {OrthographicView} from '@deck.gl/core';
 import {PanWidget, ZoomRangeWidget} from '@deck.gl-community/widgets';
-// import '@deck.gl/widgets/stylesheet.css';
+import '@deck.gl/widgets/stylesheet.css';
 import {
   GraphLayer,
   GraphEngine,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,10 @@ export default defineConfig({
     alias: {
       // make Vite itself use Node's builtin crypto in the server process
       crypto: 'node:crypto'
-    }
+    },
+    // ensure package exports that only expose the `import` condition (e.g. @deck.gl/widgets/stylesheet.css)
+    // resolve correctly when Vite performs dependency scanning
+    conditions: ['import', 'module', 'browser', 'default']
   },
   optimizeDeps: { 
     disabled: true, // <- hard off (works in Vite 5)


### PR DESCRIPTION
## Summary
- add the `import` condition to the shared Vite config so packages that only expose CSS through the ESM condition resolve correctly
- restore the widgets stylesheet import in the graph viewer example and remove a duplicated import in the legacy build

## Testing
- `git commit` (runs repository test suite via the commit hook)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69128419dcb88328951574caca028ee6)