### PR TITLE
Add tray widget menus for boolean operations

### DIFF
--- a/examples/editable-layers/editor/example.tsx
+++ b/examples/editable-layers/editor/example.tsx
@@ -2,13 +2,34 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import React, { useState } from 'react';
+import React, {useCallback, useMemo, useState} from 'react';
 import DeckGL from '@deck.gl/react';
-import { ViewMode, EditableGeoJsonLayer } from '@deck.gl-community/editable-layers';
-import { Toolbox } from './toolbox/toolbox';
+import {
+  ViewMode,
+  DrawPointMode,
+  DrawLineStringMode,
+  DrawPolygonMode,
+  DrawRectangleMode,
+  DrawCircleFromCenterMode,
+  MeasureDistanceMode,
+  MeasureAngleMode,
+  MeasureAreaMode,
+  EditableGeoJsonLayer,
+  EditModeTrayWidget,
+  type EditModeTrayWidgetModeOption,
+  type EditModeTrayWidgetMenu,
+  type EditModeTrayWidgetMenuOption,
+  type EditModeTrayWidgetMenuSelectEvent,
+  type GeoJsonEditModeConstructor,
+  type GeoJsonEditModeType
+} from '@deck.gl-community/editable-layers';
 import StaticMap from 'react-map-gl/maplibre';
+import type {FeatureCollection} from 'geojson';
 
-export function getDefaultGeoJSON() {
+import '@deck.gl/widgets/stylesheet.css';
+import {Toolbox} from './toolbox/toolbox';
+
+export function getDefaultGeoJSON(): FeatureCollection {
   return {
     type: 'FeatureCollection',
     features: [
@@ -45,7 +66,7 @@ export function getDefaultGeoJSON() {
         }
       }
     ]
-  } as const;
+  } as FeatureCollection;
 }
 
 const initialViewState = {
@@ -54,11 +75,240 @@ const initialViewState = {
   zoom: 12
 };
 
+const MODE_OPTIONS: EditModeTrayWidgetModeOption[] = [
+  {id: 'view', mode: ViewMode, icon: '👆', title: 'View mode', label: 'View'},
+  {id: 'draw-point', mode: DrawPointMode, icon: '•', title: 'Draw point', label: 'Point'},
+  {id: 'draw-line', mode: DrawLineStringMode, icon: '╱', title: 'Draw line string', label: 'Line'},
+  {id: 'draw-polygon', mode: DrawPolygonMode, icon: '⬠', title: 'Draw polygon', label: 'Polygon'},
+  {
+    id: 'draw-rectangle',
+    mode: DrawRectangleMode,
+    icon: '▭',
+    title: 'Draw rectangle',
+    label: 'Rectangle'
+  },
+  {id: 'draw-circle', mode: DrawCircleFromCenterMode, icon: '◯', title: 'Draw circle', label: 'Circle'},
+  {
+    id: 'measure-distance',
+    mode: MeasureDistanceMode,
+    icon: '📏',
+    title: 'Measure distance',
+    label: 'Distance'
+  },
+  {id: 'measure-angle', mode: MeasureAngleMode, icon: '∠', title: 'Measure angle', label: 'Angle'},
+  {id: 'measure-area', mode: MeasureAreaMode, icon: '▢', title: 'Measure area', label: 'Area'}
+];
+
+const CONTROL_PANEL_STYLE: React.CSSProperties = {
+  position: 'absolute',
+  top: 16,
+  left: 116,
+  maxWidth: 320,
+  padding: '12px 16px 16px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '12px',
+  background: 'rgba(26, 32, 44, 0.9)',
+  color: '#f8fafc',
+  borderRadius: '12px',
+  fontFamily: 'var(--ifm-font-family-base, sans-serif)'
+};
+
+const CONTROL_SECTION_STYLE: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px'
+};
+
+const CONTROL_BUTTON_GROUP_STYLE: React.CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '8px'
+};
+
+const CONTROL_BUTTON_STYLE: React.CSSProperties = {
+  appearance: 'none',
+  border: '1px solid rgba(148, 163, 184, 0.5)',
+  borderRadius: '999px',
+  background: 'rgba(15, 23, 42, 0.4)',
+  color: '#e2e8f0',
+  padding: '6px 12px',
+  fontSize: '13px',
+  lineHeight: 1.2,
+  cursor: 'pointer',
+  transition: 'background 0.15s ease, color 0.15s ease, border-color 0.15s ease'
+};
+
+type ControlPanelProps = {
+  onClear: () => void;
+  onReset: () => void;
+};
+
+function ControlPanel({onClear, onReset}: ControlPanelProps) {
+  return (
+    <aside style={CONTROL_PANEL_STYLE}>
+      <div>
+        <h2 style={{margin: '0 0 4px', fontSize: '18px', fontWeight: 600}}>Editable layers editor</h2>
+        <p style={{margin: 0, fontSize: '14px', lineHeight: 1.5}}>
+          Select a tool from the mode tray to draw new geometries, measure features, or adjust existing
+          shapes in the scene. Configure boolean operations and other options directly from the tray menus
+          to modify how new polygons interact.
+        </p>
+      </div>
+
+      <section style={{...CONTROL_SECTION_STYLE, marginTop: '4px'}}>
+        <h3 style={{margin: 0, fontSize: '15px', fontWeight: 600}}>Dataset</h3>
+        <div style={CONTROL_BUTTON_GROUP_STYLE}>
+          <button
+            type="button"
+            style={CONTROL_BUTTON_STYLE}
+            onClick={onReset}
+          >
+            Reset example
+          </button>
+          <button
+            type="button"
+            style={{...CONTROL_BUTTON_STYLE, color: '#fecaca', borderColor: 'rgba(239, 68, 68, 0.7)'}}
+            onClick={onClear}
+          >
+            Clear features
+          </button>
+        </div>
+      </section>
+    </aside>
+  );
+}
+
+type ModeType = GeoJsonEditModeConstructor | GeoJsonEditModeType;
+
+const BOOLEAN_OPERATION_MENU_ID = 'boolean-operation';
+
+const BOOLEAN_OPERATION_MENU_OPTIONS: EditModeTrayWidgetMenuOption[] = [
+  {
+    id: 'none',
+    label: 'None',
+    title: 'Edit existing geometries without boolean operations'
+  },
+  {
+    id: 'difference',
+    label: 'Subtract',
+    title: 'Cut overlapping polygons from each other'
+  },
+  {
+    id: 'union',
+    label: 'Union',
+    title: 'Merge overlapping polygons together'
+  },
+  {
+    id: 'intersection',
+    label: 'Intersect',
+    title: 'Keep only the overlapping regions'
+  }
+];
+
+function areModesEqual(modeA: ModeType, modeB: ModeType): boolean {
+  if (modeA === modeB) {
+    return true;
+  }
+  const constructorA = (modeA as GeoJsonEditModeType)?.constructor;
+  const constructorB = (modeB as GeoJsonEditModeType)?.constructor;
+  return Boolean(constructorA && constructorB && constructorA === constructorB);
+}
+
 export function Example() {
-  const [geoJson, setGeoJson] = useState(getDefaultGeoJSON());
+  const [geoJson, setGeoJson] = useState<FeatureCollection>(getDefaultGeoJSON());
   const [selectedFeatureIndexes, setSelectedFeatureIndexes] = useState([0]);
-  const [mode, setMode] = useState(() => ViewMode);
-  const [modeConfig, setModeConfig] = useState({});
+  const [mode, setMode] = useState<ModeType>(() => ViewMode);
+  const [modeConfig, setModeConfig] = useState<Record<string, unknown>>({});
+
+  const handleSetMode = useCallback(
+    (nextMode: ModeType) => {
+      if (areModesEqual(mode, nextMode)) {
+        return;
+      }
+      setMode(() => nextMode);
+      setModeConfig({});
+    },
+    [mode, setMode, setModeConfig]
+  );
+
+  const handleReset = useCallback(() => {
+    const reset = getDefaultGeoJSON();
+    setGeoJson(reset);
+    setSelectedFeatureIndexes([0]);
+    setMode(() => ViewMode);
+    setModeConfig({});
+  }, [setGeoJson, setMode, setModeConfig, setSelectedFeatureIndexes]);
+
+  const handleClear = useCallback(() => {
+    setGeoJson({type: 'FeatureCollection', features: []});
+    setSelectedFeatureIndexes([]);
+  }, [setGeoJson, setSelectedFeatureIndexes]);
+
+  const handleImport = useCallback(
+    (imported: FeatureCollection) => {
+      setGeoJson((current) => ({
+        type: 'FeatureCollection',
+        features: [...current.features, ...imported.features]
+      }));
+    },
+    [setGeoJson]
+  );
+
+  const handleSetGeoJson = useCallback((nextGeoJson: FeatureCollection) => {
+    setGeoJson(nextGeoJson);
+  }, [setGeoJson]);
+
+  const booleanOperation =
+    typeof modeConfig?.['booleanOperation'] === 'string'
+      ? (modeConfig['booleanOperation'] as string)
+      : null;
+
+  const trayMenus = useMemo<EditModeTrayWidgetMenu[]>(() => {
+    const selectedId = booleanOperation ?? 'none';
+    return [
+      {
+        id: BOOLEAN_OPERATION_MENU_ID,
+        label: 'Boolean operations',
+        options: BOOLEAN_OPERATION_MENU_OPTIONS,
+        selectedOptionId: selectedId
+      }
+    ];
+  }, [booleanOperation]);
+
+  const handleSelectMenuOption = useCallback(
+    ({menuId, optionId}: EditModeTrayWidgetMenuSelectEvent) => {
+      if (menuId !== BOOLEAN_OPERATION_MENU_ID) {
+        return;
+      }
+      setModeConfig((current) => {
+        const next = {...current};
+        if (optionId === 'none') {
+          delete next.booleanOperation;
+        } else {
+          next.booleanOperation = optionId;
+        }
+        return next;
+      });
+    },
+    [setModeConfig]
+  );
+
+  const widgets = useMemo(() => {
+    const tray = new EditModeTrayWidget({
+      placement: 'top-left',
+      layout: 'vertical',
+      style: {margin: '16px 0 0 16px'},
+      modes: MODE_OPTIONS,
+      activeMode: mode,
+      menus: trayMenus,
+      onSelectMode: ({mode: selectedMode}) => {
+        handleSetMode(selectedMode);
+      },
+      onSelectMenuOption: handleSelectMenuOption
+    });
+    return [tray];
+  }, [handleSelectMenuOption, handleSetMode, mode, trayMenus]);
 
   const layer = new EditableGeoJsonLayer({
     data: geoJson,
@@ -80,31 +330,32 @@ export function Example() {
         layers={[layer]}
         getCursor={layer.getCursor.bind(layer)}
         onClick={(info) => {
-          if (mode === ViewMode)
-            if (info) {
-              setSelectedFeatureIndexes([info.index]);
+          if (mode === ViewMode) {
+            const index = typeof info?.index === 'number' && info.index >= 0 ? info.index : null;
+            if (index !== null) {
+              setSelectedFeatureIndexes([index]);
             } else {
               setSelectedFeatureIndexes([]);
             }
+          }
         }}
+        widgets={widgets}
       >
         <StaticMap mapStyle={'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json'} />
       </DeckGL>
 
+      <ControlPanel
+        onClear={handleClear}
+        onReset={handleReset}
+      />
       <Toolbox
-        left={true}
         geoJson={geoJson}
         mode={mode}
         modeConfig={modeConfig}
-        onSetMode={setMode}
+        onSetMode={handleSetMode}
         onSetModeConfig={setModeConfig}
-        onImport={(imported) =>
-          setGeoJson({
-            ...geoJson,
-            features: [...geoJson.features, ...imported.features]
-          })
-        }
-        onSetGeoJson={setGeoJson}
+        onSetGeoJson={handleSetGeoJson}
+        onImport={handleImport}
       />
     </>
   );

--- a/examples/editable-layers/editor/svg.d.ts
+++ b/examples/editable-layers/editor/svg.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg?url' {
+  const src: string;
+  export default src;
+}

--- a/examples/editable-layers/editor/toolbox/toolbox.tsx
+++ b/examples/editable-layers/editor/toolbox/toolbox.tsx
@@ -8,26 +8,46 @@ import {
   DrawRectangleMode,
   MeasureDistanceMode,
   MeasureAngleMode,
-  MeasureAreaMode
+  MeasureAreaMode,
+  type GeoJsonEditModeConstructor,
+  type GeoJsonEditModeType
 } from '@deck.gl-community/editable-layers';
 import styled from 'styled-components';
-import {Icon} from '@deck.gl-community/react';
 
 import {ImportModal} from './import-modal';
 import {ExportModal} from './export-modal';
+import type {FeatureCollection} from 'geojson';
 
-const Tools = styled.div<{left: boolean}>`
+import pointerIconUrl from 'boxicons/svg/regular/bx-pointer.svg?url';
+import mapPinIconUrl from 'boxicons/svg/regular/bx-map-pin.svg?url';
+import statsIconUrl from 'boxicons/svg/regular/bx-stats.svg?url';
+import polygonIconUrl from 'boxicons/svg/regular/bx-shape-polygon.svg?url';
+import rectangleIconUrl from 'boxicons/svg/regular/bx-rectangle.svg?url';
+import circleIconUrl from 'boxicons/svg/regular/bx-circle.svg?url';
+import rulerIconUrl from 'boxicons/svg/regular/bx-ruler.svg?url';
+import triangleIconUrl from 'boxicons/svg/regular/bx-shape-triangle.svg?url';
+import squareIconUrl from 'boxicons/svg/regular/bx-shape-square.svg?url';
+import exportIconUrl from 'boxicons/svg/regular/bx-export.svg?url';
+import importIconUrl from 'boxicons/svg/regular/bx-import.svg?url';
+import chevronRightIconUrl from 'boxicons/svg/regular/bx-chevron-right.svg?url';
+import minusFrontIconUrl from 'boxicons/svg/regular/bx-minus-front.svg?url';
+import uniteIconUrl from 'boxicons/svg/regular/bx-unite.svg?url';
+import intersectIconUrl from 'boxicons/svg/regular/bx-intersect.svg?url';
+import cogIconUrl from 'boxicons/svg/regular/bx-cog.svg?url';
+import trashIconUrl from 'boxicons/svg/regular/bx-trash.svg?url';
+
+const Tools = styled.div<{$left: boolean}>`
   position: absolute;
   display: flex;
   flex-direction: column;
   top: 10px;
-  ${(props) => (props.left ? 'left' : 'right')}: 10px;
+  ${(props) => (props.$left ? 'left' : 'right')}: 10px;
 `;
 
-const Button = styled.button<{active?: boolean; kind?: string}>`
+const Button = styled.button<{$active?: boolean; $kind?: 'danger'}>`
   color: #fff;
-  background: ${({kind, active}) =>
-    kind === 'danger' ? 'rgb(180, 40, 40)' : active ? 'rgb(0, 105, 217)' : 'rgb(90, 98, 94)'};
+  background: ${({$kind, $active}) =>
+    $kind === 'danger' ? 'rgb(180, 40, 40)' : $active ? 'rgb(0, 105, 217)' : 'rgb(90, 98, 94)'};
   font-size: 1em;
   font-weight: 400;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
@@ -37,6 +57,10 @@ const Button = styled.button<{active?: boolean; kind?: string}>`
   border-radius: 0.25em;
   margin: 0.05em;
   padding: 0.1em 0.2em;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25em;
   :hover {
     background: rgb(128, 137, 133);
   }
@@ -46,81 +70,154 @@ const SubToolsContainer = styled.div`
   position: relative;
 `;
 
-const SubTools = styled.div<{left: boolean}>`
+const SubTools = styled.div<{$left: boolean}>`
   display: flex;
   flex-direction: row-reverse;
   position: absolute;
   top: 0;
-  ${(props) => (props.left ? 'left' : 'right')}: 0;
+  ${(props) => (props.$left ? 'left' : 'right')}: 0;
 `;
+
+const ICON_SIZE = 20;
+
+type IconImageProps = {
+  src: string;
+  label?: string;
+  ariaHidden?: boolean;
+};
+
+function IconImage({src, label, ariaHidden = false}: IconImageProps) {
+  return (
+    <img
+      src={src}
+      alt={ariaHidden ? '' : label ?? ''}
+      aria-hidden={ariaHidden ? true : undefined}
+      width={ICON_SIZE}
+      height={ICON_SIZE}
+      style={{display: 'block'}}
+      draggable={false}
+    />
+  );
+}
+
+const ICONS = {
+  pointer: pointerIconUrl,
+  mapPin: mapPinIconUrl,
+  stats: statsIconUrl,
+  polygon: polygonIconUrl,
+  rectangle: rectangleIconUrl,
+  circle: circleIconUrl,
+  ruler: rulerIconUrl,
+  triangle: triangleIconUrl,
+  square: squareIconUrl,
+  export: exportIconUrl,
+  import: importIconUrl,
+  chevronRight: chevronRightIconUrl,
+  minusFront: minusFrontIconUrl,
+  unite: uniteIconUrl,
+  intersect: intersectIconUrl,
+  cog: cogIconUrl,
+  trash: trashIconUrl
+} as const;
+
+type ModeOption = {
+  mode: GeoJsonEditModeConstructor | GeoJsonEditModeType;
+  icon: string;
+  label: string;
+};
+
+type ModeGroup = {
+  modes: ModeOption[];
+};
 
 export type Props = {
   left?: boolean;
-  mode: any;
-  modeConfig: any;
-  geoJson: any;
-  onSetMode: (mode: any) => unknown;
-  onSetModeConfig: (modeConfig: any) => unknown;
-  onSetGeoJson: (geojson: any) => unknown;
-  onImport: (imported: any) => unknown;
+  mode: GeoJsonEditModeConstructor | GeoJsonEditModeType;
+  modeConfig: Record<string, unknown>;
+  geoJson: FeatureCollection;
+  onSetMode: (mode: GeoJsonEditModeConstructor | GeoJsonEditModeType) => void;
+  onSetModeConfig: (modeConfig: Record<string, unknown>) => void;
+  onSetGeoJson: (geojson: FeatureCollection) => void;
+  onImport: (imported: FeatureCollection) => void;
 };
 
-const MODE_GROUPS = [
+const MODE_GROUPS: ModeGroup[] = [
   {
-    modes: [{mode: ViewMode, content: <Icon name="pointer" />}]
+    modes: [{mode: ViewMode, icon: ICONS.pointer, label: 'View mode'}]
   },
   {
-    modes: [{mode: DrawPointMode, content: <Icon name="map-pin" />}]
+    modes: [{mode: DrawPointMode, icon: ICONS.mapPin, label: 'Draw point'}]
+  },
+  {
+    modes: [{mode: DrawLineStringMode, icon: ICONS.stats, label: 'Draw line string'}]
   },
   {
     modes: [
-      {
-        mode: DrawLineStringMode,
-        content: <Icon name="stats" />
-      }
+      {mode: DrawPolygonMode, icon: ICONS.polygon, label: 'Draw polygon'},
+      {mode: DrawRectangleMode, icon: ICONS.rectangle, label: 'Draw rectangle'},
+      {mode: DrawCircleFromCenterMode, icon: ICONS.circle, label: 'Draw circle'}
     ]
   },
   {
     modes: [
-      {mode: DrawPolygonMode, content: <Icon name="shape-polygon" />},
-      {mode: DrawRectangleMode, content: <Icon name="rectangle" />},
-      {mode: DrawCircleFromCenterMode, content: <Icon name="circle" />}
-    ]
-  },
-  {
-    modes: [
-      {mode: MeasureDistanceMode, content: <Icon name="ruler" />},
-      {mode: MeasureAngleMode, content: <Icon name="shape-triangle" />},
-      {mode: MeasureAreaMode, content: <Icon name="shape-square" />}
+      {mode: MeasureDistanceMode, icon: ICONS.ruler, label: 'Measure distance'},
+      {mode: MeasureAngleMode, icon: ICONS.triangle, label: 'Measure angle'},
+      {mode: MeasureAreaMode, icon: ICONS.square, label: 'Measure area'}
     ]
   }
 ];
 
-function ModeButton({buttonConfig, mode, onClick}: any) {
+function ModeButton({
+  buttonConfig,
+  mode,
+  onClick
+}: {
+  buttonConfig: ModeOption;
+  mode: GeoJsonEditModeConstructor | GeoJsonEditModeType;
+  onClick: () => void;
+}) {
+  const isActive = buttonConfig.mode === mode;
   return (
-    <Button active={buttonConfig.mode === mode} onClick={onClick}>
-      {buttonConfig.content}
+    <Button
+      type="button"
+      $active={isActive}
+      onClick={onClick}
+      title={buttonConfig.label}
+      aria-label={buttonConfig.label}
+      aria-pressed={isActive}
+    >
+      <IconImage src={buttonConfig.icon} ariaHidden={true} />
     </Button>
   );
 }
 
-function ModeGroupButtons({left, modeGroup, mode, onSetMode}: any) {
+function ModeGroupButtons({
+  left,
+  modeGroup,
+  mode,
+  onSetMode
+}: {
+  left?: boolean;
+  modeGroup: ModeGroup;
+  mode: GeoJsonEditModeConstructor | GeoJsonEditModeType;
+  onSetMode: (mode: GeoJsonEditModeConstructor | GeoJsonEditModeType) => void;
+}) {
   const [expanded, setExpanded] = React.useState(false);
 
   const {modes} = modeGroup;
-  
+
   let subTools = null;
 
   if (expanded) {
     subTools = (
-      <SubTools left={left}>
+      <SubTools $left={Boolean(left)}>
         {modes.map((buttonConfig, i) => (
           <ModeButton
             key={i}
             buttonConfig={buttonConfig}
             mode={mode}
             onClick={() => {
-              onSetMode(() => buttonConfig.mode);
+              onSetMode(buttonConfig.mode);
               setExpanded(false);
             }}
           />
@@ -139,7 +236,7 @@ function ModeGroupButtons({left, modeGroup, mode, onSetMode}: any) {
         buttonConfig={buttonConfig}
         mode={mode}
         onClick={() => {
-          onSetMode(() => buttonConfig.mode);
+          onSetMode(buttonConfig.mode);
           setExpanded(true);
         }}
       />
@@ -161,10 +258,14 @@ export function Toolbox({
   const [showImport, setShowImport] = React.useState(false);
   const [showExport, setShowExport] = React.useState(false);
   const [showClearConfirmation, setShowClearConfirmation] = React.useState(false);
+  const booleanOperation =
+    typeof modeConfig?.['booleanOperation'] === 'string'
+      ? (modeConfig['booleanOperation'] as string)
+      : null;
 
   return (
     <>
-      <Tools left={left}>
+      <Tools $left={Boolean(left)}>
         {MODE_GROUPS.map((modeGroup, i) => (
           <ModeGroupButtons
             left={left}
@@ -176,65 +277,103 @@ export function Toolbox({
         ))}
 
         {/* <box-icon name='current-location' ></box-icon> */}
-        <Button onClick={() => setShowExport(true)} title="Export">
-          <Icon name="export" />
+        <Button
+          type="button"
+          onClick={() => setShowExport(true)}
+          title="Export"
+          aria-label="Export"
+        >
+          <IconImage src={ICONS.export} ariaHidden={true} />
         </Button>
-        <Button onClick={() => setShowImport(true)} title="Import">
-          <Icon name="import" />
+        <Button
+          type="button"
+          onClick={() => setShowImport(true)}
+          title="Import"
+          aria-label="Import"
+        >
+          <IconImage src={ICONS.import} ariaHidden={true} />
         </Button>
 
         <SubToolsContainer>
           {showConfig && (
-            <SubTools left={left}>
-              <Button onClick={() => setShowConfig(false)}>
-                <Icon name="chevron-right" />
+            <SubTools $left={Boolean(left)}>
+              <Button
+                type="button"
+                onClick={() => setShowConfig(false)}
+                title="Close boolean operation options"
+                aria-label="Close boolean operation options"
+              >
+                <IconImage src={ICONS.chevronRight} ariaHidden={true} />
               </Button>
               <Button
+                type="button"
                 onClick={() => onSetModeConfig({booleanOperation: 'difference'})}
-                active={modeConfig && modeConfig.booleanOperation === 'difference'}
+                $active={booleanOperation === 'difference'}
+                title="Subtract"
+                aria-label="Subtract"
               >
-                <Icon name="minus-front" />
+                <IconImage src={ICONS.minusFront} ariaHidden={true} />
               </Button>
               <Button
+                type="button"
                 onClick={() => onSetModeConfig({booleanOperation: 'union'})}
-                active={modeConfig && modeConfig.booleanOperation === 'union'}
+                $active={booleanOperation === 'union'}
+                title="Union"
+                aria-label="Union"
               >
-                <Icon name="unite" />
+                <IconImage src={ICONS.unite} ariaHidden={true} />
               </Button>
               <Button
+                type="button"
                 onClick={() => onSetModeConfig({booleanOperation: 'intersection'})}
-                active={modeConfig && modeConfig.booleanOperation === 'intersection'}
+                $active={booleanOperation === 'intersection'}
+                title="Intersect"
+                aria-label="Intersect"
               >
-                <Icon name="intersect" />
+                <IconImage src={ICONS.intersect} ariaHidden={true} />
               </Button>
               {/* <Button onClick={() => setShowConfig(false)}>
-                <Icon name="x" />
+                <IconImage src={ICONS.chevronRight} ariaHidden={true} />
               </Button> */}
             </SubTools>
           )}
-          <Button onClick={() => setShowConfig(true)}>
-            <Icon name="cog" />
+          <Button
+            type="button"
+            onClick={() => setShowConfig(true)}
+            title="Boolean operations"
+            aria-label="Boolean operations"
+          >
+            <IconImage src={ICONS.cog} ariaHidden={true} />
           </Button>
         </SubToolsContainer>
 
         <SubToolsContainer>
           {showClearConfirmation && (
-            <SubTools left={left}>
+            <SubTools $left={Boolean(left)}>
               <Button
+                type="button"
                 onClick={() => {
                   onSetGeoJson({type: 'FeatureCollection', features: []});
                   setShowClearConfirmation(false);
                 }}
-                kind="danger"
+                $kind="danger"
                 title="Clear all features"
               >
-                Clear all features <Icon name="trash" />
+                Clear all features
+                <IconImage src={ICONS.trash} ariaHidden={true} />
               </Button>
-              <Button onClick={() => setShowClearConfirmation(false)}>Cancel</Button>
+              <Button type="button" onClick={() => setShowClearConfirmation(false)}>
+                Cancel
+              </Button>
             </SubTools>
           )}
-          <Button onClick={() => setShowClearConfirmation(true)} title="Clear">
-            <Icon name="trash" />
+          <Button
+            type="button"
+            onClick={() => setShowClearConfirmation(true)}
+            title="Clear"
+            aria-label="Clear"
+          >
+            <IconImage src={ICONS.trash} ariaHidden={true} />
           </Button>
         </SubToolsContainer>
 

--- a/modules/editable-layers/package.json
+++ b/modules/editable-layers/package.json
@@ -67,6 +67,7 @@
     "eventemitter3": "^5.0.0",
     "lodash.omit": "^4.1.1",
     "lodash.throttle": "^4.1.1",
+    "preact": "^10.17.0",
     "uuid": "9.0.0",
     "viewport-mercator-project": ">=6.2.3"
   },

--- a/modules/editable-layers/src/index.ts
+++ b/modules/editable-layers/src/index.ts
@@ -29,6 +29,17 @@ export {EditableH3ClusterLayer} from './editable-layers/editable-h3-cluster-laye
 export {SelectionLayer} from './editable-layers/selection-layer';
 export {ElevatedEditHandleLayer} from './editable-layers/elevated-edit-handle-layer';
 
+// Widgets
+export {EditModeTrayWidget} from './widgets/edit-mode-tray-widget';
+export type {
+  EditModeTrayWidgetProps,
+  EditModeTrayWidgetModeOption,
+  EditModeTrayWidgetSelectEvent,
+  EditModeTrayWidgetMenu,
+  EditModeTrayWidgetMenuOption,
+  EditModeTrayWidgetMenuSelectEvent
+} from './widgets/edit-mode-tray-widget';
+
 // Layers move to deck.gl-community/layers?
 export {JunctionScatterplotLayer} from './editable-layers/junction-scatterplot-layer';
 

--- a/modules/editable-layers/src/widgets/edit-mode-tray-widget.tsx
+++ b/modules/editable-layers/src/widgets/edit-mode-tray-widget.tsx
@@ -1,0 +1,523 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {render} from 'preact';
+import type {ComponentChild, JSX} from 'preact';
+import {
+  Widget,
+  type WidgetProps,
+  type WidgetPlacement,
+  type Deck
+} from '@deck.gl/core';
+import type {
+  GeoJsonEditModeConstructor,
+  GeoJsonEditModeType
+} from '../edit-modes/geojson-edit-mode';
+
+export type EditModeTrayWidgetModeOption = {
+  /**
+   * Optional identifier for the mode button.
+   * If not provided, one will be inferred from the supplied mode.
+   */
+  id?: string;
+  /** Edit mode constructor or instance that the button should activate. */
+  mode: GeoJsonEditModeConstructor | GeoJsonEditModeType;
+  /**
+   * The icon or element rendered inside the button.
+   * A simple string can also be supplied for text labels.
+   */
+  icon?: ComponentChild;
+  /** Optional text label rendered below the icon when provided. */
+  label?: string;
+  /** Optional tooltip text applied to the button element. */
+  title?: string;
+};
+
+export type EditModeTrayWidgetSelectEvent = {
+  id: string;
+  mode: GeoJsonEditModeConstructor | GeoJsonEditModeType;
+  option: EditModeTrayWidgetModeOption;
+};
+
+export type EditModeTrayWidgetMenuOption = {
+  /** Unique identifier for the option within its menu. */
+  id: string;
+  /** Optional icon rendered before the label. */
+  icon?: ComponentChild;
+  /** Optional text label for the option. */
+  label?: string;
+  /** Optional tooltip text applied to the option button. */
+  title?: string;
+};
+
+export type EditModeTrayWidgetMenu = {
+  /** Identifier for the menu group. */
+  id: string;
+  /** Optional label rendered above the menu options. */
+  label?: string;
+  /** Collection of selectable options. */
+  options: EditModeTrayWidgetMenuOption[];
+  /** Identifier of the currently selected option. */
+  selectedOptionId?: string | null;
+};
+
+export type EditModeTrayWidgetMenuSelectEvent = {
+  menuId: string;
+  optionId: string;
+  menu: EditModeTrayWidgetMenu;
+  option: EditModeTrayWidgetMenuOption;
+};
+
+export type EditModeTrayWidgetProps = WidgetProps & {
+  /** Placement for the widget root element. */
+  placement?: WidgetPlacement;
+  /** Layout direction for mode buttons. */
+  layout?: 'vertical' | 'horizontal';
+  /** Collection of modes rendered in the tray. */
+  modes?: EditModeTrayWidgetModeOption[];
+  /** Identifier of the currently active mode. */
+  selectedModeId?: string | null;
+  /** Currently active mode instance/constructor. */
+  activeMode?: GeoJsonEditModeConstructor | GeoJsonEditModeType | null;
+  /** Callback fired when the user selects a mode. */
+  onSelectMode?: (event: EditModeTrayWidgetSelectEvent) => void;
+  /** Optional configuration menus rendered beneath the mode list. */
+  menus?: EditModeTrayWidgetMenu[];
+  /** Callback fired when the user selects a menu option. */
+  onSelectMenuOption?: (event: EditModeTrayWidgetMenuSelectEvent) => void;
+};
+
+const ROOT_STYLE: Partial<CSSStyleDeclaration> = {
+  position: 'absolute',
+  display: 'flex',
+  pointerEvents: 'auto',
+  userSelect: 'none',
+  zIndex: '99'
+};
+
+const TRAY_BASE_STYLE: JSX.CSSProperties = {
+  display: 'flex',
+  gap: '6px',
+  background: 'rgba(36, 40, 41, 0.88)',
+  borderRadius: '999px',
+  padding: '6px',
+  alignItems: 'center',
+  justifyContent: 'center',
+  boxShadow: '0 4px 12px rgba(0, 0, 0, 0.25)'
+};
+
+const BUTTON_BASE_STYLE: JSX.CSSProperties = {
+  appearance: 'none',
+  background: 'transparent',
+  border: 'none',
+  color: '#f0f0f0',
+  width: '34px',
+  height: '34px',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: '50%',
+  cursor: 'pointer',
+  padding: '0',
+  transition: 'background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease'
+};
+
+const BUTTON_ACTIVE_STYLE: JSX.CSSProperties = {
+  background: '#0071e3',
+  color: '#ffffff',
+  boxShadow: '0 0 0 2px rgba(255, 255, 255, 0.35)'
+};
+
+const BUTTON_LABEL_STYLE: JSX.CSSProperties = {
+  fontSize: '10px',
+  marginTop: '2px',
+  lineHeight: '12px'
+};
+
+const MENU_WRAPPER_STYLE: JSX.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '6px',
+  width: '100%'
+};
+
+const MENU_SECTION_STYLE: JSX.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '4px',
+  width: '100%'
+};
+
+const MENU_LABEL_STYLE: JSX.CSSProperties = {
+  fontSize: '9px',
+  lineHeight: '10px',
+  color: '#d1d5db',
+  textAlign: 'center',
+  letterSpacing: '0.04em',
+  textTransform: 'uppercase'
+};
+
+const MENU_OPTIONS_STYLE: JSX.CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  justifyContent: 'center',
+  gap: '4px'
+};
+
+const MENU_OPTION_BUTTON_STYLE: JSX.CSSProperties = {
+  appearance: 'none',
+  background: 'rgba(20, 24, 27, 0.7)',
+  border: '1px solid transparent',
+  borderRadius: '999px',
+  color: '#f5f5f5',
+  cursor: 'pointer',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '4px',
+  fontSize: '10px',
+  lineHeight: '12px',
+  padding: '4px 8px',
+  transition: 'background 0.15s ease, color 0.15s ease, border-color 0.15s ease'
+};
+
+const MENU_OPTION_BUTTON_ACTIVE_STYLE: JSX.CSSProperties = {
+  background: '#1f2937',
+  borderColor: 'rgba(59, 130, 246, 0.6)'
+};
+
+const MENU_OPTION_ICON_STYLE: JSX.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center'
+};
+
+const MENU_OPTION_LABEL_STYLE: JSX.CSSProperties = {
+  display: 'inline-block'
+};
+
+export class EditModeTrayWidget extends Widget<EditModeTrayWidgetProps> {
+  static override defaultProps = {
+    id: 'edit-mode-tray',
+    placement: 'top-left',
+    layout: 'vertical',
+    modes: [],
+    menus: [],
+    style: {},
+    className: ''
+  } satisfies Required<WidgetProps> &
+    Required<Pick<EditModeTrayWidgetProps, 'placement' | 'layout'>> &
+    EditModeTrayWidgetProps;
+
+  placement: WidgetPlacement = 'top-left';
+  className = 'deck-widget-edit-mode-tray';
+  layout: 'vertical' | 'horizontal' = 'vertical';
+  selectedModeId: string | null = null;
+  deck?: Deck | null = null;
+  private rootElement: HTMLElement | null = null;
+  private appliedCustomClassName: string | null = null;
+  private menuSelections: Map<string, string | null> = new Map();
+
+  constructor(props: EditModeTrayWidgetProps = {}) {
+    super({...EditModeTrayWidget.defaultProps, ...props});
+    this.placement = props.placement ?? EditModeTrayWidget.defaultProps.placement;
+    this.layout = props.layout ?? EditModeTrayWidget.defaultProps.layout;
+    const modes = props.modes ?? [];
+    const menus = props.menus ?? [];
+    this.selectedModeId = this.resolveSelectedModeId(modes, props);
+    this.updateMenuSelections(menus);
+  }
+
+  override setProps(props: Partial<EditModeTrayWidgetProps>): void {
+    if (props.placement !== undefined) {
+      this.placement = props.placement;
+    }
+    if (props.layout !== undefined) {
+      this.layout = props.layout;
+    }
+
+    const modes = props.modes ?? this.props.modes ?? [];
+    const menus = props.menus ?? this.props.menus ?? [];
+    this.selectedModeId = this.resolveSelectedModeId(modes, props);
+    this.updateMenuSelections(menus);
+
+    super.setProps(props);
+    this.renderTray();
+  }
+
+  override onAdd({deck}: {deck: Deck}): void {
+    this.deck = deck;
+  }
+
+  override onRemove(): void {
+    this.deck = null;
+    const root = this.rootElement;
+    if (root) {
+      render(null, root);
+    }
+    this.rootElement = null;
+  }
+
+  override onRenderHTML(rootElement: HTMLElement): void {
+    this.rootElement = rootElement;
+    const style = {...ROOT_STYLE, ...this.props.style};
+    Object.assign(rootElement.style, style);
+    if (this.appliedCustomClassName && this.appliedCustomClassName !== this.props.className) {
+      rootElement.classList.remove(this.appliedCustomClassName);
+      this.appliedCustomClassName = null;
+    }
+    if (this.props.className) {
+      rootElement.classList.add(this.props.className);
+      this.appliedCustomClassName = this.props.className;
+    }
+    rootElement.classList.add(this.className);
+
+    this.renderTray();
+  }
+
+  private renderTray() {
+    const root = this.rootElement;
+    if (!root) {
+      return;
+    }
+
+    const modes = this.props.modes ?? [];
+    const menus = this.props.menus ?? [];
+    const selectedId = this.selectedModeId;
+    const direction = this.layout === 'horizontal' ? 'row' : 'column';
+    const hasMenus = menus.length > 0;
+
+    const trayStyle: JSX.CSSProperties = {
+      ...TRAY_BASE_STYLE,
+      flexDirection: hasMenus ? 'column' : direction,
+      alignItems: hasMenus ? 'stretch' : TRAY_BASE_STYLE.alignItems
+    };
+
+    const modeListStyle: JSX.CSSProperties = {
+      display: 'flex',
+      flexDirection: direction,
+      gap: TRAY_BASE_STYLE.gap,
+      alignItems: 'center',
+      justifyContent: 'center'
+    };
+
+    const stopEvent = (event: Event) => {
+      event.stopPropagation();
+      if (typeof (event as any).stopImmediatePropagation === 'function') {
+        (event as any).stopImmediatePropagation();
+      }
+    };
+
+    const ui = (
+      <div
+        style={trayStyle}
+        onPointerDown={stopEvent}
+        onPointerMove={stopEvent}
+        onPointerUp={stopEvent}
+        onMouseDown={stopEvent}
+        onMouseMove={stopEvent}
+        onMouseUp={stopEvent}
+        onTouchStart={stopEvent}
+        onTouchMove={stopEvent}
+        onTouchEnd={stopEvent}
+      >
+        <div style={modeListStyle}>
+          {modes.map((option, index) => {
+            const id = this.getModeId(option, index);
+            const active = id === selectedId;
+            const label = option.label ?? '';
+            const title = option.title ?? label;
+
+            const buttonStyle: JSX.CSSProperties = {
+              ...BUTTON_BASE_STYLE,
+              ...(active ? BUTTON_ACTIVE_STYLE : {})
+            };
+
+            return (
+              <button
+                key={id}
+                type="button"
+                title={title || undefined}
+                aria-pressed={active}
+                style={buttonStyle}
+                onClick={(event) => {
+                  stopEvent(event);
+                  this.handleSelect(option, id);
+                }}
+              >
+                {option.icon}
+                {label ? <span style={BUTTON_LABEL_STYLE}>{label}</span> : null}
+              </button>
+            );
+          })}
+        </div>
+        {hasMenus ? (
+          <div style={MENU_WRAPPER_STYLE}>
+            {menus.map((menu) => {
+              const menuSelectedId = menu.selectedOptionId ?? this.menuSelections.get(menu.id) ?? null;
+              return (
+                <div key={menu.id} style={MENU_SECTION_STYLE}>
+                  {menu.label ? <span style={MENU_LABEL_STYLE}>{menu.label}</span> : null}
+                  <div style={MENU_OPTIONS_STYLE}>
+                    {menu.options.map((option) => {
+                      const optionId = option.id;
+                      const active = optionId === menuSelectedId;
+                      const title = option.title ?? option.label ?? '';
+                      const optionStyle: JSX.CSSProperties = {
+                        ...MENU_OPTION_BUTTON_STYLE,
+                        ...(active ? MENU_OPTION_BUTTON_ACTIVE_STYLE : {})
+                      };
+
+                      return (
+                        <button
+                          key={optionId}
+                          type="button"
+                          title={title || undefined}
+                          aria-pressed={active}
+                          style={optionStyle}
+                          onClick={(event) => {
+                            stopEvent(event);
+                            this.handleSelectMenuOption(menu, option);
+                          }}
+                        >
+                          {option.icon ? <span style={MENU_OPTION_ICON_STYLE}>{option.icon}</span> : null}
+                          {option.label ? <span style={MENU_OPTION_LABEL_STYLE}>{option.label}</span> : null}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : null}
+      </div>
+    );
+
+    render(ui, root);
+  }
+
+  private handleSelect(option: EditModeTrayWidgetModeOption, id: string) {
+    if (this.selectedModeId !== id) {
+      this.selectedModeId = id;
+      this.renderTray();
+    }
+
+    this.props.onSelectMode?.({
+      id,
+      mode: option.mode,
+      option
+    });
+  }
+
+  private handleSelectMenuOption(menu: EditModeTrayWidgetMenu, option: EditModeTrayWidgetMenuOption) {
+    this.menuSelections.set(menu.id, option.id);
+    this.renderTray();
+
+    this.props.onSelectMenuOption?.({
+      menuId: menu.id,
+      optionId: option.id,
+      menu,
+      option
+    });
+  }
+
+  private updateMenuSelections(menus: EditModeTrayWidgetMenu[]): void {
+    const previousSelections = this.menuSelections;
+    const nextSelections = new Map<string, string | null>();
+
+    for (const menu of menus) {
+      const selected =
+        menu.selectedOptionId ?? previousSelections.get(menu.id) ?? (menu.options[0]?.id ?? null);
+      nextSelections.set(menu.id, selected ?? null);
+    }
+
+    this.menuSelections = nextSelections;
+  }
+
+  private resolveSelectedModeId(
+    modes: EditModeTrayWidgetModeOption[],
+    props: Partial<EditModeTrayWidgetProps>
+  ): string | null {
+    if (props.selectedModeId !== undefined) {
+      return props.selectedModeId;
+    }
+
+    const activeMode = props.activeMode ?? this.props?.activeMode ?? null;
+    if (activeMode) {
+      const match = this.findOptionByMode(modes, activeMode);
+      if (match) {
+        return this.getModeId(match.option, match.index);
+      }
+    }
+
+    if (this.selectedModeId) {
+      const existing = this.findOptionById(modes, this.selectedModeId);
+      if (existing) {
+        return this.selectedModeId;
+      }
+    }
+
+    const first = modes[0];
+    return first ? this.getModeId(first, 0) : null;
+  }
+
+  private findOptionByMode(
+    modes: EditModeTrayWidgetModeOption[],
+    activeMode: GeoJsonEditModeConstructor | GeoJsonEditModeType
+  ): {option: EditModeTrayWidgetModeOption; index: number} | null {
+    for (let index = 0; index < modes.length; index++) {
+      const option = modes[index];
+      if (option.mode === activeMode) {
+        return {option, index};
+      }
+      if (this.isSameMode(option.mode, activeMode)) {
+        return {option, index};
+      }
+    }
+    return null;
+  }
+
+  private findOptionById(
+    modes: EditModeTrayWidgetModeOption[],
+    id: string
+  ): {option: EditModeTrayWidgetModeOption; index: number} | null {
+    for (let index = 0; index < modes.length; index++) {
+      if (this.getModeId(modes[index], index) === id) {
+        return {option: modes[index], index};
+      }
+    }
+    return null;
+  }
+
+  private getModeId(option: EditModeTrayWidgetModeOption, index: number): string {
+    if (option.id) {
+      return option.id;
+    }
+
+    const mode = option.mode as any;
+    if (mode) {
+      if (typeof mode === 'function' && mode.name) {
+        return mode.name;
+      }
+      if (mode && mode.constructor && mode.constructor.name) {
+        return mode.constructor.name;
+      }
+    }
+
+    return `mode-${index}`;
+  }
+
+  private isSameMode(
+    modeA: GeoJsonEditModeConstructor | GeoJsonEditModeType,
+    modeB: GeoJsonEditModeConstructor | GeoJsonEditModeType
+  ): boolean {
+    if (modeA === modeB) {
+      return true;
+    }
+    const constructorA = (modeA as GeoJsonEditModeType)?.constructor;
+    const constructorB = (modeB as GeoJsonEditModeType)?.constructor;
+    return Boolean(constructorA && constructorB && constructorA === constructorB);
+  }
+}

--- a/modules/editable-layers/tsconfig.json
+++ b/modules/editable-layers/tsconfig.json
@@ -6,7 +6,9 @@
     "composite": true,
     "rootDir": "src",
     "outDir": "dist",
-    "noEmit": false
+    "noEmit": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact"
   },
   "references": [
     {"path": "../layers"}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1384,6 +1384,7 @@ __metadata:
     eventemitter3: "npm:^5.0.0"
     lodash.omit: "npm:^4.1.1"
     lodash.throttle: "npm:^4.1.1"
+    preact: "npm:^10.17.0"
     uuid: "npm:9.0.0"
     viewport-mercator-project: "npm:>=6.2.3"
   peerDependencies:


### PR DESCRIPTION
## Summary
- extend the edit-mode tray widget with optional configuration menus and selection callbacks
- export the new menu types from the editable-layers entry point
- wire the editor example to configure boolean operations via the tray widget and simplify the control panel layout

## Testing
- yarn lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691114231c3083289d50e0f950d2fc27)