### PR TITLE
docs: refresh GraphLayout guide

### DIFF
--- a/docs/modules/graph-layers/api-reference/layouts/graph-layout.md
+++ b/docs/modules/graph-layers/api-reference/layouts/graph-layout.md
@@ -1,257 +1,187 @@
 # GraphLayout
 
-Create a subclass of the `GraphLayout` class to write your own custom layout for the `GraphLayer`.
+Create a subclass of the `GraphLayout` class to implement a custom layout for the `GraphLayer`.
 
-## Usage 
+## Usage
 
-The example belows illustrates the methods you will need to implement when creating your own custom layout.
+The recommended pattern is to implement a strongly typed subclass that defines its own default props, forwards them to `GraphLayout`, and emits layout lifecycle events when positions change.
 
-```js
+```ts
+import type {
+  ClassicGraph,
+  EdgeInterface,
+  GraphLayoutProps,
+  NodeInterface
+} from '@deck.gl-community/graph-layers';
 import {GraphLayout} from '@deck.gl-community/graph-layers';
 
-export class MyLayout extends GraphLayout {
-  // initialize the layout
-  constructor(options) {}
-  // first time to pass the graph data into this layout
-  initializeGraph(graph) {}
-  // update the existing graph
-  updateGraph(graph) {}
-  // start the layout calculation
-  start() {}
-  // update the layout calculation
-  update() {}
-  // resume the layout calculation manually
-  resume() {}
-  // stop the layout calculation manually
-  stop() {}
+type RandomLayoutProps = GraphLayoutProps & {
+  viewportWidth: number;
+  viewportHeight: number;
+};
 
-  // Access the position of the node in the layout
-  // If the position is not available (not calculated), returning nullish will hide the node.
-  getNodePosition(node) {}
-  // access the layout information of the edge
-  getEdgePosition(edge) {}
-  // Pin the node to a designated position, and the node won't move anymore
-  lockNodePosition(node, x, y) {}
-  // Unlock the node, the node will be able to move freely.
-  unlockNodePosition(node) {}
-}
-```
+type EdgePosition = {
+  type: 'line';
+  sourcePosition: [number, number];
+  targetPosition: [number, number];
+  controlPoints: [];
+};
 
-We will start with a `RandomLayout` as an example, you can follow the steps one by one and find the source code at the bottom.
+export class RandomLayout extends GraphLayout<RandomLayoutProps> {
+  static readonly defaultProps: RandomLayoutProps = {
+    viewportWidth: 1024,
+    viewportHeight: 768
+  };
 
-## The Layout Lifecycle
+  protected override readonly _name = 'RandomLayout';
 
-For a graph layout, everything goes through a set of events. In each event, the layout will need to take the inputs and do the different computations. Lifecycle methods are various methods which are invoked at different phases of the lifecycle of a graph layout. If you are aware of these lifecycle events, it will enable you to control their entire flow and it will definitely help us to produce better results.
+  private graph: ClassicGraph | null = null;
+  private nodePositions = new Map<string | number, [number, number]>();
 
-A layout goes through the following phases:
+  constructor(props: RandomLayoutProps = RandomLayout.defaultProps) {
+    super(props, RandomLayout.defaultProps);
+  }
 
-- Mounting:
-  `constructor` => `initializeGraph` => `start`
-- Updating:
-  `updateGraph` => `update`
-
-There are a few events that should be triggered when the layout changes:
-
-- `this._onLayoutStart()`
-  When the layout starts, `onLayoutStart` should be triggered to notify GraphGL/User. Some users might also want to leverage this event hook to perform different interactions, ex: show a spinner on the UI to indicate a new layout is computing.
-
-- `this._onLayoutChange()`
-  Every time when the layout changes, `onLayoutChange` should be triggered to notify GraphGL to re-render and update the view. Then GraphGL will use `getNodePosition` and `getEdgePosition` to get the position information to render the graph. Some users might also want to leverage this event hook to perform different interactions, ex: show a spinner on the UI to indicate the layout is computing.
-
-  All layout lifecycle callbacks receive a `GraphLayoutEventDetail` object containing the latest `{bounds}` calculated by the layout. Bounds follow the [`Bounds2D`](https://github.com/uber-web/math.gl/blob/master/modules/types/docs/api-reference/bounds.md) tuple format `[[minX, minY], [maxX, maxY]]`. You can also call `layout.getBounds()` at any time to retrieve the same values.
-
-- `this._onLayoutDone()`
-  When the layout is completed, 'onLayoutDone' should be triggered to notify GraphGL/User. Some users might also want to leverage this event hook to perform different interactions, ex: remove the spinner from the UI.
-
-If you want to implement the drag & drag interaction on nodes, you will have to implement:
-
-- `lockNodePosition`: pin the node at the designated position.
-- `unlockNodePosition`: free the node from the position.
-- `resume`: resume the layout calculation.
-
-The sequence of the events is like:
-startDragging => lockNodePosition => release => unlockNodePosition => resume
-
-### Update the graph data
-
-GraphGL will call `initializeGraph` to pass the graph data into the layout.
-If the graph is the same one but part ofthe data is changed, GraphGL will call `updateGraph` method to notify the layout.
-
-In this case, we can just simply update the `this._nodePositionMap` by going through all nodes in the graph.
-
-```js
-  initializeGraph(graph) {
+  initializeGraph(graph: ClassicGraph): void {
     this.updateGraph(graph);
   }
 
-  updateGraph(grpah) {
-    this._graph = graph;
-    this._nodePositionMap = graph.getNodes().reduce((res, node) => {
-      res[node.getId()] = this._nodePositionMap[node.getId()] || [0, 0];
-      return res;
-    }, {});
+  updateGraph(graph: ClassicGraph): void {
+    this.graph = graph;
+    const nextPositions = new Map<string | number, [number, number]>();
+
+    for (const node of graph.getNodes()) {
+      const nodeId = node.getId();
+      const previous = this.nodePositions.get(nodeId) ?? [0, 0];
+      nextPositions.set(nodeId, previous);
+    }
+
+    this.nodePositions = nextPositions;
   }
-```
 
-### Compute layout
-
-GraphGL will call `start()` of the layout to kick start the layout calculation.
-Before starting the calculation you should call `this._onLayoutStart()` to notify that a new layout has been started
-In this case, the computation is easy as assigning random position for each node only.
-Once the layout is completed, you will need to call `this._onLayoutChange()` to notify the render redraw.
-Then call `this._onLayoutDone()` to notify the render that layout is completed.
-
-```js
-  start() {
-    const {viewportWidth, viewportHeight} = this.props;
-    this._onLayoutStart();
-    this._nodePositionMap = Object.keys(this._nodePositionMap).reduce((res, nodeId) => {
-      res[nodeId] = [Math.random() * viewportWidth, Math.random() * viewportHeight];
-      return res;
-    }, {});
-    this._onLayoutChange();
-    this._onLayoutDone();
+  start(): void {
+    this._runLayout();
   }
-```
 
-### Update layout
-
-GraphGL will call `update()` of the layout to update the layout calculation when a full new layout is not required.
-Most commonly this will be when nodes or edges of the graph are updated.
-In this case we will simply assign a random position for each node.
-Once the layout is completed, you will need to call `this._onLayoutChange()` to notify the render redraw.
-Then call `this._onLayoutDone()` to notify the render that layout is completed.
-
-```js
-  update() {
-    const {viewportWidth, viewportHeight} = this.props;
-    this._nodePositionMap = Object.keys(this._nodePositionMap).reduce((res, nodeId) => {
-      res[nodeId] = [Math.random() * viewportWidth, Math.random() * viewportHeight];
-      return res;
-    }, {});
-    this._onLayoutChange();
-    this._onLayoutDone();
+  update(): void {
+    this._runLayout();
   }
-```
 
-## Methpds
+  resume(): void {
+    this._runLayout();
+  }
 
-### constructor
+  stop(): void {}
 
-In the constructor, you can initialize some internal object you'll need for the layout state.
-The most important part is to create a 'map' to keep the position of nodes.
+  getNodePosition(node: NodeInterface): [number, number] | null {
+    return this.nodePositions.get(node.getId()) ?? null;
+  }
 
-```js
-export default class RandomLayout extends GraphLayout {
-  static defaultProps = {
-    viewportWidth: 1000,
-    viewportHeight: 1000
-  };
+  getEdgePosition(edge: EdgeInterface): EdgePosition {
+    const sourcePosition = this.nodePositions.get(edge.getSourceNodeId()) ?? [0, 0];
+    const targetPosition = this.nodePositions.get(edge.getTargetNodeId()) ?? [0, 0];
 
-  constructor(options) {
-    // init GraphLayout
-    super(options);
-    // give a name to this layout
-    this._name = 'RandomLayout';
-    // combine the default options with user input
-    this.props = {
-      ...this.defaultProps,
-      ...options
+    return {
+      type: 'line',
+      sourcePosition,
+      targetPosition,
+      controlPoints: []
     };
-    // a map to persis the position of nodes.
-    this._nodePositionMap = {};
+  }
+
+  lockNodePosition(node: NodeInterface, x: number, y: number): void {
+    this.nodePositions.set(node.getId(), [x, y]);
+    this._onLayoutChange();
+  }
+
+  unlockNodePosition(node: NodeInterface): void {
+    this.nodePositions.delete(node.getId());
+    this._onLayoutChange();
+  }
+
+  protected override _updateBounds(): void {
+    this._bounds = this._calculateBounds(this.nodePositions.values());
+  }
+
+  private _runLayout(): void {
+    if (!this.graph) {
+      return;
+    }
+
+    this._onLayoutStart();
+    this._randomizePositions();
+    this._onLayoutChange();
+    this._onLayoutDone();
+  }
+
+  private _randomizePositions(): void {
+    const {viewportWidth, viewportHeight} = this.props;
+
+    for (const nodeId of this.nodePositions.keys()) {
+      this.nodePositions.set(nodeId, [
+        Math.random() * viewportWidth,
+        Math.random() * viewportHeight
+      ]);
+    }
   }
 }
 ```
 
+## The layout lifecycle
 
-### Getters
+Graph layouts respond to graph mutations and user interactions through a small set of lifecycle methods and helper utilities.
 
-GraphGL will keep retrieving the position of nodes and edges from the layout. You will need to provide two getters `getNodePosition` and `getEdgePosition`.
+### Lifecycle phases
 
-- getNodePosition: return the position of the node [x, y]. If the position is not available (not calculated), returning nullish will hide the node.
-- getEdgePosition: return the rendering information of the edge, including:
-  -- type: the type of the edge, it should be 'line', 'spline-curve', or 'path'.
-  -- sourcePosition: the position of source node.
-  -- targetPosition: the position of target node.
-  -- controlPoints: a set of control points for 'spline-curve', or 'path' edge.
+A layout transitions through the following phases:
 
-```js
-getNodePosition = (node) => this._nodePositionMap[node.getId()];
+- **Mounting** – `constructor` → `initializeGraph` → `start`
+- **Updating** – `updateGraph` → `update`
+- **Interruption** – `stop` halts any active run, while `resume` should restart computation (typically by calling `start`).
 
-getEdgePosition = (edge) => {
-  const sourcePos = this._nodePositionMap[edge.getSourceNodeId()];
-  const targetPos = this._nodePositionMap[edge.getTargetNodeId()];
-  return {
-    type: 'line',
-    sourcePosition: sourcePos,
-    targetPosition: targetPos,
-    controlPoints: []
-  };
+### Emitting layout events
+
+`GraphLayout` exposes `_onLayoutStart`, `_onLayoutChange`, `_onLayoutDone`, and `_onLayoutError` helpers that notify `GraphLayer` and any user-supplied callbacks. Use them to surface progress:
+
+- Call `_onLayoutStart` before you begin a fresh computation cycle. This transitions the internal state to `calculating` and sends the current bounds to listeners.
+- Call `_onLayoutChange` after every iteration that mutates node or edge positions. Invoking this method multiple times during a single run is expected when the layout updates incrementally.
+- Call `_onLayoutDone` once an iteration completes and no further updates are pending. This sets the internal state to `done` and re-emits the latest bounds.
+- Call `_onLayoutError` when the layout cannot continue (e.g. due to invalid data or an exception).
+
+### GraphLayoutEventDetail
+
+All lifecycle callbacks receive a `GraphLayoutEventDetail` object containing the latest `{bounds}` calculated by the layout:
+
+```ts
+type GraphLayoutEventDetail = {
+  bounds: [[number, number], [number, number]] | null;
 };
 ```
 
-### Full source code
+Bounds follow the [`Bounds2D`](https://github.com/uber-web/math.gl/blob/master/modules/types/docs/api-reference/bounds.md) tuple format `[[minX, minY], [maxX, maxY]]`. You can also call `layout.getBounds()` at any time to retrieve the same values.
 
-```js
-import {GraphLayout} from '@deck.gl-community/graph-layers';
+### Maintaining layout bounds
 
-export default class RandomLayout extends GraphLayout {
-  constructor(options) {
-    super(options);
-    this._name = 'RandomLayout';
-    this.props = {
-      ...defaultProps,
-      ...options
-    };
-    this._nodePositionMap = {};
-  }
+Override `_updateBounds` to keep `_bounds` in sync with your layout state. Most layouts only need to funnel their node positions through `_calculateBounds`, which filters out non-finite coordinates before producing the enclosing rectangle. Update bounds **before** each event emission so callbacks receive the freshest extent information.
 
-  // first time to pass the graph data into this layout
-  initializeGraph(graph) {
-    this.updateGraph(graph);
-  }
-  // update the existing graph
-  updateGraph(grpah) {
-    this._graph = graph;
-    this._nodePositionMap = graph.getNodes().reduce((res, node) => {
-      res[node.getId()] = this._nodePositionMap[node.getId()] || [0, 0];
-      return res;
-    }, {});
-  }
+### Drag interactions
 
-  start() {
-    const {viewportWidth, viewportHeight} = this.props;
-    this._onLayoutStart();
-    this._nodePositionMap = Object.keys(this._nodePositionMap).reduce((res, nodeId) => {
-      res[nodeId] = [Math.random() * viewportWidth, Math.random() * viewportHeight];
-      return res;
-    }, {});
-    this._onLayoutChange();
-    this._onLayoutDone();
-  }
+To support drag-and-drop interactions:
 
-  update() {
-    const {viewportWidth, viewportHeight} = this.props;
-    this._nodePositionMap = Object.keys(this._nodePositionMap).reduce((res, nodeId) => {
-      res[nodeId] = [Math.random() * viewportWidth, Math.random() * viewportHeight];
-      return res;
-    }, {});
-    this._onLayoutChange();
-    this._onLayoutDone();
-  }
+1. Call `lockNodePosition` when a drag starts to pin the node.
+2. Call `unlockNodePosition` after releasing the pointer.
+3. Call `resume` to restart the layout if it needs to continue processing after the drag completes.
 
-  getNodePosition = (node) => this._nodePositionMap[node.getId()];
+A typical sequence looks like `startDragging → lockNodePosition → release → unlockNodePosition → resume`.
 
-  getEdgePosition = (edge) => {
-    const sourcePos = this._nodePositionMap[edge.getSourceNodeId()];
-    const targetPos = this._nodePositionMap[edge.getTargetNodeId()];
-    return {
-      type: 'line',
-      sourcePosition: sourcePos,
-      targetPosition: targetPos,
-      controlPoints: []
-    };
-  };
-}
-```
+## Accessors
+
+GraphGL repeatedly calls `getNodePosition` and `getEdgePosition` to fetch the latest geometry:
+
+- `getNodePosition(node)` returns the node position `[x, y]`. Return `null` when a position is unavailable to hide the node until the layout resolves it.
+- `getEdgePosition(edge)` returns rendering information for an edge, including:
+  - `type`: the edge primitive (`'line'`, `'spline-curve'`, or `'path'`).
+  - `sourcePosition`/`targetPosition`: coordinates for the edge endpoints.
+  - `controlPoints`: optional control points for curved or multi-segment edges.
+
+Ensure these methods always return consistent data for the current layout state.


### PR DESCRIPTION
## Summary
- rewrite the GraphLayout documentation with a TypeScript example that demonstrates static `defaultProps`, calling `super(props, defaultProps)`, and using the layout lifecycle helpers
- update the lifecycle guidance to cover `_calculateBounds`, layout bounds events, and the `GraphLayoutEventDetail` payload

## Testing
- yarn --cwd website build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691369d3b9688328875d6dbe356141dc)