### PR TITLE
Add GraphML loader for graph-layers

### DIFF
--- a/modules/graph-layers/README.md
+++ b/modules/graph-layers/README.md
@@ -11,9 +11,9 @@ TBD
 
 ## GraphML loader
 
-`@deck.gl-community/graph-layers` ships a utility for loading GraphML documents into the
-`TabularGraph` runtime via `loadGraphML`. The loader is designed for GraphML 1.0 documents and
-supports the following constructs:
+`@deck.gl-community/graph-layers` ships utilities for loading GraphML documents. Use `loadGraphML`
+to create a runtime `Graph`, or `parseGraphML` to convert GraphML text into `PlainGraphData`. The
+loader is designed for GraphML 1.0 documents and supports the following constructs:
 
 - `<graph>` elements with `edgedefault` set to either `directed` or `undirected`.
 - `<node>` and `<edge>` elements with required identifiers and edge endpoints.

--- a/modules/graph-layers/README.md
+++ b/modules/graph-layers/README.md
@@ -8,3 +8,20 @@ TBD
 <p align="center">
   <img src="https://i.imgur.com/BF9aOEu.png" height="400" />
 </p>
+
+## GraphML loader
+
+`@deck.gl-community/graph-layers` ships a utility for loading GraphML documents into the
+`TabularGraph` runtime via `loadGraphML`. The loader is designed for GraphML 1.0 documents and
+supports the following constructs:
+
+- `<graph>` elements with `edgedefault` set to either `directed` or `undirected`.
+- `<node>` and `<edge>` elements with required identifiers and edge endpoints.
+- `<key>` declarations scoped to `node`, `edge`, or `all` domains, including `<default>` values.
+- `<data>` entries attached to nodes or edges that reference GraphML keys. Values are converted to
+  numbers or booleans when a key declares `attr.type` of `int`, `long`, `float`, `double`, or
+  `boolean`. Unrecognized types fall back to strings.
+
+The loader intentionally ignores unsupported GraphML features such as hyperedges, ports, or nested
+graphs. Data blocks that contain nested XML are preserved as serialized JSON strings inside the
+resulting attribute map so applications can continue to access vendor-specific payloads.

--- a/modules/graph-layers/package.json
+++ b/modules/graph-layers/package.json
@@ -52,6 +52,7 @@
     "d3-force": "^3.0.0",
     "d3-format": "^3.1.0",
     "d3-scale": "^4.0.2",
+    "fast-xml-parser": "^5.5.3",
     "lodash.isequal": "^4.5.0"
   },
   "devDependencies": {

--- a/modules/graph-layers/src/index.ts
+++ b/modules/graph-layers/src/index.ts
@@ -113,6 +113,7 @@ export {
   type DOTGraphLoaderOptions,
   type DOTGraphLoaderMetadata
 } from './loaders/dot-graph-loader';
+export {loadGraphML, parseGraphML} from './loaders/graphml-loader';
 
 // Deprecated exports
 export {

--- a/modules/graph-layers/src/loaders/graphml-loader.ts
+++ b/modules/graph-layers/src/loaders/graphml-loader.ts
@@ -194,7 +194,9 @@ function parseEdge(
     return null;
   }
 
-  const id = edge[`${XML_ATTRIBUTE_PREFIX}id`] ?? `edge-${index}`;
+  const rawId = edge[`${XML_ATTRIBUTE_PREFIX}id`];
+  const id =
+    typeof rawId === 'string' || typeof rawId === 'number' ? rawId : `edge-${index}`;
   const directed = parseDirected(edge[`${XML_ATTRIBUTE_PREFIX}directed`], defaultDirected);
   const attributes = buildAttributeBag('edge', edge.data, keyDefinitions);
 

--- a/modules/graph-layers/src/loaders/graphml-loader.ts
+++ b/modules/graph-layers/src/loaders/graphml-loader.ts
@@ -1,0 +1,381 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {XMLParser} from 'fast-xml-parser';
+
+import type {PlainGraphData, GraphEdgeData, GraphNodeData} from '../graph-data/graph-data';
+import type {Graph} from '../graph/graph';
+import {createGraphFromData} from '../graph/functions/create-graph-from-data';
+
+const XML_ATTRIBUTE_PREFIX = '@_';
+const XML_TEXT_KEY = '#text';
+
+type GraphMLDomain = 'all' | 'node' | 'edge' | 'graph';
+
+type GraphMLAttributeType = 'boolean' | 'int' | 'long' | 'float' | 'double' | 'string';
+
+type GraphMLKeyDefinition = {
+  id: string;
+  name: string;
+  domain: GraphMLDomain;
+  type: GraphMLAttributeType;
+  defaultValue?: unknown;
+};
+
+type GraphMLObject = Record<string, unknown> & {
+  [XML_TEXT_KEY]?: string;
+};
+
+const graphmlParser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: XML_ATTRIBUTE_PREFIX,
+  textNodeName: XML_TEXT_KEY,
+  trimValues: true,
+  parseAttributeValue: false,
+  parseTagValue: false,
+  allowBooleanAttributes: true
+});
+
+export type GraphMLInput = string | ArrayBuffer | Uint8Array;
+
+export function loadGraphML(graphml: GraphMLInput): Graph {
+  const data = parseGraphML(graphml);
+  return createGraphFromData(data);
+}
+
+export function parseGraphML(graphml: GraphMLInput): PlainGraphData {
+  const xmlText = decodeGraphML(graphml);
+  const document = graphmlParser.parse(xmlText) as GraphMLObject;
+  const graphmlRoot = getGraphMLRoot(document);
+  if (!graphmlRoot) {
+    throw new Error('GraphML document does not contain a <graphml> element.');
+  }
+
+  const graphElement = getGraphElement(graphmlRoot);
+  if (!graphElement) {
+    throw new Error('GraphML document does not contain a <graph> element.');
+  }
+
+  const keyDefinitions = collectKeyDefinitions(graphmlRoot, graphElement);
+  const defaultDirected = parseEdgeDefault(graphElement[`${XML_ATTRIBUTE_PREFIX}edgedefault`]);
+
+  const nodes = normalizeArray(graphElement.node).map((node) => parseNode(node, keyDefinitions));
+  const edges = normalizeArray(graphElement.edge).map((edge, index) =>
+    parseEdge(edge, index, keyDefinitions, defaultDirected)
+  );
+
+  const filteredNodes = nodes.filter((node): node is GraphNodeData => Boolean(node));
+  const filteredEdges = edges.filter((edge): edge is GraphEdgeData => Boolean(edge));
+
+  return {
+    shape: 'plain-graph-data',
+    nodes: filteredNodes,
+    edges: filteredEdges
+  } satisfies PlainGraphData;
+}
+
+function decodeGraphML(graphml: GraphMLInput): string {
+  if (typeof graphml === 'string') {
+    return graphml;
+  }
+
+  if (graphml instanceof Uint8Array) {
+    return new TextDecoder().decode(graphml);
+  }
+
+  if (graphml instanceof ArrayBuffer) {
+    return new TextDecoder().decode(new Uint8Array(graphml));
+  }
+
+  throw new Error('Unsupported GraphML input. Expected a string, ArrayBuffer, or Uint8Array.');
+}
+
+function getGraphMLRoot(document: GraphMLObject): GraphMLObject | null {
+  const root = document.graphml;
+  if (isObject(root)) {
+    return root;
+  }
+
+  const namespacedKey = Object.keys(document).find((key) => key.endsWith(':graphml'));
+  if (namespacedKey) {
+    const namespacedRoot = document[namespacedKey];
+    if (isObject(namespacedRoot)) {
+      return namespacedRoot;
+    }
+  }
+
+  return null;
+}
+
+function getGraphElement(graphmlRoot: GraphMLObject): GraphMLObject | null {
+  const graph = graphmlRoot.graph;
+  if (!graph) {
+    return null;
+  }
+
+  if (Array.isArray(graph)) {
+    const firstGraph = graph.find((entry) => isObject(entry));
+    return isObject(firstGraph) ? firstGraph : null;
+  }
+
+  return isObject(graph) ? graph : null;
+}
+
+function collectKeyDefinitions(
+  graphmlRoot: GraphMLObject,
+  graphElement: GraphMLObject
+): Map<string, GraphMLKeyDefinition> {
+  const keys = new Map<string, GraphMLKeyDefinition>();
+
+  for (const candidate of [...normalizeArray(graphmlRoot.key), ...normalizeArray(graphElement.key)]) {
+    if (isObject(candidate)) {
+      const id = String(candidate[`${XML_ATTRIBUTE_PREFIX}id`] ?? '').trim();
+      if (id) {
+        const domain = normalizeDomain(candidate[`${XML_ATTRIBUTE_PREFIX}for`]);
+        const name = String(candidate[`${XML_ATTRIBUTE_PREFIX}attr.name`] ?? id).trim();
+        const type = normalizeType(candidate[`${XML_ATTRIBUTE_PREFIX}attr.type`]);
+        const defaultNode = candidate.default ?? null;
+        const defaultValue = defaultNode !== null ? castDataValue(defaultNode, type) : undefined;
+
+        keys.set(id, {id, domain, name, type, defaultValue});
+      }
+    }
+  }
+
+  return keys;
+}
+
+function parseNode(
+  node: unknown,
+  keyDefinitions: Map<string, GraphMLKeyDefinition>
+): GraphNodeData | null {
+  if (!isObject(node)) {
+    return null;
+  }
+
+  const id = node[`${XML_ATTRIBUTE_PREFIX}id`];
+  if (typeof id !== 'string' && typeof id !== 'number') {
+    return null;
+  }
+
+  const attributes = buildAttributeBag('node', node.data, keyDefinitions);
+
+  const graphNode: GraphNodeData = {
+    type: 'graph-node-data',
+    id,
+    attributes: Object.keys(attributes).length > 0 ? attributes : undefined
+  };
+
+  const label = attributes.label;
+  if (typeof label === 'string') {
+    graphNode.label = label;
+  }
+
+  return graphNode;
+}
+
+function parseEdge(
+  edge: unknown,
+  index: number,
+  keyDefinitions: Map<string, GraphMLKeyDefinition>,
+  defaultDirected: boolean
+): GraphEdgeData | null {
+  if (!isObject(edge)) {
+    return null;
+  }
+
+  const sourceId = edge[`${XML_ATTRIBUTE_PREFIX}source`];
+  const targetId = edge[`${XML_ATTRIBUTE_PREFIX}target`];
+  if (typeof sourceId !== 'string' && typeof sourceId !== 'number') {
+    return null;
+  }
+  if (typeof targetId !== 'string' && typeof targetId !== 'number') {
+    return null;
+  }
+
+  const id = edge[`${XML_ATTRIBUTE_PREFIX}id`] ?? `edge-${index}`;
+  const directed = parseDirected(edge[`${XML_ATTRIBUTE_PREFIX}directed`], defaultDirected);
+  const attributes = buildAttributeBag('edge', edge.data, keyDefinitions);
+
+  const graphEdge: GraphEdgeData = {
+    type: 'graph-edge-data',
+    id,
+    sourceId,
+    targetId,
+    directed,
+    attributes: Object.keys(attributes).length > 0 ? attributes : undefined
+  };
+
+  const label = attributes.label;
+  if (typeof label === 'string') {
+    graphEdge.label = label;
+  }
+
+  return graphEdge;
+}
+
+function buildAttributeBag(
+  domain: GraphMLDomain,
+  data: unknown,
+  keyDefinitions: Map<string, GraphMLKeyDefinition>
+): Record<string, unknown> {
+  const attributes: Record<string, unknown> = {};
+
+  for (const key of keyDefinitions.values()) {
+    if (key.domain === 'all' || key.domain === domain) {
+      if (key.defaultValue !== undefined) {
+        attributes[key.name] = key.defaultValue;
+      }
+    }
+  }
+
+  for (const entry of normalizeArray(data)) {
+    assignAttributeFromDataEntry(entry, keyDefinitions, attributes);
+  }
+
+  return attributes;
+}
+
+function assignAttributeFromDataEntry(
+  entry: unknown,
+  keyDefinitions: Map<string, GraphMLKeyDefinition>,
+  attributes: Record<string, unknown>
+): void {
+  if (!isObject(entry)) {
+    return;
+  }
+
+  const keyId = entry[`${XML_ATTRIBUTE_PREFIX}key`];
+  if (typeof keyId !== 'string') {
+    return;
+  }
+
+  const definition = keyDefinitions.get(keyId);
+  const attributeName = definition?.name ?? keyId;
+  const value = castDataValue(entry, definition?.type ?? 'string');
+  if (value !== undefined) {
+    attributes[attributeName] = value;
+  }
+}
+
+function castDataValue(value: unknown, type: GraphMLAttributeType): unknown {
+  if (value === null || typeof value === 'undefined') {
+    return undefined;
+  }
+
+  const text = extractTextContent(value);
+  if (text === undefined) {
+    return undefined;
+  }
+
+  if (type === 'boolean') {
+    return parseBoolean(text);
+  }
+  if (type === 'int' || type === 'long') {
+    const parsed = Number.parseInt(text, 10);
+    return Number.isNaN(parsed) ? text : parsed;
+  }
+  if (type === 'float' || type === 'double') {
+    const parsed = Number.parseFloat(text);
+    return Number.isNaN(parsed) ? text : parsed;
+  }
+  return text;
+}
+
+function extractTextContent(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    return extractTextContent(value[0]);
+  }
+
+  if (isObject(value)) {
+    const text = value[XML_TEXT_KEY];
+    if (typeof text === 'string') {
+      return text;
+    }
+
+    const nonAttributeEntries = Object.entries(value).filter(
+      ([key]) => !key.startsWith(XML_ATTRIBUTE_PREFIX)
+    );
+    if (nonAttributeEntries.length === 0) {
+      return undefined;
+    }
+    return JSON.stringify(Object.fromEntries(nonAttributeEntries));
+  }
+
+  return undefined;
+}
+
+function normalizeArray<T>(value: T | T[] | null | undefined): T[] {
+  if (!value) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+function isObject(value: unknown): value is GraphMLObject {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeDomain(value: unknown): GraphMLDomain {
+  if (typeof value !== 'string') {
+    return 'all';
+  }
+
+  const lower = value.toLowerCase();
+  if (lower === 'node' || lower === 'edge' || lower === 'graph' || lower === 'all') {
+    return lower;
+  }
+  return 'all';
+}
+
+function normalizeType(value: unknown): GraphMLAttributeType {
+  if (typeof value !== 'string') {
+    return 'string';
+  }
+
+  const lower = value.toLowerCase();
+  if (lower === 'boolean' || lower === 'int' || lower === 'long' || lower === 'float' || lower === 'double') {
+    return lower;
+  }
+  return 'string';
+}
+
+function parseEdgeDefault(value: unknown): boolean {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  return value.toLowerCase() !== 'undirected';
+}
+
+function parseDirected(value: unknown, defaultDirected: boolean): boolean {
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'directed') {
+      return true;
+    }
+    if (normalized === 'false' || normalized === '0' || normalized === 'no' || normalized === 'undirected') {
+      return false;
+    }
+  }
+  return defaultDirected;
+}
+
+function parseBoolean(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'y') {
+    return true;
+  }
+  if (normalized === 'false' || normalized === '0' || normalized === 'no' || normalized === 'n') {
+    return false;
+  }
+  return Boolean(value);
+}

--- a/modules/graph-layers/src/loaders/graphml-loader.ts
+++ b/modules/graph-layers/src/loaders/graphml-loader.ts
@@ -60,7 +60,7 @@ export function parseGraphML(graphml: GraphMLInput): PlainGraphData {
   const keyDefinitions = collectKeyDefinitions(graphmlRoot, graphElement);
   const defaultDirected = parseEdgeDefault(graphElement[`${XML_ATTRIBUTE_PREFIX}edgedefault`]);
 
-  const nodes = normalizeArray(graphElement.node).map((node) => parseNode(node, keyDefinitions));
+  const nodes = normalizeArray(graphElement.node).map(node => parseNode(node, keyDefinitions));
   const edges = normalizeArray(graphElement.edge).map((edge, index) =>
     parseEdge(edge, index, keyDefinitions, defaultDirected)
   );
@@ -97,7 +97,7 @@ function getGraphMLRoot(document: GraphMLObject): GraphMLObject | null {
     return root;
   }
 
-  const namespacedKey = Object.keys(document).find((key) => key.endsWith(':graphml'));
+  const namespacedKey = Object.keys(document).find(key => key.endsWith(':graphml'));
   if (namespacedKey) {
     const namespacedRoot = document[namespacedKey];
     if (isObject(namespacedRoot)) {
@@ -115,7 +115,7 @@ function getGraphElement(graphmlRoot: GraphMLObject): GraphMLObject | null {
   }
 
   if (Array.isArray(graph)) {
-    const firstGraph = graph.find((entry) => isObject(entry));
+    const firstGraph = graph.find(entry => isObject(entry));
     return isObject(firstGraph) ? firstGraph : null;
   }
 
@@ -128,7 +128,10 @@ function collectKeyDefinitions(
 ): Map<string, GraphMLKeyDefinition> {
   const keys = new Map<string, GraphMLKeyDefinition>();
 
-  for (const candidate of [...normalizeArray(graphmlRoot.key), ...normalizeArray(graphElement.key)]) {
+  for (const candidate of [
+    ...normalizeArray(graphmlRoot.key),
+    ...normalizeArray(graphElement.key)
+  ]) {
     if (isObject(candidate)) {
       const id = String(candidate[`${XML_ATTRIBUTE_PREFIX}id`] ?? '').trim();
       if (id) {
@@ -162,7 +165,6 @@ function parseNode(
   const attributes = buildAttributeBag('node', node.data, keyDefinitions);
 
   const graphNode: GraphNodeData = {
-    type: 'graph-node-data',
     id,
     attributes: Object.keys(attributes).length > 0 ? attributes : undefined
   };
@@ -195,13 +197,11 @@ function parseEdge(
   }
 
   const rawId = edge[`${XML_ATTRIBUTE_PREFIX}id`];
-  const id =
-    typeof rawId === 'string' || typeof rawId === 'number' ? rawId : `edge-${index}`;
+  const id = typeof rawId === 'string' || typeof rawId === 'number' ? rawId : `edge-${index}`;
   const directed = parseDirected(edge[`${XML_ATTRIBUTE_PREFIX}directed`], defaultDirected);
   const attributes = buildAttributeBag('edge', edge.data, keyDefinitions);
 
   const graphEdge: GraphEdgeData = {
-    type: 'graph-edge-data',
     id,
     sourceId,
     targetId,
@@ -345,7 +345,13 @@ function normalizeType(value: unknown): GraphMLAttributeType {
   }
 
   const lower = value.toLowerCase();
-  if (lower === 'boolean' || lower === 'int' || lower === 'long' || lower === 'float' || lower === 'double') {
+  if (
+    lower === 'boolean' ||
+    lower === 'int' ||
+    lower === 'long' ||
+    lower === 'float' ||
+    lower === 'double'
+  ) {
     return lower;
   }
   return 'string';
@@ -361,10 +367,20 @@ function parseEdgeDefault(value: unknown): boolean {
 function parseDirected(value: unknown, defaultDirected: boolean): boolean {
   if (typeof value === 'string') {
     const normalized = value.trim().toLowerCase();
-    if (normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'directed') {
+    if (
+      normalized === 'true' ||
+      normalized === '1' ||
+      normalized === 'yes' ||
+      normalized === 'directed'
+    ) {
       return true;
     }
-    if (normalized === 'false' || normalized === '0' || normalized === 'no' || normalized === 'undirected') {
+    if (
+      normalized === 'false' ||
+      normalized === '0' ||
+      normalized === 'no' ||
+      normalized === 'undirected'
+    ) {
       return false;
     }
   }

--- a/modules/graph-layers/test/data/__fixtures__/graphml/basic.graphml
+++ b/modules/graph-layers/test/data/__fixtures__/graphml/basic.graphml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+  <key id="node-label" for="node" attr.name="label" attr.type="string" />
+  <key id="node-count" for="node" attr.name="count" attr.type="int">
+    <default>5</default>
+  </key>
+  <key id="edge-weight" for="edge" attr.name="weight" attr.type="double">
+    <default>1.5</default>
+  </key>
+  <key id="shared-flag" for="all" attr.name="flag" attr.type="boolean">
+    <default>true</default>
+  </key>
+  <graph id="G" edgedefault="directed">
+    <node id="n0">
+      <data key="node-label">Node Zero</data>
+      <data key="shared-flag">false</data>
+    </node>
+    <node id="n1">
+      <data key="node-label">Node One</data>
+      <data key="node-count">7</data>
+      <data key="custom-text">note</data>
+    </node>
+    <edge id="e0" source="n0" target="n1">
+      <data key="edge-weight">2.5</data>
+    </edge>
+    <edge source="n1" target="n0" directed="false">
+      <data key="shared-flag">true</data>
+    </edge>
+  </graph>
+</graphml>

--- a/modules/graph-layers/test/data/__fixtures__/graphml/defaults.graphml
+++ b/modules/graph-layers/test/data/__fixtures__/graphml/defaults.graphml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+  <key id="node-category" for="node" attr.name="category" attr.type="string">
+    <default>general</default>
+  </key>
+  <key id="edge-weight" for="edge" attr.name="weight" attr.type="double">
+    <default>3.5</default>
+  </key>
+  <graph id="undirected" edgedefault="undirected">
+    <node id="a" />
+    <node id="b" />
+    <edge source="a" target="b" />
+  </graph>
+</graphml>

--- a/modules/graph-layers/test/loaders/graphml-loader.spec.ts
+++ b/modules/graph-layers/test/loaders/graphml-loader.spec.ts
@@ -1,0 +1,101 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {beforeAll, describe, expect, it} from 'vitest';
+import {readFileSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import {join} from 'node:path';
+
+import {loadGraphML, parseGraphML} from '../../src/loaders/graphml-loader';
+
+const FIXTURES_DIR = fileURLToPath(new URL('../data/__fixtures__/graphml/', import.meta.url));
+
+function readFixture(name: string): string {
+  return readFileSync(join(FIXTURES_DIR, name), {encoding: 'utf8'});
+}
+
+beforeAll(() => {
+  globalThis.CustomEvent = Event as any;
+});
+
+describe('loadGraphML', () => {
+  let graph: ReturnType<typeof loadGraphML>;
+
+  beforeAll(() => {
+    graph = loadGraphML(readFixture('basic.graphml'));
+  });
+
+  it('parses node attributes from GraphML text', () => {
+    const nodeIds = Array.from(graph.getNodes(), (node) => node.getId());
+    expect(nodeIds).toEqual(expect.arrayContaining(['n0', 'n1']));
+
+    const nodeZero = graph.findNodeById('n0');
+    if (!nodeZero) {
+      throw new Error('Expected node n0 to be defined');
+    }
+    expect(nodeZero.getPropertyValue('label')).toBe('Node Zero');
+    expect(nodeZero.getPropertyValue('flag')).toBe(false);
+
+    const nodeOne = graph.findNodeById('n1');
+    if (!nodeOne) {
+      throw new Error('Expected node n1 to be defined');
+    }
+    const nodeOneCount = nodeOne.getPropertyValue('count');
+    expect(nodeOne.getPropertyValue('label')).toBe('Node One');
+    expect(nodeOneCount).toBe(7);
+    expect(typeof nodeOneCount).toBe('number');
+    expect(nodeOne.getPropertyValue('flag')).toBe(true);
+    expect(nodeOne.getPropertyValue('custom-text')).toBe('note');
+  });
+
+  it('parses edges and typed defaults', () => {
+    const edges = Array.from(graph.getEdges());
+    expect(edges).toHaveLength(2);
+
+    const [firstEdge, secondEdge] = edges;
+    expect(firstEdge.getId()).toBe('e0');
+    expect(firstEdge.isDirected()).toBe(true);
+    expect(firstEdge.getPropertyValue('weight')).toBe(2.5);
+    expect(typeof firstEdge.getPropertyValue('weight')).toBe('number');
+    expect(firstEdge.getPropertyValue('flag')).toBe(true);
+
+    expect(secondEdge.getId()).toBe('edge-1');
+    expect(secondEdge.isDirected()).toBe(false);
+    expect(secondEdge.getPropertyValue('weight')).toBe(1.5);
+    expect(secondEdge.getPropertyValue('flag')).toBe(true);
+  });
+
+  it('accepts ArrayBuffer inputs and applies default values', () => {
+    const buffer = readFileSync(join(FIXTURES_DIR, 'defaults.graphml'));
+    const arrayBuffer = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+
+    const bufferedGraph = loadGraphML(arrayBuffer);
+    const nodes = Array.from(bufferedGraph.getNodes());
+    expect(nodes).toHaveLength(2);
+    expect(nodes.every((node) => node.getPropertyValue('category') === 'general')).toBe(true);
+
+    const [edge] = Array.from(bufferedGraph.getEdges());
+    expect(edge.isDirected()).toBe(false);
+    expect(edge.getPropertyValue('weight')).toBe(3.5);
+  });
+});
+
+describe('parseGraphML', () => {
+  it('returns GraphData compatible objects', () => {
+    const xml = readFixture('basic.graphml');
+    const data = parseGraphML(xml);
+
+    expect(data.shape).toBe('plain-graph-data');
+    expect(data.nodes).toHaveLength(2);
+    expect(data.edges).toHaveLength(2);
+
+    const firstEdge = data.edges?.[0];
+    if (!firstEdge) {
+      throw new Error('Expected first edge to be defined');
+    }
+    expect(firstEdge.directed).toBe(true);
+    expect(firstEdge.attributes?.weight).toBe(2.5);
+    expect(firstEdge.attributes?.flag).toBe(true);
+  });
+});

--- a/modules/graph-layers/test/loaders/graphml-loader.spec.ts
+++ b/modules/graph-layers/test/loaders/graphml-loader.spec.ts
@@ -3,17 +3,9 @@
 // Copyright (c) vis.gl contributors
 
 import {beforeAll, describe, expect, it} from 'vitest';
-import {readFileSync} from 'node:fs';
-import {fileURLToPath} from 'node:url';
-import {join} from 'node:path';
-
 import {loadGraphML, parseGraphML} from '../../src/loaders/graphml-loader';
-
-const FIXTURES_DIR = fileURLToPath(new URL('../data/__fixtures__/graphml/', import.meta.url));
-
-function readFixture(name: string): string {
-  return readFileSync(join(FIXTURES_DIR, name), {encoding: 'utf8'});
-}
+import basicGraphml from '../data/__fixtures__/graphml/basic.graphml?raw';
+import defaultsGraphml from '../data/__fixtures__/graphml/defaults.graphml?raw';
 
 beforeAll(() => {
   globalThis.CustomEvent = Event as any;
@@ -23,7 +15,7 @@ describe('loadGraphML', () => {
   let graph: ReturnType<typeof loadGraphML>;
 
   beforeAll(() => {
-    graph = loadGraphML(readFixture('basic.graphml'));
+    graph = loadGraphML(basicGraphml);
   });
 
   it('parses node attributes from GraphML text', () => {
@@ -67,7 +59,8 @@ describe('loadGraphML', () => {
   });
 
   it('accepts ArrayBuffer inputs and applies default values', () => {
-    const buffer = readFileSync(join(FIXTURES_DIR, 'defaults.graphml'));
+    const encoder = new TextEncoder();
+    const buffer = encoder.encode(defaultsGraphml);
     const arrayBuffer = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
 
     const bufferedGraph = loadGraphML(arrayBuffer);
@@ -83,8 +76,7 @@ describe('loadGraphML', () => {
 
 describe('parseGraphML', () => {
   it('returns GraphData compatible objects', () => {
-    const xml = readFixture('basic.graphml');
-    const data = parseGraphML(xml);
+    const data = parseGraphML(basicGraphml);
 
     expect(data.shape).toBe('plain-graph-data');
     expect(data.nodes).toHaveLength(2);

--- a/modules/graph-layers/test/loaders/graphml-loader.spec.ts
+++ b/modules/graph-layers/test/loaders/graphml-loader.spec.ts
@@ -19,7 +19,7 @@ describe('loadGraphML', () => {
   });
 
   it('parses node attributes from GraphML text', () => {
-    const nodeIds = Array.from(graph.getNodes(), (node) => node.getId());
+    const nodeIds = Array.from(graph.getNodes(), node => node.getId());
     expect(nodeIds).toEqual(expect.arrayContaining(['n0', 'n1']));
 
     const nodeZero = graph.findNodeById('n0');
@@ -61,12 +61,15 @@ describe('loadGraphML', () => {
   it('accepts ArrayBuffer inputs and applies default values', () => {
     const encoder = new TextEncoder();
     const buffer = encoder.encode(defaultsGraphml);
-    const arrayBuffer = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+    const arrayBuffer = buffer.buffer.slice(
+      buffer.byteOffset,
+      buffer.byteOffset + buffer.byteLength
+    );
 
     const bufferedGraph = loadGraphML(arrayBuffer);
     const nodes = Array.from(bufferedGraph.getNodes());
     expect(nodes).toHaveLength(2);
-    expect(nodes.every((node) => node.getPropertyValue('category') === 'general')).toBe(true);
+    expect(nodes.every(node => node.getPropertyValue('category') === 'general')).toBe(true);
 
     const [edge] = Array.from(bufferedGraph.getEdges());
     expect(edge.isDirected()).toBe(false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -550,6 +550,7 @@ __metadata:
     d3-force: "npm:^3.0.0"
     d3-format: "npm:^3.1.0"
     d3-scale: "npm:^4.0.2"
+    fast-xml-parser: "npm:^5.5.3"
     lodash.isequal: "npm:^4.5.0"
     ngraph.generators: "npm:^20.1.0"
     zod: "npm:^4.0.0"


### PR DESCRIPTION
## Summary
- rebase the GraphML loader branch onto current `master`
- add `loadGraphML` and `parseGraphML` for GraphML 1.0 node/edge/key/default parsing using the current `PlainGraphData` and runtime `Graph` APIs
- add focused GraphML fixtures and Node tests, document supported constructs, and record the `fast-xml-parser` dependency in `modules/graph-layers`

## Classification
Feature / data-loader API addition for graph-layers. It adds parser/runtime conversion utilities and package docs; it does not change a rendered example route or interactive UI.

## Validation
- `yarn`
- `yarn test-node modules/graph-layers/test/loaders/graphml-loader.spec.ts`
- `yarn test-node modules/graph-layers/test`
- `yarn lint-fix`
- `yarn lint`
- `yarn build`
- pre-commit `yarn test` (164 files passed, 1383 tests passed, 9 skipped)

## Visual proof
Not applicable. This PR adds a graph data loader and README/API surface; verification is by parser fixtures, graph runtime assertions, lint, and package build rather than a visual route or interaction recording.

## Residual risk
Low to medium. The parser intentionally supports common GraphML 1.0 graph/node/edge/key/default/data constructs and ignores unsupported advanced features such as hyperedges, ports, and nested graphs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913661f76548328bb79747e5a8b97b3)