### PR TITLE
Adjust graph layout position return types

### DIFF
--- a/docs/modules/graph-layers/api-reference/layouts/graph-layout.md
+++ b/docs/modules/graph-layers/api-reference/layouts/graph-layout.md
@@ -26,9 +26,10 @@ export class MyLayout extends GraphLayout {
   stop() {}
 
   // Access the position of the node in the layout
-  // If the position is not available (not calculated), returning nullish will hide the node.
+  // If the position is not available (not calculated), returning null will hide the node.
   getNodePosition(node) {}
-  // access the layout information of the edge
+  // Access the layout information of the edge
+  // Return a GraphEdgeLayout object or null if the edge should be hidden.
   getEdgePosition(edge) {}
   // Pin the node to a designated position, and the node won't move anymore
   lockNodePosition(node, x, y) {}
@@ -87,7 +88,7 @@ In this case, we can just simply update the `this._nodePositionMap` by going thr
   updateGraph(grpah) {
     this._graph = graph;
     this._nodePositionMap = graph.getNodes().reduce((res, node) => {
-      res[node.getId()] = this._nodePositionMap[node.getId()] || [0, 0];
+      res[node.getId()] = this._nodePositionMap[node.getId()] ?? null;
       return res;
     }, {});
   }
@@ -215,7 +216,7 @@ export default class RandomLayout extends GraphLayout {
   updateGraph(grpah) {
     this._graph = graph;
     this._nodePositionMap = graph.getNodes().reduce((res, node) => {
-      res[node.getId()] = this._nodePositionMap[node.getId()] || [0, 0];
+      res[node.getId()] = this._nodePositionMap[node.getId()] ?? null;
       return res;
     }, {});
   }

--- a/modules/graph-layers/src/core/graph-engine.ts
+++ b/modules/graph-layers/src/core/graph-engine.ts
@@ -7,7 +7,7 @@ import type {Bounds2D} from '@math.gl/types';
 import type {Graph, EdgeInterface, NodeInterface} from '../graph/graph';
 import {ClassicGraph, ClassicGraphLayoutAdapter} from '../graph/classic-graph';
 import type {GraphRuntimeLayout} from './graph-runtime-layout';
-import {GraphLayout, type GraphLayoutEventDetail} from './graph-layout';
+import {GraphLayout, type GraphLayoutEventDetail, type GraphEdgeLayout} from './graph-layout';
 import {Cache} from './cache';
 import {log} from '../utils/log';
 import {GraphStylesheetEngine, type GraphStylesheet} from '../style/graph-style-engine';
@@ -127,11 +127,11 @@ export class GraphEngine {
     return (this._cache.get('edges') as EdgeInterface[]) ?? [];
   };
 
-  getNodePosition = (node: NodeInterface) => {
+  getNodePosition = (node: NodeInterface): [number, number] | null => {
     return this._layout.getNodePosition(node) ?? null;
   };
 
-  getEdgePosition = (edge: EdgeInterface) => {
+  getEdgePosition = (edge: EdgeInterface): GraphEdgeLayout | null => {
     return this._layout.getEdgePosition(edge) ?? null;
   };
 

--- a/modules/graph-layers/src/core/graph-layout.ts
+++ b/modules/graph-layers/src/core/graph-layout.ts
@@ -31,6 +31,13 @@ export const GRAPH_LAYOUT_DEFAULT_PROPS: Readonly<Required<GraphLayoutProps>> = 
   onLayoutError: undefined
 };
 
+export type GraphEdgeLayout = {
+  type: string;
+  sourcePosition: [number, number];
+  targetPosition: [number, number];
+  controlPoints: [number, number][];
+};
+
 export abstract class GraphLayout<
   PropsT extends GraphLayoutProps = GraphLayoutProps
 > {
@@ -85,18 +92,13 @@ export abstract class GraphLayout<
   // Accessors
 
   /** access the position of the node in the layout */
-  getNodePosition(node: NodeInterface): [number, number] {
-    return [0, 0];
+  getNodePosition(node: NodeInterface): [number, number] | null | undefined {
+    return null;
   }
 
   /** access the layout information of the edge */
-  getEdgePosition(edge: EdgeInterface) {
-    return {
-      type: 'line',
-      sourcePosition: [0, 0],
-      targetPosition: [0, 0],
-      controlPoints: []
-    };
+  getEdgePosition(edge: EdgeInterface): GraphEdgeLayout | null {
+    return null;
   }
 
   /**

--- a/modules/graph-layers/src/core/graph-runtime-layout.ts
+++ b/modules/graph-layers/src/core/graph-runtime-layout.ts
@@ -4,7 +4,7 @@
 
 import type {Bounds2D} from '@math.gl/types';
 
-import type {GraphLayoutProps, GraphLayoutState} from './graph-layout';
+import type {GraphLayoutProps, GraphLayoutState, GraphEdgeLayout} from './graph-layout';
 import type {EdgeInterface, Graph, NodeInterface} from '../graph/graph';
 
 export interface GraphRuntimeLayout {
@@ -20,7 +20,7 @@ export interface GraphRuntimeLayout {
   stop(): void;
   getBounds(): Bounds2D | null;
   getNodePosition(node: NodeInterface): [number, number] | null | undefined;
-  getEdgePosition(edge: EdgeInterface): unknown;
+  getEdgePosition(edge: EdgeInterface): GraphEdgeLayout | null;
   lockNodePosition(node: NodeInterface, x: number, y: number): void;
   unlockNodePosition(node: NodeInterface): void;
   destroy?(): void;

--- a/modules/graph-layers/src/graph/classic-graph.ts
+++ b/modules/graph-layers/src/graph/classic-graph.ts
@@ -6,7 +6,12 @@ import {warn} from '../utils/log';
 import {Cache} from '../core/cache';
 import {Edge} from './edge';
 import {Node} from './node';
-import {GraphLayout, type GraphLayoutProps, type GraphLayoutState} from '../core/graph-layout';
+import {
+  GraphLayout,
+  type GraphLayoutProps,
+  type GraphLayoutState,
+  type GraphEdgeLayout
+} from '../core/graph-layout';
 import type {GraphRuntimeLayout} from '../core/graph-runtime-layout';
 import type {EdgeInterface, NodeInterface, GraphProps} from './graph';
 import {Graph} from './graph';
@@ -427,11 +432,11 @@ export class ClassicGraphLayoutAdapter implements GraphRuntimeLayout {
     return this.layout.getBounds();
   }
 
-  getNodePosition(node: NodeInterface) {
+  getNodePosition(node: NodeInterface): [number, number] | null {
     return this.layout.getNodePosition(node as Node);
   }
 
-  getEdgePosition(edge: EdgeInterface) {
+  getEdgePosition(edge: EdgeInterface): GraphEdgeLayout | null {
     return this.layout.getEdgePosition(edge as Edge);
   }
 

--- a/modules/graph-layers/src/index.ts
+++ b/modules/graph-layers/src/index.ts
@@ -42,7 +42,8 @@ export {GraphEngine} from './core/graph-engine';
 export type {
   GraphLayoutProps,
   GraphLayoutState,
-  GraphLayoutEventDetail
+  GraphLayoutEventDetail,
+  GraphEdgeLayout
 } from './core/graph-layout';
 export {GraphLayout} from './core/graph-layout';
 

--- a/modules/graph-layers/src/layouts/d3-dag/d3-dag-layout.ts
+++ b/modules/graph-layers/src/layouts/d3-dag/d3-dag-layout.ts
@@ -4,7 +4,12 @@
 
 /* eslint-disable no-continue, complexity, max-statements */
 
-import {GraphLayout, GraphLayoutProps, GRAPH_LAYOUT_DEFAULT_PROPS} from '../../core/graph-layout';
+import {
+  GraphLayout,
+  GraphLayoutProps,
+  GRAPH_LAYOUT_DEFAULT_PROPS,
+  type GraphEdgeLayout
+} from '../../core/graph-layout';
 import type {ClassicGraph} from '../../graph/classic-graph';
 import type {NodeInterface, EdgeInterface} from '../../graph/graph';
 import {Node} from '../../graph/node';
@@ -278,14 +283,7 @@ export class D3DagLayout<PropsT extends D3DagLayoutProps = D3DagLayoutProps> ext
     return this._nodePositions.get(mappedId) || null;
   }
 
-  getEdgePosition(edge: EdgeInterface):
-    | {
-        type: string;
-        sourcePosition: [number, number];
-        targetPosition: [number, number];
-        controlPoints: [number, number][];
-      }
-    | null {
+  getEdgePosition(edge: EdgeInterface): GraphEdgeLayout | null {
     const mappedSourceId = this._mapNodeId(edge.getSourceNodeId());
     const mappedTargetId = this._mapNodeId(edge.getTargetNodeId());
     if (mappedSourceId === mappedTargetId) {

--- a/modules/graph-layers/src/layouts/d3-force/d3-force-layout.ts
+++ b/modules/graph-layers/src/layouts/d3-force/d3-force-layout.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {GraphLayout, GraphLayoutProps, GRAPH_LAYOUT_DEFAULT_PROPS} from '../../core/graph-layout';
+import {
+  GraphLayout,
+  GraphLayoutProps,
+  GRAPH_LAYOUT_DEFAULT_PROPS,
+  type GraphEdgeLayout
+} from '../../core/graph-layout';
 import {log} from '../../utils/log';
 
 export type D3ForceLayoutOptions = GraphLayoutProps & {
@@ -114,7 +119,7 @@ export class D3ForceLayout extends GraphLayout<D3ForceLayoutOptions> {
     }
   }
 
-  getEdgePosition = (edge) => {
+  getEdgePosition = (edge): GraphEdgeLayout | null => {
     const sourceNode = this._graph.findNode(edge.getSourceNodeId());
     const targetNode = this._graph.findNode(edge.getTargetNodeId());
     if (!sourceNode || !targetNode) {
@@ -136,7 +141,7 @@ export class D3ForceLayout extends GraphLayout<D3ForceLayoutOptions> {
     };
   };
 
-  getNodePosition = (node) => {
+  getNodePosition = (node): [number, number] | null => {
     if (!node) {
       return null;
     }

--- a/modules/graph-layers/src/layouts/experimental/hive-plot-layout.ts
+++ b/modules/graph-layers/src/layouts/experimental/hive-plot-layout.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {GraphLayout, GraphLayoutProps, GRAPH_LAYOUT_DEFAULT_PROPS} from '../../core/graph-layout';
+import {
+  GraphLayout,
+  GraphLayoutProps,
+  GRAPH_LAYOUT_DEFAULT_PROPS,
+  type GraphEdgeLayout
+} from '../../core/graph-layout';
 import {Node} from '../../graph/node';
 import {ClassicGraph} from '../../graph/classic-graph';
 
@@ -104,9 +109,10 @@ export class HivePlotLayout extends GraphLayout<HivePlotLayoutProps> {
 
   resume() {}
 
-  getNodePosition = (node) => this._nodePositionMap[node.getId()];
+  getNodePosition = (node: Node): [number, number] | null =>
+    this._nodePositionMap[node.getId()] ?? null;
 
-  getEdgePosition = (edge) => {
+  getEdgePosition = (edge): GraphEdgeLayout | null => {
     const {getNodeAxis} = this.props;
     const sourceNodeId = edge.getSourceNodeId();
     const targetNodeId = edge.getTargetNodeId();
@@ -114,8 +120,16 @@ export class HivePlotLayout extends GraphLayout<HivePlotLayoutProps> {
     const sourcePosition = this._nodePositionMap[sourceNodeId];
     const targetPosition = this._nodePositionMap[targetNodeId];
 
+    if (!sourcePosition || !targetPosition) {
+      return null;
+    }
+
     const sourceNode = this._nodeMap[sourceNodeId];
     const targetNode = this._nodeMap[targetNodeId];
+
+    if (!sourceNode || !targetNode) {
+      return null;
+    }
 
     const sourceNodeAxis = getNodeAxis(sourceNode);
     const targetNodeAxis = getNodeAxis(targetNode);

--- a/modules/graph-layers/src/layouts/experimental/radial-layout.ts
+++ b/modules/graph-layers/src/layouts/experimental/radial-layout.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {GraphLayout, GraphLayoutProps, GRAPH_LAYOUT_DEFAULT_PROPS} from '../../core/graph-layout';
+import {
+  GraphLayout,
+  GraphLayoutProps,
+  GRAPH_LAYOUT_DEFAULT_PROPS,
+  type GraphEdgeLayout
+} from '../../core/graph-layout';
 import {ClassicGraph} from '../../graph/classic-graph';
 import type {Node} from '../../graph/node';
 
@@ -161,16 +166,20 @@ export class RadialLayout extends GraphLayout<RadialLayoutProps> {
 
   update() {}
 
-  getNodePosition = (node: Node) => {
-    return this._hierarchicalPoints[node.getId()];
+  getNodePosition = (node: Node): [number, number] | null => {
+    return this._hierarchicalPoints[node.getId()] ?? null;
   };
 
   // spline curve version
-  getEdgePosition = (edge) => {
+  getEdgePosition = (edge): GraphEdgeLayout | null => {
     const sourceNodeId = edge.getSourceNodeId();
     const targetNodeId = edge.getTargetNodeId();
     const sourceNodePos = this._hierarchicalPoints[sourceNodeId];
     const targetNodePos = this._hierarchicalPoints[targetNodeId];
+
+    if (!sourceNodePos || !targetNodePos) {
+      return null;
+    }
 
     const sourcePath = [];
     getPath(this.nestedTree, sourceNodeId, sourcePath);

--- a/modules/graph-layers/src/layouts/gpu-force/gpu-force-layout.ts
+++ b/modules/graph-layers/src/layouts/gpu-force/gpu-force-layout.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {GraphLayout, GraphLayoutProps, GRAPH_LAYOUT_DEFAULT_PROPS} from '../../core/graph-layout';
+import {
+  GraphLayout,
+  GraphLayoutProps,
+  GRAPH_LAYOUT_DEFAULT_PROPS,
+  type GraphEdgeLayout
+} from '../../core/graph-layout';
 
 export type GPUForceLayoutOptions = GraphLayoutProps & {
   alpha?: number;
@@ -213,15 +218,15 @@ export class GPUForceLayout extends GraphLayout<GPUForceLayoutOptions> {
     this._d3Graph.edges = newD3Edges;
   }
 
-  getNodePosition = (node): [number, number] => {
+  getNodePosition = (node): [number, number] | null => {
     const d3Node = this._nodeMap[node.id];
     if (d3Node) {
       return [d3Node.x, d3Node.y];
     }
-    return [0, 0];
+    return null;
   };
 
-  getEdgePosition = (edge) => {
+  getEdgePosition = (edge): GraphEdgeLayout | null => {
     const d3Edge = this._edgeMap[edge.id];
     const sourcePosition = d3Edge && d3Edge.source;
     const targetPosition = d3Edge && d3Edge.target;
@@ -233,12 +238,7 @@ export class GPUForceLayout extends GraphLayout<GPUForceLayoutOptions> {
         controlPoints: []
       };
     }
-    return {
-      type: 'line',
-      sourcePosition: [0, 0],
-      targetPosition: [0, 0],
-      controlPoints: []
-    };
+    return null;
   };
 
   lockNodePosition = (node, x, y) => {

--- a/modules/graph-layers/src/layouts/simple-layout.ts
+++ b/modules/graph-layers/src/layouts/simple-layout.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {GraphLayout, GraphLayoutProps, GRAPH_LAYOUT_DEFAULT_PROPS} from '../core/graph-layout';
+import {
+  GraphLayout,
+  GraphLayoutProps,
+  GRAPH_LAYOUT_DEFAULT_PROPS,
+  type GraphEdgeLayout
+} from '../core/graph-layout';
 import {Node} from '../graph/node';
 import {Edge} from '../graph/edge';
 import {ClassicGraph} from '../graph/classic-graph';
@@ -81,19 +86,27 @@ export class SimpleLayout extends GraphLayout<SimpleLayoutProps> {
     (this.props as any).nodePositionAccessor = accessor;
   };
 
-  getNodePosition = (node: Node | null): [number, number] => {
+  getNodePosition = (node: Node | null): [number, number] | null => {
     if (!node) {
-      return [0, 0] as [number, number];
+      return null;
     }
     const position = this._nodePositionMap[node.getId()];
-    return position ?? [0, 0] as [number, number];
+    return position ?? null;
   };
 
-  getEdgePosition = (edge: Edge) => {
+  getEdgePosition = (edge: Edge): GraphEdgeLayout | null => {
     const sourceNode = this._nodeMap[edge.getSourceNodeId()];
     const targetNode = this._nodeMap[edge.getTargetNodeId()];
-    const sourcePos = sourceNode ? this.getNodePosition(sourceNode) : [0, 0];
-    const targetPos = targetNode ? this.getNodePosition(targetNode) : [0, 0];
+    if (!sourceNode || !targetNode) {
+      return null;
+    }
+
+    const sourcePos = this.getNodePosition(sourceNode);
+    const targetPos = this.getNodePosition(targetNode);
+    if (!sourcePos || !targetPos) {
+      return null;
+    }
+
     return {
       type: 'line',
       sourcePosition: sourcePos,


### PR DESCRIPTION
## Summary
- add a typed `GraphEdgeLayout` result and have `GraphLayout` getters default to `null` when geometry is unavailable
- align engine, runtime adapter, and built-in layouts with the new node/edge position typings and re-export the type surface
- document the updated getter contract and null-return guidance in the graph layout guide

## Testing
- yarn vitest run modules/graph-layers/test/layouts/d3-dag-layout.spec.ts *(fails: Playwright browsers not installed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691369ca2abc8328b256962f614ed4ae)