### PR TITLE
Fix GraphLayer normalized graph data inputs

### DIFF
--- a/docs/modules/graph-layers/api-reference/layers/graph-layer.md
+++ b/docs/modules/graph-layers/api-reference/layers/graph-layer.md
@@ -54,6 +54,8 @@ Unified graph input. Accepts:
 
 - A `GraphEngine` instance to reuse an existing engine.
 - A [`Graph`](../graph.md) instance to have the layer build its own engine.
+- Normalized `GraphData` emitted by bundled loaders such as `PlainGraphData` or
+  `ArrowGraphData`.
 - Raw graph payloads—either arrays of edges or `{nodes, edges}` objects. Strings
   and promises are resolved via Deck.gl's async prop system.
 
@@ -70,8 +72,8 @@ releases will remove this prop.
 
 Custom loader that converts raw `data` into a `Graph`. Defaults to the bundled
 `JSONLoader`, which accepts arrays of edges or `{nodes, edges}` collections and
-automatically synthesizes missing nodes. Graph instances are no longer
-normalized by the loader—pass them directly to `data`.
+automatically synthesizes missing nodes. Graph instances and normalized
+`GraphData` are no longer normalized by the loader—pass them directly to `data`.
 
 #### `engine` (`GraphEngine`, optional)
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -4,6 +4,12 @@
 
 Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community/milestone/5).
 
+### `@deck.gl-community/graph-layers`
+
+- `GraphLayer` now accepts normalized `PlainGraphData` and `ArrowGraphData`
+  loader outputs directly through `data`, without routing them through a custom
+  `graphLoader`.
+
 ### `@deck.gl-community/layers`
 
 - `DependencyArrowLayer` - NEW directional marker layer for dependency links with path, line, or arc routing.

--- a/modules/graph-layers/src/graph-data/graph-data.ts
+++ b/modules/graph-layers/src/graph-data/graph-data.ts
@@ -55,3 +55,7 @@ export function isPlainGraphData(value: unknown): value is PlainGraphData {
   const candidate = value as PlainGraphData;
   return typeof value === 'object' && candidate?.shape === 'plain-graph-data';
 }
+
+export function isGraphData(value: unknown): value is GraphData {
+  return isPlainGraphData(value) || isArrowGraphData(value);
+}

--- a/modules/graph-layers/src/layers/graph-layer.ts
+++ b/modules/graph-layers/src/layers/graph-layer.ts
@@ -54,6 +54,7 @@ import {
   type RankAccessor
 } from '../utils/rank-grid';
 import {createGraphFromData} from '../graph/functions/create-graph-from-data';
+import {type GraphData, isGraphData} from '../graph-data/graph-data';
 
 import {warn} from '../utils/log';
 
@@ -122,6 +123,7 @@ export type GraphLayerRawData = {
 export type GraphLayerDataInput =
   | GraphEngine
   | Graph
+  | GraphData
   | GraphLayerRawData
   | unknown[]
   | string
@@ -484,6 +486,10 @@ export class GraphLayer extends CompositeLayer<GraphLayerProps> {
     const graphCandidate = this._coerceGraph(data);
     if (graphCandidate) {
       return this._buildEngineFromGraph(graphCandidate, props.layout);
+    }
+
+    if (isGraphData(data)) {
+      return this._buildEngineFromGraph(createGraphFromData(data), props.layout);
     }
 
     if (typeof data === 'string') {

--- a/modules/graph-layers/test/layers/graph-layer.spec.ts
+++ b/modules/graph-layers/test/layers/graph-layer.spec.ts
@@ -1,0 +1,48 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, it, vi} from 'vitest';
+
+import {GraphLayer} from '../../src/layers/graph-layer';
+import {SimpleLayout} from '../../src/layouts/simple-layout';
+import {isGraphData, type PlainGraphData} from '../../src/graph-data/graph-data';
+import type {GraphLayerProps} from '../../src/layers/graph-layer';
+
+type TestableGraphLayer = GraphLayer & {
+  _deriveEngineFromData(data: GraphLayerProps['data'], props: GraphLayerProps): unknown;
+};
+
+const graphData: PlainGraphData = {
+  shape: 'plain-graph-data',
+  version: 1,
+  nodes: [
+    {id: 'a', attributes: {x: 0, y: 0}},
+    {id: 'b', attributes: {x: 1, y: 1}}
+  ],
+  edges: [{id: 'ab', sourceId: 'a', targetId: 'b'}]
+};
+
+describe('layers/graph-layer', () => {
+  it('recognizes normalized graph data', () => {
+    expect(isGraphData(graphData)).toBe(true);
+    expect(isGraphData({nodes: [], edges: []})).toBe(false);
+  });
+
+  it('builds graph engines directly from normalized graph data', () => {
+    const graphLoader = vi.fn(() => null);
+    const layer = new GraphLayer({id: 'graph-layer-test'}) as TestableGraphLayer;
+    const layout = new SimpleLayout();
+
+    const engine = layer._deriveEngineFromData(graphData, {
+      id: 'graph-layer-test',
+      data: graphData,
+      layout,
+      graphLoader
+    } as GraphLayerProps) as {getNodes: () => unknown[]; getEdges: () => unknown[]};
+
+    expect(graphLoader).not.toHaveBeenCalled();
+    expect(engine.getNodes()).toHaveLength(2);
+    expect(engine.getEdges()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- refreshes this stale branch onto current `master` as a focused `GraphLayer` data-input fix
- exports `isGraphData()` and lets `GraphLayer.data` accept normalized `PlainGraphData` / `ArrowGraphData` directly
- bypasses `graphLoader` for already-normalized graph data while preserving loader handling for raw JSON-like inputs
- documents the direct `GraphData` input path and adds a v9.4 release note

## Classification
Type/API bug fix. Visual proof is not applicable because this changes the graph-layers TypeScript/API data contract and engine construction path, not rendered UI or example behavior.

## Validation
- `yarn`
- `yarn test-node modules/graph-layers/test/layers/graph-layer.spec.ts`
- `yarn test-node modules/graph-layers/test`
- `yarn test-node modules/graph-layers/test/layers/graph-layer.spec.ts modules/graph-layers/test/graph-data/graph-data.spec.ts modules/graph-layers/test/graph-data/create-graph-from-data.spec.ts`
- `yarn lint-fix`
- `yarn lint`
- `yarn build`
- `cd website && yarn && yarn build`
- pre-commit `yarn test` (164 files passed, 1381 tests passed, 9 skipped)

## Residual risk
Low. The new path is gated by the explicit `shape` tags used by existing `GraphData` types, so raw data and custom loader behavior remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913c1d418a88328a87687267993bcb5)
