### PR TITLE
docs(graph-layers) Remove GraphGL references outside historical context

### DIFF
--- a/docs/modules/graph-layers/developer-guide/get-started.md
+++ b/docs/modules/graph-layers/developer-guide/get-started.md
@@ -14,12 +14,12 @@ The deck.gl-community repo is specifically set up to collect useful code that no
 There is an ambition to phase out React specific code for deck.gl-community modules. This model is expected to be deprecated in the near future.
 :::
 
-graph-layers provides React components for visualizing large graphs with several utility functions. 
+graph-layers provides Deck.gl layers and utilities for visualizing large graphs with several utility functions.
 
-graph-layers can build a highly customizable graph visualization through its composable API. The rendering is powered by deck.gl which is a WebGL based visualization framework.  With graph-layers, users are enabled to build various type of graph/network applications with minimum efforts while having the capability to extend the existing styles and layouts.
+graph-layers can build a highly customizable graph visualization through its composable API. The rendering is powered by deck.gl which is a WebGL based visualization framework. With graph-layers, users are enabled to build various type of graph/network applications with minimum efforts while having the capability to extend the existing styles and layouts.
 
 ## Abstract
-graph-layers is a React component for visualizing large graphs with several utility functions. It can build a highly customizable graph visualization through its composable API. The rendering is powered by deck.gl which is a WebGL based visualization framework.  With graph-layers, users are enabled to build various type of graph/network applications with minimum efforts while having the capability to extend the existing styles and layouts.
+graph-layers is a Deck.gl layer pack for visualizing large graphs with several utility functions. It can build a highly customizable graph visualization through its composable API. The rendering is powered by deck.gl which is a WebGL based visualization framework. With graph-layers, users are enabled to build various type of graph/network applications with minimum efforts while having the capability to extend the existing styles and layouts.
 
 ## Motivation
 Uber originally started this project as Graph.gl. After stopping efforts on Graph.gl, the OpenJS Foundation has resumed efforts.
@@ -32,47 +32,58 @@ TBD, we've just started a reboot to update dependencies and modernize the codeba
 
 ## Get Started
 ```js
-import GraphGL, {JSONLoader, D3ForceLayout} from 'deck-graph-layers';
+import DeckGL from '@deck.gl/react';
+import {GraphLayer, D3ForceLayout} from '@deck.gl-community/graph-layers';
 
-const App = ({data}) => {
-  const graph = JSONLoader({
-    json: data,
-    nodeParser: node => ({id: node.id}),
-    edgeParser: edge => ({
-      id: edge.id,
-      sourceId: edge.sourceId,
-      targetId: edge.targetId,
-      directed: true,
-    }),
-  });
-  return (
-    <GraphGL
-      graph={graph}
-      layout={new D3ForceLayout()}
-      stylesheet={{
-        nodes: [
-          {
-            type: 'circle',
-            radius: 10,
-            fill: 'blue',
-            opacity: 1,
-          },
-          {
-            type: 'label',
-            text: '@id',
-            color: '#ffffff',
-            offset: [0, 18],
-          },
-        ],
-        edges: {
-          stroke: 'black',
-          strokeWidth: 2,
+const SAMPLE_GRAPH = {
+  nodes: [
+    {id: 'A'},
+    {id: 'B'},
+    {id: 'C'}
+  ],
+  edges: [
+    {source: 'A', target: 'B'},
+    {source: 'B', target: 'C'},
+    {source: 'C', target: 'A'}
+  ]
+};
+
+const App = () => {
+  const layer = new GraphLayer({
+    id: 'graph-layer',
+    data: SAMPLE_GRAPH,
+    layout: new D3ForceLayout(),
+    stylesheet: {
+      nodes: [
+        {
+          type: 'circle',
+          radius: 10,
+          fill: 'blue',
+          opacity: 1
         },
-      }}
-      enableDragging
+        {
+          type: 'label',
+          text: '@id',
+          color: '#ffffff',
+          offset: [0, 18]
+        }
+      ],
+      edges: {
+        stroke: 'black',
+        strokeWidth: 2
+      }
+    },
+    enableDragging: true
+  });
+
+  return (
+    <DeckGL
+      initialViewState={{target: [0, 0], zoom: 1}}
+      controller={{doubleClickZoom: false}}
+      layers={[layer]}
     />
   );
-}
+};
 ```
 
 

--- a/docs/modules/graph-layers/developer-guide/interactions.md
+++ b/docs/modules/graph-layers/developer-guide/interactions.md
@@ -2,7 +2,7 @@
 
 In this chapter, you'll learn about how to interact with the graph.
 
-There are the porperties you can specify when using the GraphGL component:
+These are the properties you can specify when configuring the `GraphLayer`:
 
 ### `nodeEvents` (Object, optional)
 All events callbacks will be triggered with the following parameters:

--- a/examples/graph-layers/graph-viewer/examples.ts
+++ b/examples/graph-layers/graph-viewer/examples.ts
@@ -898,9 +898,9 @@ export const EXAMPLES: ExampleDefinition[] = [
     type: 'graph'
   },
   {
-    name: 'World trade (radial, graph.gl)',
+    name: 'World trade (radial)',
     description:
-      'Recreates the original graph.gl radial layout example using World Integrated Trade Solution partner flows grouped by region.',
+      'Radial layout of World Integrated Trade Solution partner flows grouped by region, inspired by the original demo.',
     data: () => cloneGraphData(WITS_GRAPH_DATA),
     layouts: ['radial-layout'],
     layoutDescriptions: LAYOUT_DESCRIPTIONS,
@@ -950,9 +950,9 @@ export const EXAMPLES: ExampleDefinition[] = [
         : undefined
   },
   {
-    name: 'World trade (hive plot, graph.gl)',
+    name: 'World trade (hive plot)',
     description:
-      'Original graph.gl hive plot demo data visualising international trade communities grouped by their regional bloc.',
+      'Hive plot demo data visualising international trade communities grouped by their regional bloc.',
     data: () => cloneGraphData(WITS_GRAPH_DATA),
     layouts: ['hive-plot-layout'],
     layoutDescriptions: LAYOUT_DESCRIPTIONS,
@@ -986,9 +986,9 @@ export const EXAMPLES: ExampleDefinition[] = [
         : undefined
   },
   {
-    name: 'World trade (force multi-graph, graph.gl)',
+    name: 'World trade (force multi-graph)',
     description:
-      'Applies the force multi-graph layout to the graph.gl WITS dataset to emphasise dense trade corridors and minimise overlapping links.',
+      'Applies the force multi-graph layout to the WITS dataset to emphasise dense trade corridors and minimise overlapping links.',
     data: () => cloneGraphData(WITS_GRAPH_DATA),
     layouts: ['force-multi-graph-layout'],
     layoutDescriptions: LAYOUT_DESCRIPTIONS,

--- a/wip/examples-wip/graph-viewer-legacy/app-hive-plot-wip.tsx
+++ b/wip/examples-wip/graph-viewer-legacy/app-hive-plot-wip.tsx
@@ -9,8 +9,8 @@ import {extent} from 'd3-array';
 import Color from 'color';
 import {fetchJSONFromS3} from '../../utils/data/io';
 
-// graph.gl
-import GraphGL, {JSONLoader} from '../../src';
+import {JSONLoader} from '../../src';
+import {GraphViewer} from './react-graph-layers/graph-viewer';
 import HivePlot from './hive-plot-layout';
 
 const DEFAULT_NODE_SIZE = 3;
@@ -55,7 +55,7 @@ export default class HivePlotExample extends Component {
       return null;
     }
     return (
-      <GraphGL
+      <GraphViewer
         graph={this.state.graph}
         layout={
           new HivePlot({

--- a/wip/examples-wip/graph-viewer-legacy/app-multi-graph-wip.tsx
+++ b/wip/examples-wip/graph-viewer-legacy/app-multi-graph-wip.tsx
@@ -5,8 +5,8 @@
 import React, {Component} from 'react';
 import Color from 'color';
 
-// graph.gl
-import GraphGL, {JSONLoader} from '@deck.gl-community/graph-layers';
+import {JSONLoader} from '@deck.gl-community/graph-layers';
+import {GraphViewer} from './react-graph-layers/graph-viewer';
 import MultiGraphLayout from './layouts/multi-graph-layout';
 
 // data
@@ -33,7 +33,7 @@ export default class MultiGraphExample extends Component {
 
   render() {
     return (
-      <GraphGL
+      <GraphViewer
         graph={JSONLoader({json: sampleGraph})}
         layout={
           new MultiGraphLayout({

--- a/wip/examples-wip/graph-viewer-legacy/app-radial-layout-wip.tsx
+++ b/wip/examples-wip/graph-viewer-legacy/app-radial-layout-wip.tsx
@@ -11,8 +11,8 @@ import Color from 'color';
 // data
 import {fetchJSONFromS3} from './io';
 
-// graph.gl
-import GraphGL, {JSONLoader} from '@deck.gl-community/graph-layers';
+import {JSONLoader} from '@deck.gl-community/graph-layers';
+import {GraphViewer} from './react-graph-layers/graph-viewer';
 import RadialLayout from './layouts/radial-layout';
 
 const DEFAULT_NODE_SIZE = 5;
@@ -59,7 +59,7 @@ export default class BasicRadialExample extends Component {
     }
 
     return (
-      <GraphGL
+      <GraphViewer
         graph={this.state.graph}
         layout={
           new RadialLayout({

--- a/wip/examples-wip/graph-viewer-legacy/app.tsx
+++ b/wip/examples-wip/graph-viewer-legacy/app.tsx
@@ -6,7 +6,7 @@ import React, {Component} from 'react';
 import {createRoot} from 'react-dom/client';
 
 import {D3ForceLayout, JSONLoader} from '@deck.gl-community/graph-layers';
-import {GraphGL} from './react-graph-layers/graph-gl';
+import {GraphViewer} from './react-graph-layers/graph-viewer';
 
 // eslint-disable-next-line import/no-unresolved
 import {SAMPLE_GRAPH_DATASETS} from '../../../modules/graph-layers/test/data/graphs/sample-datasets';
@@ -59,7 +59,7 @@ export class App extends Component {
     return (
       <div style={{display: 'flex', flexDirection: 'column', height: '100%'}}>
         <div style={{width: '100%', flex: 1}}>
-          <GraphGL
+          <GraphViewer
             graph={graph}
             layout={new D3ForceLayout()}
             stylesheet={{

--- a/wip/examples-wip/graph-viewer-legacy/react-graph-layers/graph-viewer.tsx
+++ b/wip/examples-wip/graph-viewer-legacy/react-graph-layers/graph-viewer.tsx
@@ -41,7 +41,7 @@ const DEFAULT_STYLESHEET = {
   }
 } as const satisfies GraphLayerStylesheet;
 
-export const GraphGL = ({
+export const GraphViewer = ({
   graph = new Graph(),
   layout = new SimpleLayout(),
   glOptions = {},
@@ -235,7 +235,7 @@ export const GraphGL = ({
   );
 };
 
-GraphGL.propTypes = {
+GraphViewer.propTypes = {
   /** Input graph data */
   graph: PropTypes.object.isRequired,
   /** Layout algorithm */


### PR DESCRIPTION
## Summary
- update graph-layers developer documentation to reference GraphLayer and refresh the getting started example
- rename legacy graph viewer components and usages to drop the GraphGL branding
- revise graph viewer example labels to remove graph.gl mentions outside historical context

## Testing
- yarn test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b12ecb1588328bb894fff4c6e2d09)