### PR TITLE
fix(editable-layers): Fix import of PathMarkerLayer

### DIFF
--- a/modules/editable-layers/src/lib/layers/segments-layer.ts
+++ b/modules/editable-layers/src/lib/layers/segments-layer.ts
@@ -6,7 +6,7 @@ import {ArrowStyles, DEFAULT_STYLE, MAX_ARROWS} from '../style';
 import {NebulaLayer} from '../nebula-layer';
 import {toDeckColor} from '../../utils/utils';
 import {DeckCache} from '../deck-renderer/deck-cache';
-import {PathMarkerLayer} from '../../../../layers/src/path-marker-layer/path-marker-layer';
+import {PathMarkerLayer} from '@deck.gl-community/layers';
 
 const NEBULA_TO_DECK_DIRECTIONS = {
   [ArrowStyles.NONE]: {forward: false, backward: false},


### PR DESCRIPTION
Summary: 
 * fix invalid cross-module import  in `@deck.gl-community/editable-layers`
 
---

Fixes, fegression from https://github.com/visgl/deck.gl-community/pull/333

This fix interesting issue with tsc jumping from "{moduleA}/dist/..." to "{moduleB}/src" when checking types.

Note, that currently distributed `node_modules/@deck.gl-community/editable-layers/dist/lib/layers/segments-layer.d.ts` for reads like this:

```
import { PathMarkerLayer } from "../../../../layers/src/path-marker-layer/path-marker-layer.js";
```

That means, it imports not from "official types" of  `@deck.gl-community/layers` which live in `dist/...`, but does "self-path-traversal-attack" and reaches to 'src' folder of this package.


