### PR TITLE
fix(website): gallery leaflet link .html extension

### DIFF
--- a/examples/gallery/manifest.json
+++ b/examples/gallery/manifest.json
@@ -4,6 +4,6 @@
     "title": "Leaflet Basemap",
     "description": "deck.gl layers synchronized with Leaflet basemap.",
     "thumbnail": "/images/maps.jpg",
-    "href": "/gallery/leaflet"
+    "href": "/gallery/leaflet.html"
   }
 ]


### PR DESCRIPTION
## Summary
- update the gallery manifest so the Leaflet example links to the built leaflet.html asset

## Testing
- yarn test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921d13ce0b08328bf0b8033c81ae857)