### PR TITLE
Chore: import geojson types directly, do not re-export them

### DIFF
--- a/modules/editable-layers/src/edit-modes/composite-mode.ts
+++ b/modules/editable-layers/src/edit-modes/composite-mode.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {FeatureCollection} from '../utils/geojson-types';
+import {FeatureCollection} from 'geojson';
 import {
   ModeProps,
   ClickEvent,

--- a/modules/editable-layers/src/edit-modes/delete-mode.ts
+++ b/modules/editable-layers/src/edit-modes/delete-mode.ts
@@ -1,4 +1,4 @@
-import {FeatureCollection} from '../utils/geojson-types';
+import {FeatureCollection} from 'geojson';
 
 import {GeoJsonEditMode} from './geojson-edit-mode';
 import {ClickEvent, ModeProps} from './types';

--- a/modules/editable-layers/src/edit-modes/draw-90degree-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-90degree-polygon-mode.ts
@@ -19,7 +19,8 @@ import {
   GuideFeatureCollection,
   TentativeFeature
 } from './types';
-import {Polygon, LineString, Position, FeatureCollection, SimpleFeatureCollection} from '../utils/geojson-types';
+import {Polygon, LineString, Position, FeatureCollection} from 'geojson'
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {GeoJsonEditMode} from './geojson-edit-mode';
 
 export class Draw90DegreePolygonMode extends GeoJsonEditMode {

--- a/modules/editable-layers/src/edit-modes/draw-circle-by-diameter-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-circle-by-diameter-mode.ts
@@ -7,7 +7,7 @@ import distance from '@turf/distance';
 import area from '@turf/area';
 import {memoize} from '../utils/memoize';
 import {ModeProps, Tooltip} from './types';
-import {Position, Polygon, Feature, FeatureCollection} from '../utils/geojson-types';
+import {Position, Polygon, Feature, FeatureCollection} from 'geojson';
 import {getIntermediatePosition} from './geojson-edit-mode';
 import {TwoClickPolygonMode} from './two-click-polygon-mode';
 

--- a/modules/editable-layers/src/edit-modes/draw-circle-from-center-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-circle-from-center-mode.ts
@@ -7,7 +7,7 @@ import distance from '@turf/distance';
 import area from '@turf/area';
 import {memoize} from '../utils/memoize';
 import {ModeProps, Tooltip} from './types';
-import {Position, Polygon, Feature, FeatureCollection} from '../utils/geojson-types';
+import {Position, Polygon, Feature, FeatureCollection} from 'geojson';
 import {TwoClickPolygonMode} from './two-click-polygon-mode';
 
 export class DrawCircleFromCenterMode extends TwoClickPolygonMode {

--- a/modules/editable-layers/src/edit-modes/draw-ellipse-by-bounding-box-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-ellipse-by-bounding-box-mode.ts
@@ -6,7 +6,7 @@ import bboxPolygon from '@turf/bbox-polygon';
 import distance from '@turf/distance';
 import ellipse from '@turf/ellipse';
 import {point} from '@turf/helpers';
-import {Position, Polygon, Feature} from '../utils/geojson-types';
+import {Position, Polygon, Feature} from 'geojson';
 import {getIntermediatePosition} from './geojson-edit-mode';
 import {TwoClickPolygonMode} from './two-click-polygon-mode';
 

--- a/modules/editable-layers/src/edit-modes/draw-ellipse-using-three-points-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-ellipse-using-three-points-mode.ts
@@ -6,7 +6,7 @@ import distance from '@turf/distance';
 import ellipse from '@turf/ellipse';
 import bearing from '@turf/bearing';
 import {point} from '@turf/helpers';
-import {Position, Polygon, Feature} from '../utils/geojson-types';
+import {Position, Polygon, Feature} from 'geojson';
 import {getIntermediatePosition} from './geojson-edit-mode';
 import {ThreeClickPolygonMode} from './three-click-polygon-mode';
 

--- a/modules/editable-layers/src/edit-modes/draw-line-string-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-line-string-mode.ts
@@ -4,7 +4,8 @@
 
 import distance from '@turf/distance';
 import {memoize} from '../utils/memoize';
-import {LineString, FeatureCollection, Position, SimpleFeatureCollection} from '../utils/geojson-types';
+import {LineString, FeatureCollection, Position} from 'geojson';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {
   ClickEvent,
   PointerMoveEvent,

--- a/modules/editable-layers/src/edit-modes/draw-point-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-point-mode.ts
@@ -3,7 +3,8 @@
 // Copyright (c) vis.gl contributors
 
 import {ClickEvent, PointerMoveEvent, ModeProps, TentativeFeature} from './types';
-import {FeatureCollection, SimpleFeatureCollection, Point} from '../utils/geojson-types';
+import {FeatureCollection, Point} from 'geojson';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {GeoJsonEditMode} from './geojson-edit-mode';
 
 export class DrawPointMode extends GeoJsonEditMode {

--- a/modules/editable-layers/src/edit-modes/draw-polygon-by-dragging-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-polygon-by-dragging-mode.ts
@@ -4,7 +4,8 @@
 
 import throttle from 'lodash.throttle';
 import {ClickEvent, StartDraggingEvent, StopDraggingEvent, DraggingEvent, ModeProps} from './types';
-import {Polygon, SimpleFeatureCollection} from '../utils/geojson-types';
+import {Polygon} from 'geojson'
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {getPickedEditHandle} from './utils';
 import {DrawPolygonMode} from './draw-polygon-mode';
 

--- a/modules/editable-layers/src/edit-modes/draw-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-polygon-mode.ts
@@ -16,7 +16,8 @@ import {
   GuideFeature,
   DoubleClickEvent
 } from './types';
-import {Position, FeatureCollection, SimpleFeatureCollection} from '../utils/geojson-types';
+import {Position, FeatureCollection} from 'geojson';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {getPickedEditHandle} from './utils';
 import {GeoJsonEditMode} from './geojson-edit-mode';
 import { ImmutableFeatureCollection } from './immutable-feature-collection';

--- a/modules/editable-layers/src/edit-modes/draw-rectangle-from-center-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-rectangle-from-center-mode.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import bboxPolygon from '@turf/bbox-polygon';
-import {Position, Polygon, Feature} from '../utils/geojson-types';
+import {Position, Polygon, Feature} from 'geojson';
 import {TwoClickPolygonMode} from './two-click-polygon-mode';
 
 export class DrawRectangleFromCenterMode extends TwoClickPolygonMode {

--- a/modules/editable-layers/src/edit-modes/draw-rectangle-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-rectangle-mode.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import bboxPolygon from '@turf/bbox-polygon';
-import {Position, Polygon, Feature} from '../utils/geojson-types';
+import {Position, Polygon, Feature} from 'geojson';
 import {TwoClickPolygonMode} from './two-click-polygon-mode';
 
 export class DrawRectangleMode extends TwoClickPolygonMode {

--- a/modules/editable-layers/src/edit-modes/draw-rectangle-using-three-points-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-rectangle-using-three-points-mode.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {generatePointsParallelToLinePoints} from './utils';
-import {Position, Polygon, Feature} from '../utils/geojson-types';
+import {Position, Polygon, Feature} from 'geojson';
 import {ThreeClickPolygonMode} from './three-click-polygon-mode';
 
 export class DrawRectangleUsingThreePointsMode extends ThreeClickPolygonMode {

--- a/modules/editable-layers/src/edit-modes/draw-square-from-center-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-square-from-center-mode.ts
@@ -6,7 +6,7 @@ import bboxPolygon from '@turf/bbox-polygon';
 import turfDistance from '@turf/distance';
 import turfAlong from '@turf/along';
 import {point, lineString as turfLineString} from '@turf/helpers';
-import {Position, Polygon, Feature} from '../utils/geojson-types';
+import {Position, Polygon, Feature} from 'geojson';
 import {TwoClickPolygonMode} from './two-click-polygon-mode';
 
 export class DrawSquareFromCenterMode extends TwoClickPolygonMode {

--- a/modules/editable-layers/src/edit-modes/draw-square-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-square-mode.ts
@@ -6,7 +6,7 @@ import bboxPolygon from '@turf/bbox-polygon';
 import turfDistance from '@turf/distance';
 import turfAlong from '@turf/along';
 import {point, lineString as turfLineString} from '@turf/helpers';
-import {Position, Polygon, Feature} from '../utils/geojson-types';
+import {Position, Polygon, Feature} from 'geojson';
 import {TwoClickPolygonMode} from './two-click-polygon-mode';
 
 export class DrawSquareMode extends TwoClickPolygonMode {

--- a/modules/editable-layers/src/edit-modes/duplicate-mode.ts
+++ b/modules/editable-layers/src/edit-modes/duplicate-mode.ts
@@ -3,7 +3,8 @@
 // Copyright (c) vis.gl contributors
 
 import {StartDraggingEvent, ModeProps} from './types';
-import {FeatureCollection, SimpleFeatureCollection} from '../utils/geojson-types';
+import {FeatureCollection} from 'geojson';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {TranslateMode} from './translate-mode';
 
 export class DuplicateMode extends TranslateMode {

--- a/modules/editable-layers/src/edit-modes/elevation-mode.ts
+++ b/modules/editable-layers/src/edit-modes/elevation-mode.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {ModeProps, PointerMoveEvent, StopDraggingEvent} from './types';
-import {Position, FeatureCollection} from '../utils/geojson-types';
+import {Position, FeatureCollection} from 'geojson';
 import {getPickedEditHandle} from './utils';
 import {ModifyMode} from './modify-mode';
 

--- a/modules/editable-layers/src/edit-modes/extend-line-string-mode.ts
+++ b/modules/editable-layers/src/edit-modes/extend-line-string-mode.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Position, LineString, FeatureCollection, SimpleFeatureCollection} from '../utils/geojson-types';
+import {Position, LineString, FeatureCollection} from 'geojson';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {ClickEvent, PointerMoveEvent, ModeProps, GuideFeatureCollection} from './types';
 import {GeoJsonEditMode} from './geojson-edit-mode';
 import {ImmutableFeatureCollection} from './immutable-feature-collection';

--- a/modules/editable-layers/src/edit-modes/geojson-edit-mode.ts
+++ b/modules/editable-layers/src/edit-modes/geojson-edit-mode.ts
@@ -21,7 +21,8 @@ import {
   GuideFeatureCollection,
   TentativeFeature
 } from './types';
-import {FeatureCollection, Feature, Polygon, SimpleGeometry, Position, SimpleFeatureCollection, SimpleFeature} from '../utils/geojson-types';
+import {SimpleGeometry, SimpleFeatureCollection, SimpleFeature} from '../utils/geojson-types';
+import {FeatureCollection, Feature, Polygon, Position} from 'geojson';
 import {getPickedEditHandles, getNonGuidePicks} from './utils';
 import {EditMode} from './edit-mode';
 import {ImmutableFeatureCollection} from './immutable-feature-collection';

--- a/modules/editable-layers/src/edit-modes/immutable-feature-collection.ts
+++ b/modules/editable-layers/src/edit-modes/immutable-feature-collection.ts
@@ -2,16 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {
-  SimpleFeatureCollection,
-  SimpleGeometry,
-  Polygon,
-  MultiLineString,
-  MultiPolygon,
-  Position,
-  SimpleFeature,
-} from '../utils/geojson-types';
-
+import {SimpleFeatureCollection, SimpleGeometry, SimpleFeature} from '../utils/geojson-types';
+import {Polygon, MultiLineString, MultiPolygon, Position} from 'geojson';
 export class ImmutableFeatureCollection {
   featureCollection: Readonly<SimpleFeatureCollection>;
 

--- a/modules/editable-layers/src/edit-modes/measure-angle-mode.ts
+++ b/modules/editable-layers/src/edit-modes/measure-angle-mode.ts
@@ -3,7 +3,7 @@ import turfCenter from '@turf/center';
 import {memoize} from '../utils/memoize';
 
 import {ClickEvent, PointerMoveEvent, Tooltip, ModeProps, GuideFeatureCollection} from './types';
-import {FeatureCollection, Position} from '../utils/geojson-types';
+import {FeatureCollection, Position} from 'geojson';
 import {GeoJsonEditMode} from './geojson-edit-mode';
 
 const DEFAULT_TOOLTIPS: Tooltip[] = [];

--- a/modules/editable-layers/src/edit-modes/measure-area-mode.ts
+++ b/modules/editable-layers/src/edit-modes/measure-area-mode.ts
@@ -5,7 +5,8 @@
 import turfArea from '@turf/area';
 import turfCentroid from '@turf/centroid';
 import {ClickEvent, Tooltip, ModeProps} from './types';
-import {FeatureCollection, SimpleFeatureCollection} from '../utils/geojson-types';
+import {FeatureCollection} from 'geojson';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {DrawPolygonMode} from './draw-polygon-mode';
 
 const DEFAULT_TOOLTIPS = [];

--- a/modules/editable-layers/src/edit-modes/measure-distance-mode.ts
+++ b/modules/editable-layers/src/edit-modes/measure-distance-mode.ts
@@ -4,7 +4,7 @@
 
 import turfDistance from '@turf/distance';
 import turfMidpoint from '@turf/midpoint';
-import {FeatureCollection} from '../utils/geojson-types';
+import {FeatureCollection} from 'geojson';
 import {
   ClickEvent,
   PointerMoveEvent,

--- a/modules/editable-layers/src/edit-modes/modify-mode.ts
+++ b/modules/editable-layers/src/edit-modes/modify-mode.ts
@@ -16,7 +16,8 @@ import {
   NearestPointType,
   shouldCancelPan
 } from './utils';
-import {LineString, Point, Polygon, FeatureCollection, Feature, SimpleFeatureCollection} from '../utils/geojson-types';
+import {LineString, Point, Polygon, FeatureCollection, Feature} from 'geojson';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {
   ModeProps,
   ClickEvent,

--- a/modules/editable-layers/src/edit-modes/resize-circle-mode.ts
+++ b/modules/editable-layers/src/edit-modes/resize-circle-mode.ts
@@ -14,7 +14,8 @@ import {
   getPickedEditHandle,
   NearestPointType
 } from './utils';
-import {LineString, Point, FeatureCollection, Feature, SimpleFeatureCollection} from '../utils/geojson-types';
+import {LineString, Point, FeatureCollection, Feature} from 'geojson';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {Viewport} from '../utils/types';
 import {
   ModeProps,

--- a/modules/editable-layers/src/edit-modes/rotate-mode.ts
+++ b/modules/editable-layers/src/edit-modes/rotate-mode.ts
@@ -22,7 +22,8 @@ import {
   GuideFeatureCollection
 } from './types';
 import {getPickedEditHandle} from './utils';
-import {FeatureCollection, Position, SimpleFeatureCollection} from '../utils/geojson-types';
+import {FeatureCollection, Position} from 'geojson';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {GeoJsonEditMode, GeoJsonEditAction, getIntermediatePosition} from './geojson-edit-mode';
 import {ImmutableFeatureCollection} from './immutable-feature-collection';
 

--- a/modules/editable-layers/src/edit-modes/scale-mode.ts
+++ b/modules/editable-layers/src/edit-modes/scale-mode.ts
@@ -12,7 +12,8 @@ import {coordEach} from '@turf/meta';
 import turfDistance from '@turf/distance';
 import turfTransformScale from '@turf/transform-scale';
 import {getCoord, getGeom} from '@turf/invariant';
-import {FeatureCollection, Position, SimpleFeatureCollection} from '../utils/geojson-types';
+import {FeatureCollection, Position} from 'geojson';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {
   ModeProps,
   PointerMoveEvent,

--- a/modules/editable-layers/src/edit-modes/snappable-mode.ts
+++ b/modules/editable-layers/src/edit-modes/snappable-mode.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Position, FeatureCollection, SimpleFeatureCollection, SimpleFeature} from '../utils/geojson-types';
+import {Position, FeatureCollection} from 'geojson';
+import {SimpleFeatureCollection, SimpleFeature} from '../utils/geojson-types';
 import {
   PointerMoveEvent,
   StartDraggingEvent,

--- a/modules/editable-layers/src/edit-modes/split-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/split-polygon-mode.ts
@@ -14,7 +14,8 @@ import turfDestination from '@turf/destination';
 import turfPolygonToLine from '@turf/polygon-to-line';
 import nearestPointOnLine from '@turf/nearest-point-on-line';
 import {generatePointsParallelToLinePoints} from './utils';
-import {FeatureCollection, PolygonGeometry, SimpleFeatureCollection} from '../utils/geojson-types';
+import {FeatureCollection} from 'geojson';
+import {PolygonGeometry, SimpleFeatureCollection} from '../utils/geojson-types';
 import {
   ClickEvent,
   PointerMoveEvent,

--- a/modules/editable-layers/src/edit-modes/three-click-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/three-click-polygon-mode.ts
@@ -9,7 +9,8 @@ import {
   GuideFeatureCollection,
   TentativeFeature
 } from './types';
-import {Position, Polygon, Feature, FeatureCollection, SimpleFeatureCollection} from '../utils/geojson-types';
+import {Position, Polygon, Feature, FeatureCollection} from 'geojson';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {GeoJsonEditMode} from './geojson-edit-mode';
 import omit from 'lodash.omit';
 

--- a/modules/editable-layers/src/edit-modes/transform-mode.ts
+++ b/modules/editable-layers/src/edit-modes/transform-mode.ts
@@ -4,7 +4,7 @@
 
 import {featureCollection} from '@turf/helpers';
 import {PointerMoveEvent, ModeProps, StartDraggingEvent} from './types';
-import {FeatureCollection} from '../utils/geojson-types';
+import {FeatureCollection} from 'geojson';
 import {TranslateMode} from './translate-mode';
 import {ScaleMode} from './scale-mode';
 import {RotateMode} from './rotate-mode';

--- a/modules/editable-layers/src/edit-modes/translate-mode.ts
+++ b/modules/editable-layers/src/edit-modes/translate-mode.ts
@@ -7,7 +7,8 @@ import turfDistance from '@turf/distance';
 import clone from '@turf/clone';
 import {point} from '@turf/helpers';
 import {WebMercatorViewport} from 'viewport-mercator-project';
-import {FeatureCollection, Position, SimpleGeometry, SimpleFeatureCollection} from '../utils/geojson-types';
+import {FeatureCollection, Position} from 'geojson';
+import {SimpleGeometry, SimpleFeatureCollection} from '../utils/geojson-types';
 import {
   PointerMoveEvent,
   StartDraggingEvent,

--- a/modules/editable-layers/src/edit-modes/two-click-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/two-click-polygon-mode.ts
@@ -11,7 +11,8 @@ import {
   GuideFeatureCollection,
   TentativeFeature
 } from './types';
-import {Polygon, FeatureCollection, Feature, Position, SimpleFeatureCollection} from '../utils/geojson-types';
+import {Polygon, FeatureCollection, Feature, Position} from 'geojson';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {GeoJsonEditMode} from './geojson-edit-mode';
 import omit from 'lodash.omit';
 

--- a/modules/editable-layers/src/edit-modes/types.ts
+++ b/modules/editable-layers/src/edit-modes/types.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Position, Point, SimpleGeometry, Feature} from '../utils/geojson-types';
+import {Position, Point, Feature} from 'geojson';
+import {SimpleGeometry} from '../utils/geojson-types';
 
 export type ScreenCoordinates = [number, number];
 

--- a/modules/editable-layers/src/edit-modes/utils.ts
+++ b/modules/editable-layers/src/edit-modes/utils.ts
@@ -12,15 +12,8 @@ import {point} from '@turf/helpers';
 import {getCoords} from '@turf/invariant';
 import {WebMercatorViewport} from 'viewport-mercator-project';
 import {Viewport, Pick, EditHandleFeature, EditHandleType, StartDraggingEvent} from './types';
-import {
-  SimpleGeometry,
-  Position,
-  Point,
-  LineString,
-  Polygon,
-  Feature,
-  SimpleGeometryCoordinates
-} from '../utils/geojson-types';
+import {SimpleGeometry, SimpleGeometryCoordinates} from '../utils/geojson-types';
+import {Position, Point, LineString, Polygon, Feature} from 'geojson';
 
 export type NearestPointType = Feature<Point, {dist: number; index: number}>;
 

--- a/modules/editable-layers/src/editable-layers/editable-geojson-layer.ts
+++ b/modules/editable-layers/src/editable-layers/editable-geojson-layer.ts
@@ -50,7 +50,7 @@ import {PROJECTED_PIXEL_SIZE_MULTIPLIER} from '../constants';
 
 import {EditableLayer, EditableLayerProps} from './editable-layer';
 import {EditablePathLayer} from './editable-path-layer';
-import {Feature, FeatureCollection} from '../utils/geojson-types';
+import {Feature, FeatureCollection} from 'geojson';
 
 const DEFAULT_LINE_COLOR: Color = [0x0, 0x0, 0x0, 0x99];
 const DEFAULT_FILL_COLOR: Color = [0x0, 0x0, 0x0, 0x90];

--- a/modules/editable-layers/src/editable-layers/editable-layer.ts
+++ b/modules/editable-layers/src/editable-layers/editable-layer.ts
@@ -14,7 +14,7 @@ import {
   PointerMoveEvent,
   DoubleClickEvent
 } from '../edit-modes/types';
-import {Position} from '../utils/geojson-types';
+import {Position} from 'geojson';
 
 const EVENT_TYPES = ['click', 'pointermove', 'panstart', 'panmove', 'panend', 'keyup', 'dblclick'];
 

--- a/modules/editable-layers/src/index.ts
+++ b/modules/editable-layers/src/index.ts
@@ -96,20 +96,11 @@ export type {
 } from './edit-modes/types';
 
 export type {
-  Position,
   SimpleFeature,
   SimpleFeatureCollection,
   SimpleGeometry,
   SimpleGeometryCoordinates,
-  Point,
-  LineString,
-  Polygon,
-  MultiPoint,
-  MultiLineString,
-  MultiPolygon,
   PolygonGeometry,
-  Feature,
-  FeatureCollection,
   AnyGeoJson
 } from './utils/geojson-types';
 

--- a/modules/editable-layers/src/mode-handlers/composite-mode-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/composite-mode-handler.ts
@@ -1,4 +1,5 @@
-import {SimpleFeature, SimpleFeatureCollection, Position} from '../utils/geojson-types';
+import {SimpleFeature, SimpleFeatureCollection} from '../utils/geojson-types';
+import {Position} from 'geojson';
 import {
   ClickEvent,
   PointerMoveEvent,

--- a/modules/editable-layers/src/mode-handlers/draw-90degree-polygon-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/draw-90degree-polygon-handler.ts
@@ -7,7 +7,7 @@ import bearing from '@turf/bearing';
 import lineIntersect from '@turf/line-intersect';
 import turfDistance from '@turf/distance';
 import {point, lineString} from '@turf/helpers';
-import {Polygon, Position} from '../utils/geojson-types';
+import {Polygon, Position} from 'geojson';
 import {generatePointsParallelToLinePoints} from '../utils/utils';
 import {ClickEvent, PointerMoveEvent} from '../edit-modes/types';
 import {

--- a/modules/editable-layers/src/mode-handlers/draw-line-string-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/draw-line-string-handler.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Position, LineString} from '../utils/geojson-types';
+import {Position, LineString} from 'geojson';
 import {ClickEvent, PointerMoveEvent} from '../edit-modes/types';
 import {EditAction, ModeHandler} from './mode-handler';
 

--- a/modules/editable-layers/src/mode-handlers/draw-polygon-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/draw-polygon-handler.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Polygon, Position} from '../utils/geojson-types';
+import {Polygon, Position} from 'geojson';
 import {ClickEvent, PointerMoveEvent} from '../edit-modes/types';
 import {
   EditAction,

--- a/modules/editable-layers/src/mode-handlers/draw-rectangle-using-three-points-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/draw-rectangle-using-three-points-handler.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {LineString} from '../utils/geojson-types';
+import {LineString} from 'geojson';
 import {generatePointsParallelToLinePoints} from '../utils/utils';
 import {PointerMoveEvent} from '../edit-modes/types';
 import {EditAction} from './mode-handler';

--- a/modules/editable-layers/src/mode-handlers/elevation-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/elevation-handler.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Position} from '../utils/geojson-types';
+import {Position} from 'geojson';
 import {PointerMoveEvent, StopDraggingEvent} from '../edit-modes/types';
 import {EditAction, getPickedEditHandle} from './mode-handler';
 

--- a/modules/editable-layers/src/mode-handlers/mode-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/mode-handler.ts
@@ -9,7 +9,8 @@ import turfUnion from '@turf/union';
 import turfDifference from '@turf/difference';
 import turfIntersect from '@turf/intersect';
 
-import {FeatureCollection, Feature, Polygon, SimpleGeometry, Position, PolygonGeometry, SimpleFeatureCollection, SimpleFeature} from '../utils/geojson-types';
+import {SimpleGeometry, SimpleFeatureCollection, SimpleFeature, PolygonGeometry} from '../utils/geojson-types';
+import {FeatureCollection, Feature, Polygon, Position} from 'geojson';
 
 import {
   ClickEvent,

--- a/modules/editable-layers/src/mode-handlers/modify-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/modify-handler.ts
@@ -4,7 +4,7 @@
 
 import nearestPointOnLine from '@turf/nearest-point-on-line';
 import {point, lineString as toLineString} from '@turf/helpers';
-import {Position, Feature, Point, LineString} from '../utils/geojson-types';
+import {Position, Feature, Point, LineString} from 'geojson';
 import {
   recursivelyTraverseNestedArrays,
   nearestPointOnProjectedLine,

--- a/modules/editable-layers/src/mode-handlers/rotate-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/rotate-handler.ts
@@ -5,7 +5,8 @@
 import turfCentroid from '@turf/centroid';
 import turfBearing from '@turf/bearing';
 import turfTransformRotate from '@turf/transform-rotate';
-import {SimpleFeatureCollection, Position} from '../utils/geojson-types';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
+import {Position} from 'geojson';
 import {PointerMoveEvent, StartDraggingEvent, StopDraggingEvent} from '../edit-modes/types';
 import {EditAction, ModeHandler} from './mode-handler';
 

--- a/modules/editable-layers/src/mode-handlers/scale-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/scale-handler.ts
@@ -5,7 +5,8 @@
 import turfCentroid from '@turf/centroid';
 import turfDistance from '@turf/distance';
 import turfTransformScale from '@turf/transform-scale';
-import {SimpleFeatureCollection, Position, SimpleGeometry} from '../utils/geojson-types';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
+import {Position} from 'geojson';
 import {PointerMoveEvent, StartDraggingEvent, StopDraggingEvent} from '../edit-modes/types';
 import {EditAction, ModeHandler} from './mode-handler';
 

--- a/modules/editable-layers/src/mode-handlers/snappable-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/snappable-handler.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {SimpleFeature, SimpleFeatureCollection, Position} from '../utils/geojson-types';
+import {SimpleFeature, SimpleFeatureCollection} from '../utils/geojson-types';
+import {Position} from 'geojson';
 import {PointerMoveEvent, StartDraggingEvent, StopDraggingEvent} from '../edit-modes/types';
 import {
   EditHandle,

--- a/modules/editable-layers/src/mode-handlers/translate-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/translate-handler.ts
@@ -6,7 +6,8 @@ import turfBearing from '@turf/bearing';
 import turfDistance from '@turf/distance';
 import turfTransformTranslate from '@turf/transform-translate';
 import {point} from '@turf/helpers';
-import {SimpleFeatureCollection, Position} from '../utils/geojson-types';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
+import {Position} from 'geojson';
 import {PointerMoveEvent, StartDraggingEvent, StopDraggingEvent} from '../edit-modes/types';
 import {EditAction, ModeHandler} from './mode-handler';
 

--- a/modules/editable-layers/src/mode-handlers/view-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/view-handler.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Position} from '../utils/geojson-types';
+import {Position} from 'geojson';
 import {EditHandle, ModeHandler} from './mode-handler';
 
 // TODO edit-modes: delete handlers once EditMode fully implemented

--- a/modules/editable-layers/src/utils/geojson-types.ts
+++ b/modules/editable-layers/src/utils/geojson-types.ts
@@ -9,12 +9,9 @@ import type {
   MultiPoint,
   MultiLineString,
   MultiPolygon,
-  Position,
   Feature,
   FeatureCollection,
 } from 'geojson';
-
-export { Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, Position, Feature, FeatureCollection };
 
 /** Simple geometries (excludes GeometryCollection) */
 export type SimpleGeometry = Point | LineString | Polygon | MultiPoint | MultiLineString | MultiPolygon;

--- a/modules/editable-layers/src/utils/utils.ts
+++ b/modules/editable-layers/src/utils/utils.ts
@@ -7,7 +7,7 @@ import bearing from '@turf/bearing';
 import pointToLineDistance from '@turf/point-to-line-distance';
 import {point} from '@turf/helpers';
 import {WebMercatorViewport} from 'viewport-mercator-project';
-import {Feature, LineString, Point, Position} from './geojson-types';
+import {Feature, LineString, Point, Position} from 'geojson';
 import {Viewport} from './types';
 
 // TODO edit-modes: delete and use edit-modes/utils instead


### PR DESCRIPTION
Cleans up imports of geojson types, so all files import from `geojson` directly.

Removes export of standard geojson types from the library.  This _will_ require anyone doing an `import { FeatureCollection, ... } from '@deck.gl-community/editable-layers'` to follow suit.