### PR TITLE
Add scaffolding for graph-loaders module

### DIFF
--- a/docs/modules/graph-loaders/README.md
+++ b/docs/modules/graph-loaders/README.md
@@ -1,0 +1,28 @@
+# Overview
+
+Graph loaders provide shared utilities for reading graph data into the formats expected by deck.gl community packages such as `@deck.gl-community/graph-layers`.
+
+:::danger
+The deck.gl-community repo is specifically set up to collect useful code that no longer has dedicated maintainers. This means that there is often no one who can respond quickly to issues. The vis.gl / Open Visualization team members who try to keep this running can only put a few hours into it every now and then. It is important to understand this limitation. If your project depends on timely fixes, and you are not able to contribute them yourself, deck.gl-community modules may not be the right choice for you.
+:::
+
+## Installation
+
+```bash
+npm install @deck.gl-community/graph-loaders
+```
+
+## Getting started
+
+This module currently ships a small set of types and helpers that normalize loader output into a consistent shape. Future loader implementations (for formats like DOT or JSON) will be built on top of these primitives.
+
+```ts
+import {normalizeGraphData} from '@deck.gl-community/graph-loaders';
+
+const graph = normalizeGraphData({
+  nodes: [{id: 'n1', label: 'Origin'}],
+  edges: [{source: 'n1', target: 'n2'}]
+});
+```
+
+`normalizeGraphData` returns a `GraphLoaderResult` that always includes node and edge arrays, making it easier to plug into visualization layers.

--- a/docs/modules/graph-loaders/sidebar.json
+++ b/docs/modules/graph-loaders/sidebar.json
@@ -1,0 +1,7 @@
+{
+  "type": "category",
+  "label": "@deck.gl-community/graph-loaders",
+  "items": [
+    "modules/graph-loaders/README"
+  ]
+}

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -31,7 +31,11 @@ A new module containing unofficial / experimental widgets for deck.gl, initially
 - `ZoomRangeWidget` - NEW deck.gl `Widget` providing a zoom slider.
 - `PanWidget` - NEW deck.gl `Widget` providing buttons for panning the view.
 
-### `@deck.gl-community/graph-layers` 
+### `@deck.gl-community/graph-loaders` (NEW module)
+
+A scaffold for shared graph loader utilities and typings that will underpin upcoming DOT and JSON graph loaders. The helpers exposed in this release normalize nodes and edges into a consistent `GraphLoaderResult` structure that can be reused by `@deck.gl-community/graph-layers` and other visualization packages.
+
+### `@deck.gl-community/graph-layers`
 
 - [`GraphLayer`](/docs/modules/graph-layers/api-reference/layers/graph-layer)
   - `GraphLayerProps.data` - `GraphLayer` now accepts `GraphEngine`, `Graph`, or raw JSON via the new `data` prop (including async URLs).

--- a/modules/graph-loaders/LICENSE
+++ b/modules/graph-loaders/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2015 - 2021 Uber Technologies, Inc.
+Copyright (c) 2022 - 2025 vis.gl contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/modules/graph-loaders/README.md
+++ b/modules/graph-loaders/README.md
@@ -1,0 +1,30 @@
+# @deck.gl-community/graph-loaders
+
+Graph data loaders and normalization utilities for [deck.gl](https://deck.gl).
+
+:::danger
+The deck.gl-community repo is specifically set up to collect useful code that no longer has dedicated maintainers. This means that there is often no one who can respond quickly to issues. The vis.gl / Open Visualization team members who try to keep this running can only put a few hours into it every now and then. It is important to understand this limitation. If your project depends on timely fixes, and you are not able to contribute them yourself, deck.gl-community modules may not be the right choice for you.
+:::
+
+## Installation
+
+```bash
+npm install @deck.gl-community/graph-loaders
+```
+
+## Usage
+
+The initial release exposes a minimal set of types and helpers that are shared across graph loader implementations.
+
+```ts
+import {normalizeGraphData} from '@deck.gl-community/graph-loaders';
+
+const graph = normalizeGraphData({
+  nodes: [{id: 'a', label: 'Start'}],
+  edges: [{source: 'a', target: 'b', relationship: 'leads-to'}]
+});
+```
+
+## Status
+
+This package is a scaffold for upcoming graph loader implementations (for example, DOT and JSON-based loaders). The shared helpers live here so that future loaders can publish a consistent `GraphLoaderResult` without relying on graph-layer internals.

--- a/modules/graph-loaders/package.json
+++ b/modules/graph-loaders/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@deck.gl-community/graph-loaders",
+  "version": "9.2.0-beta.3",
+  "description": "Graph data loaders and normalization utilities for deck.gl.",
+  "license": "MIT",
+  "keywords": [
+    "graph",
+    "loaders",
+    "visualization",
+    "deck.gl"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -b tsconfig.json",
+    "test": "vitest run",
+    "test-watch": "vitest"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/modules/graph-loaders/src/index.ts
+++ b/modules/graph-loaders/src/index.ts
@@ -1,0 +1,56 @@
+/**
+ * Minimal graph data primitives shared by graph loader implementations.
+ */
+export type GraphNode = {
+  /** Unique identifier for the node. */
+  id: string;
+  /** Optional metadata attached to the node. */
+  [key: string]: unknown;
+};
+
+export type GraphEdge = {
+  /** Identifier for the source node. */
+  source: string;
+  /** Identifier for the target node. */
+  target: string;
+  /** Optional metadata attached to the edge. */
+  [key: string]: unknown;
+};
+
+export type GraphData = {
+  /** List of nodes referenced by the graph. */
+  nodes: GraphNode[];
+  /** List of edges connecting nodes. */
+  edges: GraphEdge[];
+};
+
+export type GraphLoaderResult = GraphData & {
+  /** Optional loader-specific metadata for downstream visualization components. */
+  metadata?: Record<string, unknown>;
+};
+
+/**
+ * Create a normalized, empty graph payload.
+ */
+export function createEmptyGraph(metadata: Record<string, unknown> = {}): GraphLoaderResult {
+  return {
+    nodes: [],
+    edges: [],
+    metadata
+  };
+}
+
+/**
+ * Normalize partially specified graph data into the canonical `GraphLoaderResult` shape.
+ */
+export function normalizeGraphData(input?: Partial<GraphData> | null): GraphLoaderResult {
+  if (!input) {
+    return createEmptyGraph();
+  }
+
+  const {nodes = [], edges = []} = input;
+  return {
+    nodes: [...nodes],
+    edges: [...edges]
+  };
+}

--- a/modules/graph-loaders/tsconfig.json
+++ b/modules/graph-loaders/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "noEmit": false
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,7 @@
       "@deck.gl-community/infovis-layers": ["./modules/infovis-layers/src"],
       "@deck.gl-community/react": ["./modules/react/src"],
       "@deck.gl-community/template": ["./modules/template/src"],
+      "@deck.gl-community/graph-loaders": ["./modules/graph-loaders/src"],
       "@deck.gl-community/graph-layers": ["./modules/graph-layers/src"]
     },
     "typeRoots": ["./node_modules/@types"],

--- a/website/src/docs-sidebar.js
+++ b/website/src/docs-sidebar.js
@@ -13,6 +13,7 @@ const layerDocs = require('../../docs/modules/layers/sidebar.json');
 
 const infovisLayerDocs = require('../../docs/modules/infovis-layers/sidebar.json');
 const graphLayerDocs = require('../../docs/modules/graph-layers/sidebar.json');
+const graphLoaderDocs = require('../../docs/modules/graph-loaders/sidebar.json');
 const editableLayerDocs = require('../../docs/modules/editable-layers/sidebar.json');
 // const arrowLayerDocs = require('../../docs/modules/arrow-layers/sidebar.json');
 
@@ -50,6 +51,7 @@ const sidebars = {
         layerDocs,
         infovisLayerDocs,
         graphLayerDocs,
+        graphLoaderDocs,
         geoLayerDocs,
         editableLayerDocs,
         // arrowLayerDocs,


### PR DESCRIPTION
## Summary
- add the @deck.gl-community/graph-loaders package with shared graph data typings and helpers
- document the new module and surface it in the docs sidebar/navigation
- update path mappings and release notes to recognize the new package

## Testing
- yarn lint *(fails: existing lint errors in other modules)*
- yarn --cwd website write-heading-ids *(fails: ts-node/ESM loader issue with scripts/write-heading-ids.ts)*
- git commit *(hooks ran vitest suite across modules)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_691f4cf60c44832cbd463a2ff6906af4)