### PR TITLE
chore: add code style section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,22 @@ This file applies to the entire `deck.gl-community` repository. Directories may 
 - Follow the contribution flow in `docs/CONTRIBUTING.md` before landing breaking changes.
 - When adding or removing packages or examples, update any related documentation, sidebars, or release notes under `docs/`.
 
+## Code style
+
+Formatting is enforced by Prettier and ESLint via `ocular-lint`.
+
+**Prettier rules** (`.prettierrc`):
+- Print width: 100
+- Semicolons: yes
+- Single quotes: yes
+- Trailing commas: none
+- Bracket spacing: no (`{a}` not `{ a }`)
+
+**Guidelines:**
+- Run `yarn lint-fix` before committing
+- Do NOT reformat files you are not otherwise changing
+- Keep formatting changes in separate commits from logic changes
+
 ## Naming conventions
 
 - Typescript functions use verb-noun, in camelCase.


### PR DESCRIPTION
## Summary

Add Prettier configuration details and formatting guidelines to the root AGENTS.md so contributors and AI agents know the repo style conventions.

Split out from #486 per review feedback - ibgreen preferred using the AGENTS.md standard over a separate CLAUDE.md file.

## Changes

Adds a **Code style** section to `AGENTS.md` with:
- Prettier rule summary (print width, quotes, semicolons, etc.)
- Guidelines: run lint-fix before committing, don't reformat unrelated files, keep formatting separate from logic commits