### PR TITLE
chore(deps): bump @vis.gl/dev-tools to stable 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@luma.gl/webgl": "~9.2.0",
     "@testing-library/react": "^14.3.0",
     "@types/bin-pack": "^1.0.3",
-    "@vis.gl/dev-tools": "1.0.0-alpha.21",
+    "@vis.gl/dev-tools": "^1.0.1",
     "@vis.gl/ts-plugins": "^1.0.0",
     "@vitejs/plugin-react": "5.1.0",
     "@vitest/browser": "4.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4168,9 +4168,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vis.gl/dev-tools@npm:1.0.0-alpha.21":
-  version: 1.0.0-alpha.21
-  resolution: "@vis.gl/dev-tools@npm:1.0.0-alpha.21"
+"@vis.gl/dev-tools@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@vis.gl/dev-tools@npm:1.0.1"
   dependencies:
     "@esbuild-plugins/node-globals-polyfill": "npm:^0.2.0"
     "@esbuild-plugins/node-modules-polyfill": "npm:^0.2.0"
@@ -4211,7 +4211,7 @@ __metadata:
     ocular-metrics: scripts/metrics.js
     ocular-publish: scripts/publish.js
     ocular-test: scripts/test.js
-  checksum: 10c0/12c8f5ac372a2256031740dabac9026cae41ecd291a53ec062cba9fb75fce12602e8c904540bb7a90b155228a0bd8de69a1f03c0ffa8f5d2b9f95df261bf56d3
+  checksum: 10c0/c1d63c38e3a7de574586c19669e8f8b155387beff56843604750fa1d2daa162ed5206f196c91d4c24c05833da20ed2ed55964606a7c4bb0f451a622184800d46
   languageName: node
   linkType: hard
 
@@ -6239,7 +6239,7 @@ __metadata:
     "@luma.gl/webgl": "npm:~9.2.0"
     "@testing-library/react": "npm:^14.3.0"
     "@types/bin-pack": "npm:^1.0.3"
-    "@vis.gl/dev-tools": "npm:1.0.0-alpha.21"
+    "@vis.gl/dev-tools": "npm:^1.0.1"
     "@vis.gl/ts-plugins": "npm:^1.0.0"
     "@vitejs/plugin-react": "npm:5.1.0"
     "@vitest/browser": "npm:4.0.5"


### PR DESCRIPTION
## Summary
- Bumps @vis.gl/dev-tools from 1.0.0-alpha.21 to ^1.0.1 (stable release)

Note: The transitive vulnerabilities from dev-tools own dependencies (lerna -> axios/tar, coveralls -> request -> form-data/qs, tap-spec -> trim, esbuild) remain unchanged between these versions. Those must be addressed upstream in @vis.gl/dev-tools.

## Test plan
- [x] yarn install resolves cleanly
- [x] yarn test-node -- all 50 test files pass (248 tests)
- [x] yarn build completes successfully