### PR TITLE
chore(deps): replace deprecated viewport-mercator-project with @math.gl/web-mercator

### DIFF
--- a/modules/editable-layers/package.json
+++ b/modules/editable-layers/package.json
@@ -36,6 +36,7 @@
     "src"
   ],
   "dependencies": {
+    "@math.gl/web-mercator": ">=4.0.1",
     "@turf/along": "^7.2.0",
     "@turf/area": "^7.2.0",
     "@turf/bbox": "^7.2.0",
@@ -72,8 +73,7 @@
     "lodash.omit": "^4.1.1",
     "lodash.throttle": "^4.1.1",
     "preact": "^10.17.0",
-    "uuid": "9.0.0",
-    "viewport-mercator-project": ">=6.2.3"
+    "uuid": "9.0.0"
   },
   "peerDependencies": {
     "@deck.gl-community/layers": "^9.2.0-beta",

--- a/modules/editable-layers/src/edit-modes/translate-mode.ts
+++ b/modules/editable-layers/src/edit-modes/translate-mode.ts
@@ -6,7 +6,7 @@ import turfBearing from '@turf/bearing';
 import turfDistance from '@turf/distance';
 import clone from '@turf/clone';
 import {point} from '@turf/helpers';
-import {WebMercatorViewport} from 'viewport-mercator-project';
+import {WebMercatorViewport} from '@math.gl/web-mercator';
 import {
   FeatureCollection,
   Position,

--- a/modules/editable-layers/src/edit-modes/utils.ts
+++ b/modules/editable-layers/src/edit-modes/utils.ts
@@ -10,7 +10,7 @@ import pointToLineDistance from '@turf/point-to-line-distance';
 import {flattenEach} from '@turf/meta';
 import {point} from '@turf/helpers';
 import {getCoords} from '@turf/invariant';
-import {WebMercatorViewport} from 'viewport-mercator-project';
+import {WebMercatorViewport} from '@math.gl/web-mercator';
 import {Viewport, Pick, EditHandleFeature, EditHandleType, StartDraggingEvent} from './types';
 import {
   SimpleGeometry,

--- a/modules/editable-layers/src/utils/utils.ts
+++ b/modules/editable-layers/src/utils/utils.ts
@@ -6,7 +6,7 @@ import destination from '@turf/destination';
 import bearing from '@turf/bearing';
 import pointToLineDistance from '@turf/point-to-line-distance';
 import {point} from '@turf/helpers';
-import {WebMercatorViewport} from 'viewport-mercator-project';
+import {WebMercatorViewport} from '@math.gl/web-mercator';
 import {Feature, LineString, Point, Position} from './geojson-types';
 import {Viewport} from './types';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -195,7 +195,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.5":
+"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.5":
   version: 7.28.4
   resolution: "@babel/runtime@npm:7.28.4"
   checksum: 10c0/792ce7af9750fb9b93879cc9d1db175701c4689da890e6ced242ea0207c9da411ccf16dc04e689cc01158b28d7898c40d75598f4559109f761c12ce01e959bf7
@@ -276,6 +276,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@deck.gl-community/editable-layers@workspace:modules/editable-layers"
   dependencies:
+    "@math.gl/web-mercator": "npm:>=4.0.1"
     "@turf/along": "npm:^7.2.0"
     "@turf/area": "npm:^7.2.0"
     "@turf/bbox": "npm:^7.2.0"
@@ -313,7 +314,6 @@ __metadata:
     lodash.throttle: "npm:^4.1.1"
     preact: "npm:^10.17.0"
     uuid: "npm:9.0.0"
-    viewport-mercator-project: "npm:>=6.2.3"
   peerDependencies:
     "@deck.gl-community/layers": ^9.2.0-beta
     "@deck.gl/core": ~9.2.1
@@ -2296,17 +2296,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@math.gl/web-mercator@npm:^3.5.5":
-  version: 3.6.3
-  resolution: "@math.gl/web-mercator@npm:3.6.3"
-  dependencies:
-    "@babel/runtime": "npm:^7.12.0"
-    gl-matrix: "npm:^3.4.0"
-  checksum: 10c0/95a1267261e03fa0194ec5ac5f3f8c3a13e1182cf3865d4d3bbd669706d42bd067335d1812df2e844c63c1f0f21c50e08af2b90168f2db1d3fa3ba2087f59703
-  languageName: node
-  linkType: hard
-
-"@math.gl/web-mercator@npm:^4.1.0":
+"@math.gl/web-mercator@npm:>=4.0.1, @math.gl/web-mercator@npm:^4.1.0":
   version: 4.1.0
   resolution: "@math.gl/web-mercator@npm:4.1.0"
   dependencies:
@@ -8568,7 +8558,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gl-matrix@npm:^3.0.0, gl-matrix@npm:^3.4.0, gl-matrix@npm:^3.4.3":
+"gl-matrix@npm:^3.0.0, gl-matrix@npm:^3.4.3":
   version: 3.4.4
   resolution: "gl-matrix@npm:3.4.4"
   checksum: 10c0/9aa022ffac0d158212ad0cd29939864ad919ac31cd5dc5a5d35e9d66bb62679ddf152ff7b2173ded20131045e40572b87f31b26a920be2a7583a1516b13b5b4b
@@ -15207,15 +15197,6 @@ __metadata:
     core-util-is: "npm:1.0.2"
     extsprintf: "npm:^1.2.0"
   checksum: 10c0/37ccdf8542b5863c525128908ac80f2b476eed36a32cb944de930ca1e2e78584cc435c4b9b4c68d0fc13a47b45ff364b4be43aa74f8804f9050140f660fb660d
-  languageName: node
-  linkType: hard
-
-"viewport-mercator-project@npm:>=6.2.3":
-  version: 7.0.4
-  resolution: "viewport-mercator-project@npm:7.0.4"
-  dependencies:
-    "@math.gl/web-mercator": "npm:^3.5.5"
-  checksum: 10c0/9a8a12f4bd68355a8162a23d4b161133b45aee71b2453fd8d57f54c55466007428cf502d0c02f58620d4c92ba934c29608613bc3176dd8c1d348f8a9deb34e32
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Replaces deprecated `viewport-mercator-project` with `@math.gl/web-mercator` in editable-layers
- `@math.gl/web-mercator` is the official successor with identical `WebMercatorViewport` API
- Updated 3 source files: `translate-mode.ts`, `utils/utils.ts`, `edit-modes/utils.ts`
- Only `project()` and `unproject()` methods are used -- both are API-compatible

## Test plan
- [x] `yarn install` resolves cleanly
- [x] `yarn test-node` -- all 50 test files pass (248 tests)