### PR TITLE
feat(three/tree-layer): stronger canopy shape variety for spherical tree types

### DIFF
--- a/modules/three/src/tree-layer/tree-layer.ts
+++ b/modules/three/src/tree-layer/tree-layer.ts
@@ -545,19 +545,19 @@ export class TreeLayer<DataT = unknown, ExtraPropsT extends {} = {}> extends Com
           // Per-tree asymmetric XY scale from position hash — no two canopies
           // are the same oval, giving organic variety with zero extra draw calls.
           const seed = positionSeed(pos[0], pos[1]);
-          const sx = 1 + ((seed & 0xffff) / 65535 - 0.5) * 0.3;
-          const sy = 1 + (((seed >>> 16) & 0xffff) / 65535 - 0.5) * 0.3;
+          const sx = 1 + ((seed & 0xffff) / 65535 - 0.5) * 0.6;
+          const sy = 1 + (((seed >>> 16) & 0xffff) / 65535 - 0.5) * 0.6;
           return [r * sx, r * sy, h * (1 - f)];
         },
         getOrientation: (d) => {
-          // Random bearing per tree: yaw (index 1) rotates around the vertical
-          // Z axis in deck.gl's [pitch, yaw, roll] convention.
-          // Pine tiers face different compass directions; bumpy canopies present
-          // a unique silhouette from every viewing angle.
+          // Random bearing + slight pitch per tree so spherical canopies show
+          // visible lean variety at typical farm viewing angles (30–60° pitch).
+          // pitch [0]: ±12°, yaw [1]: full 360°, roll [2]: 0
           const pos = getPosition(d);
           const seed = positionSeed(pos[0], pos[1]);
-          const angle = (((seed ^ (seed >>> 13)) & 0xffff) / 65535) * 360;
-          return [0, angle, 0];
+          const yaw = (((seed ^ (seed >>> 13)) & 0xffff) / 65535) * 360;
+          const pitch = (((seed ^ (seed >>> 7)) & 0xff) / 255 - 0.5) * 24;
+          return [pitch, yaw, 0];
         },
         getColor: (d) => {
           const explicit = getCanopyColor(d);


### PR DESCRIPTION
## Problem

The existing per-tree randomisation (random yaw + ±15% XY scale) has no visible effect on spherical canopy meshes (oak, cherry, birch, citrus). A sphere is rotationally symmetric, so yaw rotation alone changes nothing. The ±15% asymmetric XY scale creates an ellipsoid, but the variation is too subtle to read as distinct individuals in a dense farm/orchard row.

## Changes

**`modules/three/src/tree-layer/tree-layer.ts` — `_buildCanopyLayer`**

| | Before | After |
|---|---|---|
| XY scale asymmetry | ±15% (`* 0.3`) | ±30% (`* 0.6`) |
| Orientation | `[0, yaw, 0]` | `[pitch ±12°, yaw, 0]` |

The pitch component (`± 12°`) is derived from the same position seed as yaw so it is deterministic and stable across re-renders. Combined with the wider ellipsoid, each tree now presents a clearly distinct silhouette when viewed from a typical oblique / 3D map perspective (30–60° pitch).

Pine trees also benefit: the wider asymmetric scale makes layered tier silhouettes more varied across branch-level groups.

## Visual impact

- Dense orchards (citrus, oak, cherry) now show individual tree character instead of identical spheres
- Pitch variation is subtle enough to read as natural lean rather than artificial tilt
- No change to picking, performance, or API surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)