### PR TITLE
fix(website): remove three/wild-forest from sidebar

### DIFF
--- a/website/src/examples-sidebar.js
+++ b/website/src/examples-sidebar.js
@@ -81,14 +81,6 @@ const sidebars = {
     //   ]
     // },
 
-    {
-      type: 'category',
-      label: '@deck.gl-community/three',
-      items: [
-        "three/wild-forest"
-      ]
-    },
-
     // TODO - need BING map key
     // {
     //   type: 'category',


### PR DESCRIPTION
Removes the three/wild-forest sidebar entry that references a doc page which does not exist yet, fixing the website build CI failure.