### PR TITLE
ci: disable Yarn hardened mode to fix dependabot CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Install dependencies
         run: yarn
+        env:
+          YARN_ENABLE_HARDENED_MODE: 0
 
       - name: Lint
         run: yarn lint
@@ -77,6 +79,8 @@ jobs:
 
       - name: Install dependencies
         run: yarn
+        env:
+          YARN_ENABLE_HARDENED_MODE: 0
 
       - name: Build packages
         run: yarn build
@@ -231,6 +235,8 @@ jobs:
 
       - name: Install dependencies
         run: yarn
+        env:
+          YARN_ENABLE_HARDENED_MODE: 0
 
       - name: Build packages
         run: yarn build


### PR DESCRIPTION
Yarn 4 auto-enables hardened mode on public PRs, blocking lockfile updates from dependabot. All three CI jobs fail at yarn install. Adds YARN_ENABLE_HARDENED_MODE=0 to the install step in lint, test-node, and test-headless. After merging, rerun #548 and it should pass.