### PR TITLE
fix: move vis.gl singleton deps to peerDependencies

### DIFF
--- a/modules/arrow-layers/package.json
+++ b/modules/arrow-layers/package.json
@@ -36,14 +36,16 @@
     "test-watch": "vitest"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "~9.3.0",
-    "@deck.gl/core": "~9.3.0",
-    "@deck.gl/geo-layers": "~9.3.0",
-    "@deck.gl/layers": "~9.3.0",
     "@geoarrow/geoarrow-js": "^0.3.0",
     "@math.gl/core": "^4.0.0",
     "@math.gl/polygon": "^4.0.0",
     "apache-arrow": ">=15",
     "threads": "^1.7.0"
+  },
+  "peerDependencies": {
+    "@deck.gl/aggregation-layers": "~9.3.0",
+    "@deck.gl/core": "~9.3.0",
+    "@deck.gl/geo-layers": "~9.3.0",
+    "@deck.gl/layers": "~9.3.0"
   }
 }

--- a/modules/basemap-layers/package.json
+++ b/modules/basemap-layers/package.json
@@ -44,16 +44,18 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
+    "@loaders.gl/loader-utils": "^4.4.1",
+    "@loaders.gl/mvt": "^4.4.1",
+    "@mapbox/mapbox-gl-style-spec": "^13.12.0",
+    "@turf/polygon-to-line": "^6.0.3",
+    "zod": "^4.0.0"
+  },
+  "peerDependencies": {
     "@deck.gl/core": "~9.3.0",
     "@deck.gl/geo-layers": "~9.3.0",
     "@deck.gl/layers": "~9.3.0",
     "@loaders.gl/core": "^4.4.1",
-    "@loaders.gl/loader-utils": "^4.4.1",
-    "@loaders.gl/mvt": "^4.4.1",
     "@luma.gl/core": "~9.3.2",
-    "@luma.gl/engine": "~9.3.2",
-    "@mapbox/mapbox-gl-style-spec": "^13.12.0",
-    "@turf/polygon-to-line": "^6.0.3",
-    "zod": "^4.0.0"
+    "@luma.gl/engine": "~9.3.2"
   }
 }

--- a/modules/bing-maps/package.json
+++ b/modules/bing-maps/package.json
@@ -35,7 +35,7 @@
     "test": "vitest run",
     "test-watch": "vitest"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@deck.gl/core": "~9.3.0"
   }
 }

--- a/modules/editable-layers/package.json
+++ b/modules/editable-layers/package.json
@@ -77,7 +77,7 @@
     "preact": "^10.17.0"
   },
   "peerDependencies": {
-    "@deck.gl-community/layers": "^9.3.0",
+    "@deck.gl-community/layers": "~9.3.0",
     "@deck.gl/core": "~9.3.0",
     "@deck.gl/extensions": "~9.3.0",
     "@deck.gl/geo-layers": "~9.3.0",

--- a/modules/experimental/package.json
+++ b/modules/experimental/package.json
@@ -33,17 +33,19 @@
     "test-watch": "vitest"
   },
   "dependencies": {
+    "@loaders.gl/i3s": "^4.4.1",
+    "@loaders.gl/loader-utils": "^4.4.1",
+    "@loaders.gl/schema": "^4.4.1",
+    "@loaders.gl/tiles": "^4.4.1",
+    "@luma.gl/shadertools": "~9.3.2"
+  },
+  "peerDependencies": {
     "@deck.gl/core": "~9.3.0",
     "@deck.gl/geo-layers": "~9.3.0",
     "@deck.gl/layers": "~9.3.0",
     "@deck.gl/mesh-layers": "~9.3.0",
     "@loaders.gl/core": "^4.4.1",
-    "@loaders.gl/i3s": "^4.4.1",
-    "@loaders.gl/loader-utils": "^4.4.1",
-    "@loaders.gl/schema": "^4.4.1",
-    "@loaders.gl/tiles": "^4.4.1",
     "@luma.gl/core": "~9.3.2",
-    "@luma.gl/engine": "~9.3.2",
-    "@luma.gl/shadertools": "~9.3.2"
+    "@luma.gl/engine": "~9.3.2"
   }
 }

--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -38,17 +38,19 @@
     "test-watch": "vitest"
   },
   "dependencies": {
-    "@deck.gl/core": "~9.3.0",
-    "@deck.gl/geo-layers": "~9.3.0",
-    "@deck.gl/layers": "~9.3.0",
     "@loaders.gl/loader-utils": "^4.4.1",
-    "@luma.gl/core": "~9.3.2",
-    "@luma.gl/engine": "~9.3.2",
     "@luma.gl/shadertools": "~9.3.2",
     "@math.gl/core": "^4.0.0",
     "@probe.gl/stats": "^4.1.1",
     "a5-js": "^0.5.0",
     "h3-js": "^4.2.1"
+  },
+  "peerDependencies": {
+    "@deck.gl/core": "~9.3.0",
+    "@deck.gl/geo-layers": "~9.3.0",
+    "@deck.gl/layers": "~9.3.0",
+    "@luma.gl/core": "~9.3.2",
+    "@luma.gl/engine": "~9.3.2"
   },
   "devDependencies": {
     "@deck.gl/test-utils": "~9.3.0",

--- a/modules/graph-layers/package.json
+++ b/modules/graph-layers/package.json
@@ -41,12 +41,6 @@
     "test-watch": "vitest"
   },
   "dependencies": {
-    "@deck.gl/core": "~9.3.0",
-    "@deck.gl/layers": "~9.3.0",
-    "@deck.gl/widgets": "~9.3.0",
-    "@loaders.gl/core": "^4.4.1",
-    "@luma.gl/core": "~9.3.2",
-    "@luma.gl/engine": "~9.3.2",
     "@luma.gl/shadertools": "~9.3.2",
     "@probe.gl/log": "^4.0.4",
     "apache-arrow": "^17.0.0",
@@ -66,6 +60,12 @@
     "zod-to-json-schema": "patch:zod-to-json-schema@npm%3A3.24.6#~/.yarn/patches/zod-to-json-schema-npm-3.24.6-1ea8d4e085.patch"
   },
   "peerDependencies": {
+    "@deck.gl/core": "~9.3.0",
+    "@deck.gl/layers": "~9.3.0",
+    "@deck.gl/widgets": "~9.3.0",
+    "@loaders.gl/core": "^4.4.1",
+    "@luma.gl/core": "~9.3.2",
+    "@luma.gl/engine": "~9.3.2",
     "zod": "^4.0.0"
   }
 }

--- a/modules/infovis-layers/package.json
+++ b/modules/infovis-layers/package.json
@@ -33,11 +33,13 @@
     "test-watch": "vitest"
   },
   "dependencies": {
+    "@luma.gl/shadertools": "~9.3.2"
+  },
+  "peerDependencies": {
     "@deck.gl/core": "~9.3.0",
     "@deck.gl/layers": "~9.3.0",
     "@luma.gl/core": "~9.3.2",
-    "@luma.gl/engine": "~9.3.2",
-    "@luma.gl/shadertools": "~9.3.2"
+    "@luma.gl/engine": "~9.3.2"
   },
   "devDependencies": {
     "@deck.gl/test-utils": "~9.3.0",

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -33,16 +33,18 @@
     "test-watch": "vitest"
   },
   "dependencies": {
+    "@loaders.gl/textures": "^4.4.1",
+    "@luma.gl/constants": "~9.3.2",
+    "@luma.gl/shadertools": "~9.3.2",
+    "@math.gl/core": "^4.0.0"
+  },
+  "peerDependencies": {
     "@deck.gl/core": "~9.3.0",
     "@deck.gl/layers": "~9.3.0",
     "@deck.gl/mesh-layers": "~9.3.0",
     "@loaders.gl/core": "^4.4.1",
-    "@loaders.gl/textures": "^4.4.1",
-    "@luma.gl/constants": "~9.3.2",
     "@luma.gl/core": "~9.3.2",
-    "@luma.gl/engine": "~9.3.2",
-    "@luma.gl/shadertools": "~9.3.2",
-    "@math.gl/core": "^4.0.0"
+    "@luma.gl/engine": "~9.3.2"
   },
   "devDependencies": {
     "@deck.gl/test-utils": "~9.3.0",

--- a/modules/layers/test/peer-dependencies.spec.ts
+++ b/modules/layers/test/peer-dependencies.spec.ts
@@ -1,0 +1,115 @@
+import {describe, it, expect} from 'vitest';
+import {readFileSync, readdirSync, statSync, existsSync} from 'fs';
+import {join, resolve} from 'path';
+
+const MODULES_DIR = resolve(__dirname, '../../');
+
+/**
+ * Singleton packages that must be declared as peerDependencies.
+ * These are core runtimes where duplicate copies cause version conflicts.
+ * Pattern follows how @deck.gl itself declares its dependencies.
+ */
+const SINGLETON_PATTERNS = [
+  /^@deck\.gl\//,
+  /^@deck\.gl-community\//,
+  /^@luma\.gl\/core$/,
+  /^@luma\.gl\/engine$/,
+  /^@loaders\.gl\/core$/
+];
+
+/**
+ * Singleton packages should use tilde (~) ranges, not caret (^),
+ * because @deck.gl minor versions are often breaking.
+ */
+const TILDE_REQUIRED_PATTERNS = [/^@deck\.gl\//, /^@deck\.gl-community\//, /^@luma\.gl\//];
+
+function isSingleton(pkg: string): boolean {
+  return SINGLETON_PATTERNS.some((p) => p.test(pkg));
+}
+
+function requiresTilde(pkg: string): boolean {
+  return TILDE_REQUIRED_PATTERNS.some((p) => p.test(pkg));
+}
+
+interface PackageJson {
+  private?: boolean;
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+}
+
+function getModulePackageJsons(): {name: string; path: string; pkg: PackageJson}[] {
+  return readdirSync(MODULES_DIR)
+    .filter((dir) => {
+      const pkgPath = join(MODULES_DIR, dir, 'package.json');
+      return existsSync(pkgPath) && statSync(join(MODULES_DIR, dir)).isDirectory();
+    })
+    .map((dir) => {
+      const pkgPath = join(MODULES_DIR, dir, 'package.json');
+      return {
+        name: dir,
+        path: pkgPath,
+        pkg: JSON.parse(readFileSync(pkgPath, 'utf8')) as PackageJson
+      };
+    })
+    .filter(({pkg}) => !pkg.private);
+}
+
+describe('peer dependency structure', () => {
+  const modules = getModulePackageJsons();
+
+  it.each(modules.map(({name, pkg}) => [name, pkg.dependencies ?? {}]))(
+    '%s should not have singleton vis.gl packages in dependencies',
+    (name, deps) => {
+      const violations = Object.keys(deps).filter(isSingleton);
+      expect(
+        violations,
+        `${name} has singleton packages in dependencies instead of peerDependencies`
+      ).toEqual([]);
+    }
+  );
+});
+
+describe('peer dependency version ranges', () => {
+  const modules = getModulePackageJsons();
+
+  it.each(modules.map(({name, pkg}) => [name, pkg.peerDependencies ?? {}]))(
+    '%s should use tilde (~) ranges for @deck.gl and @luma.gl peer deps',
+    (name, peers) => {
+      const violations = Object.entries(peers)
+        .filter(([dep]) => requiresTilde(dep))
+        .filter(([, range]) => range.startsWith('^'));
+      expect(
+        violations.map(([dep, range]) => `${dep}: ${range}`),
+        `${name} uses caret (^) where tilde (~) is required`
+      ).toEqual([]);
+    }
+  );
+});
+
+describe('peer dependency version consistency', () => {
+  const modules = getModulePackageJsons();
+  const versionMap = new Map<string, {version: string; module: string}[]>();
+
+  for (const {name, pkg} of modules) {
+    const peers = pkg.peerDependencies ?? {};
+    for (const [dep, range] of Object.entries(peers)) {
+      if (!versionMap.has(dep)) {
+        versionMap.set(dep, []);
+      }
+      versionMap.get(dep)?.push({version: range, module: name});
+    }
+  }
+
+  const multiVersionDeps = [...versionMap.entries()].filter(([, entries]) => entries.length >= 2);
+
+  it.each(multiVersionDeps)(
+    '%s should have consistent version range across modules',
+    (dep, entries) => {
+      const versions = [...new Set(entries.map((e) => e.version))];
+      if (versions.length > 1) {
+        const detail = entries.map((e) => `  ${e.module}: ${e.version}`).join('\n');
+        expect.fail(`${dep} has inconsistent ranges:\n${detail}`);
+      }
+    }
+  );
+});

--- a/modules/leaflet/package.json
+++ b/modules/leaflet/package.json
@@ -38,14 +38,12 @@
     "test": "vitest run",
     "test-watch": "vitest"
   },
-  "dependencies": {
-    "@deck.gl/core": "~9.3.0"
-  },
   "devDependencies": {
     "@types/leaflet": "^1.9.18",
     "leaflet": "^1.9.4"
   },
   "peerDependencies": {
+    "@deck.gl/core": "~9.3.0",
     "leaflet": "^1.9.4"
   }
 }

--- a/modules/three/package.json
+++ b/modules/three/package.json
@@ -35,9 +35,11 @@
     "test-watch": "vitest"
   },
   "dependencies": {
-    "@deck.gl/core": "~9.3.0",
-    "@deck.gl/mesh-layers": "~9.3.0",
     "three": "^0.170.0"
+  },
+  "peerDependencies": {
+    "@deck.gl/core": "~9.3.0",
+    "@deck.gl/mesh-layers": "~9.3.0"
   },
   "devDependencies": {
     "@types/three": "^0.170.0"

--- a/modules/widgets/package.json
+++ b/modules/widgets/package.json
@@ -32,10 +32,12 @@
     "test-watch": "vitest"
   },
   "dependencies": {
-    "@deck.gl/core": "~9.3.0",
     "@probe.gl/stats": "^4.1.1",
     "@turf/helpers": "^6.5.0",
     "preact": "^10.17.0",
     "supercluster": "^8.0.1"
+  },
+  "peerDependencies": {
+    "@deck.gl/core": "~9.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -275,15 +275,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@deck.gl-community/arrow-layers@workspace:modules/arrow-layers"
   dependencies:
-    "@deck.gl/aggregation-layers": "npm:~9.3.0"
-    "@deck.gl/core": "npm:~9.3.0"
-    "@deck.gl/geo-layers": "npm:~9.3.0"
-    "@deck.gl/layers": "npm:~9.3.0"
     "@geoarrow/geoarrow-js": "npm:^0.3.0"
     "@math.gl/core": "npm:^4.0.0"
     "@math.gl/polygon": "npm:^4.0.0"
     apache-arrow: "npm:>=15"
     threads: "npm:^1.7.0"
+  peerDependencies:
+    "@deck.gl/aggregation-layers": ~9.3.0
+    "@deck.gl/core": ~9.3.0
+    "@deck.gl/geo-layers": ~9.3.0
+    "@deck.gl/layers": ~9.3.0
   languageName: unknown
   linkType: soft
 
@@ -291,26 +292,27 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@deck.gl-community/basemap-layers@workspace:modules/basemap-layers"
   dependencies:
-    "@deck.gl/core": "npm:~9.3.0"
-    "@deck.gl/geo-layers": "npm:~9.3.0"
-    "@deck.gl/layers": "npm:~9.3.0"
-    "@loaders.gl/core": "npm:^4.4.1"
     "@loaders.gl/loader-utils": "npm:^4.4.1"
     "@loaders.gl/mvt": "npm:^4.4.1"
-    "@luma.gl/core": "npm:~9.3.2"
-    "@luma.gl/engine": "npm:~9.3.2"
     "@mapbox/mapbox-gl-style-spec": "npm:^13.12.0"
     "@turf/polygon-to-line": "npm:^6.0.3"
     vitest: "npm:^4.0.18"
     zod: "npm:^4.0.0"
+  peerDependencies:
+    "@deck.gl/core": ~9.3.0
+    "@deck.gl/geo-layers": ~9.3.0
+    "@deck.gl/layers": ~9.3.0
+    "@loaders.gl/core": ^4.4.1
+    "@luma.gl/core": ~9.3.2
+    "@luma.gl/engine": ~9.3.2
   languageName: unknown
   linkType: soft
 
 "@deck.gl-community/bing-maps@workspace:*, @deck.gl-community/bing-maps@workspace:modules/bing-maps":
   version: 0.0.0-use.local
   resolution: "@deck.gl-community/bing-maps@workspace:modules/bing-maps"
-  dependencies:
-    "@deck.gl/core": "npm:~9.3.0"
+  peerDependencies:
+    "@deck.gl/core": ~9.3.0
   languageName: unknown
   linkType: soft
 
@@ -358,7 +360,7 @@ __metadata:
     lodash.throttle: "npm:^4.1.1"
     preact: "npm:^10.17.0"
   peerDependencies:
-    "@deck.gl-community/layers": ^9.3.0
+    "@deck.gl-community/layers": ~9.3.0
     "@deck.gl/core": ~9.3.0
     "@deck.gl/extensions": ~9.3.0
     "@deck.gl/geo-layers": ~9.3.0
@@ -375,18 +377,19 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@deck.gl-community/experimental@workspace:modules/experimental"
   dependencies:
-    "@deck.gl/core": "npm:~9.3.0"
-    "@deck.gl/geo-layers": "npm:~9.3.0"
-    "@deck.gl/layers": "npm:~9.3.0"
-    "@deck.gl/mesh-layers": "npm:~9.3.0"
-    "@loaders.gl/core": "npm:^4.4.1"
     "@loaders.gl/i3s": "npm:^4.4.1"
     "@loaders.gl/loader-utils": "npm:^4.4.1"
     "@loaders.gl/schema": "npm:^4.4.1"
     "@loaders.gl/tiles": "npm:^4.4.1"
-    "@luma.gl/core": "npm:~9.3.2"
-    "@luma.gl/engine": "npm:~9.3.2"
     "@luma.gl/shadertools": "npm:~9.3.2"
+  peerDependencies:
+    "@deck.gl/core": ~9.3.0
+    "@deck.gl/geo-layers": ~9.3.0
+    "@deck.gl/layers": ~9.3.0
+    "@deck.gl/mesh-layers": ~9.3.0
+    "@loaders.gl/core": ^4.4.1
+    "@luma.gl/core": ~9.3.2
+    "@luma.gl/engine": ~9.3.2
   languageName: unknown
   linkType: soft
 
@@ -394,13 +397,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@deck.gl-community/geo-layers@workspace:modules/geo-layers"
   dependencies:
-    "@deck.gl/core": "npm:~9.3.0"
-    "@deck.gl/geo-layers": "npm:~9.3.0"
-    "@deck.gl/layers": "npm:~9.3.0"
     "@deck.gl/test-utils": "npm:~9.3.0"
     "@loaders.gl/loader-utils": "npm:^4.4.1"
-    "@luma.gl/core": "npm:~9.3.2"
-    "@luma.gl/engine": "npm:~9.3.2"
     "@luma.gl/shadertools": "npm:~9.3.2"
     "@luma.gl/webgpu": "npm:~9.3.2"
     "@math.gl/core": "npm:^4.0.0"
@@ -408,6 +406,12 @@ __metadata:
     "@probe.gl/test-utils": "npm:^4.0.4"
     a5-js: "npm:^0.5.0"
     h3-js: "npm:^4.2.1"
+  peerDependencies:
+    "@deck.gl/core": ~9.3.0
+    "@deck.gl/geo-layers": ~9.3.0
+    "@deck.gl/layers": ~9.3.0
+    "@luma.gl/core": ~9.3.2
+    "@luma.gl/engine": ~9.3.2
   languageName: unknown
   linkType: soft
 
@@ -415,12 +419,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@deck.gl-community/graph-layers@workspace:modules/graph-layers"
   dependencies:
-    "@deck.gl/core": "npm:~9.3.0"
-    "@deck.gl/layers": "npm:~9.3.0"
-    "@deck.gl/widgets": "npm:~9.3.0"
-    "@loaders.gl/core": "npm:^4.4.1"
-    "@luma.gl/core": "npm:~9.3.2"
-    "@luma.gl/engine": "npm:~9.3.2"
     "@luma.gl/shadertools": "npm:~9.3.2"
     "@probe.gl/log": "npm:^4.0.4"
     apache-arrow: "npm:^17.0.0"
@@ -437,6 +435,12 @@ __metadata:
     zod: "npm:^4.0.0"
     zod-to-json-schema: "patch:zod-to-json-schema@npm%3A3.24.6#~/.yarn/patches/zod-to-json-schema-npm-3.24.6-1ea8d4e085.patch"
   peerDependencies:
+    "@deck.gl/core": ~9.3.0
+    "@deck.gl/layers": ~9.3.0
+    "@deck.gl/widgets": ~9.3.0
+    "@loaders.gl/core": ^4.4.1
+    "@luma.gl/core": ~9.3.2
+    "@luma.gl/engine": ~9.3.2
     zod: ^4.0.0
   languageName: unknown
   linkType: soft
@@ -445,14 +449,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@deck.gl-community/infovis-layers@workspace:modules/infovis-layers"
   dependencies:
-    "@deck.gl/core": "npm:~9.3.0"
-    "@deck.gl/layers": "npm:~9.3.0"
     "@deck.gl/test-utils": "npm:~9.3.0"
-    "@luma.gl/core": "npm:~9.3.2"
-    "@luma.gl/engine": "npm:~9.3.2"
     "@luma.gl/shadertools": "npm:~9.3.2"
     "@luma.gl/webgpu": "npm:~9.3.2"
     "@probe.gl/test-utils": "npm:^4.0.4"
+  peerDependencies:
+    "@deck.gl/core": ~9.3.0
+    "@deck.gl/layers": ~9.3.0
+    "@luma.gl/core": ~9.3.2
+    "@luma.gl/engine": ~9.3.2
   languageName: unknown
   linkType: soft
 
@@ -460,19 +465,20 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@deck.gl-community/layers@workspace:modules/layers"
   dependencies:
-    "@deck.gl/core": "npm:~9.3.0"
-    "@deck.gl/layers": "npm:~9.3.0"
-    "@deck.gl/mesh-layers": "npm:~9.3.0"
     "@deck.gl/test-utils": "npm:~9.3.0"
-    "@loaders.gl/core": "npm:^4.4.1"
     "@loaders.gl/textures": "npm:^4.4.1"
     "@luma.gl/constants": "npm:~9.3.2"
-    "@luma.gl/core": "npm:~9.3.2"
-    "@luma.gl/engine": "npm:~9.3.2"
     "@luma.gl/shadertools": "npm:~9.3.2"
     "@luma.gl/webgpu": "npm:~9.3.2"
     "@math.gl/core": "npm:^4.0.0"
     "@probe.gl/test-utils": "npm:^4.0.4"
+  peerDependencies:
+    "@deck.gl/core": ~9.3.0
+    "@deck.gl/layers": ~9.3.0
+    "@deck.gl/mesh-layers": ~9.3.0
+    "@loaders.gl/core": ^4.4.1
+    "@luma.gl/core": ~9.3.2
+    "@luma.gl/engine": ~9.3.2
   languageName: unknown
   linkType: soft
 
@@ -480,10 +486,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@deck.gl-community/leaflet@workspace:modules/leaflet"
   dependencies:
-    "@deck.gl/core": "npm:~9.3.0"
     "@types/leaflet": "npm:^1.9.18"
     leaflet: "npm:^1.9.4"
   peerDependencies:
+    "@deck.gl/core": ~9.3.0
     leaflet: ^1.9.4
   languageName: unknown
   linkType: soft
@@ -512,10 +518,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@deck.gl-community/three@workspace:modules/three"
   dependencies:
-    "@deck.gl/core": "npm:~9.3.0"
-    "@deck.gl/mesh-layers": "npm:~9.3.0"
     "@types/three": "npm:^0.170.0"
     three: "npm:^0.170.0"
+  peerDependencies:
+    "@deck.gl/core": ~9.3.0
+    "@deck.gl/mesh-layers": ~9.3.0
   languageName: unknown
   linkType: soft
 
@@ -538,11 +545,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@deck.gl-community/widgets@workspace:modules/widgets"
   dependencies:
-    "@deck.gl/core": "npm:~9.3.0"
     "@probe.gl/stats": "npm:^4.1.1"
     "@turf/helpers": "npm:^6.5.0"
     preact: "npm:^10.17.0"
     supercluster: "npm:^8.0.1"
+  peerDependencies:
+    "@deck.gl/core": ~9.3.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Closes #590

- Moves singleton runtime packages (`@deck.gl/*`, `@luma.gl/core`, `@luma.gl/engine`, `@loaders.gl/core`) from `dependencies` to `peerDependencies` across all 12 modules — matching how `@deck.gl` itself declares its deps
- Leaf utilities (`@luma.gl/shadertools`, `@loaders.gl` sub-packages, `@math.gl/*`) remain as regular dependencies
- Fixes `editable-layers` using caret (`^`) instead of tilde (`~`) on `@deck.gl-community/layers`, which allowed cross-minor resolution (the direct trigger of #590)

This prevents npm from installing duplicate copies of core vis.gl packages when consumers pin to a specific minor version line.

## Test plan

- [x] All 424 existing tests pass (66 test files)
- [x] Prettier + ESLint pre-commit hooks pass
- [x] Validated via script: no `@deck.gl/*`, `@luma.gl/core`, `@luma.gl/engine`, or `@loaders.gl/core` remain in `dependencies` for any module

cc @w1nklr — would appreciate your review since you filed #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)