### PR TITLE
ci: node 24, fix website build errors surfaced in first deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Enable Corepack / Yarn 4
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Enable Corepack / Yarn 4
         run: |
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Enable Corepack / Yarn 4
         run: |
@@ -218,7 +218,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Enable Corepack / Yarn 4
         run: |

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Enable Corepack / Yarn 4
         run: |

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -4,15 +4,6 @@
 
 Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community/milestone/5).
 
-Inofficial wishlist and roadmap type information is also available in github trackers:
-
-- **`@deck.gl-community/editable-layers`**
-  - [Tracker](https://github.com/visgl/deck.gl-community/issues/38)
-- **`@deck.gl-community/graph-layers`**
-  - [Tracker](https://github.com/visgl/deck.gl-community/issues/78)
-- **`@deck.gl-community/infovis-layers`**
-  - Goal: Some of the improved support for (non-geospatial) views etc should be upstreamed into deck.gl v9.3.
-
 ## v9.3
 
 Released: April 15, 2026

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -33,7 +33,7 @@ Highlights:
 
 A new experimental basemap module for rendering style-defined basemaps directly with deck.gl.
 
-- [`BasemapLayer`](/docs/modules/basemap-layers/api-reference/basemap-layer) - NEW `CompositeLayer` that loads a MapLibre / Mapbox style document and renders background, raster, vector, and label content using deck.gl sublayers.
+- `BasemapLayer` - NEW `CompositeLayer` that loads a MapLibre / Mapbox style document and renders background, raster, vector, and label content using deck.gl sublayers.
 - `getBasemapLayers` - Generate deck.gl sublayers from an already-resolved basemap style definition.
 - `getGlobeBaseLayers` - Convenience helper for generating the globe-surface basemap layers.
 - `getGlobeTopLayers` - Convenience helper for generating globe overlay layers such as atmosphere.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,7 +2,9 @@
 
 ## v9.4 - In Planning
 
-Inofficial wishlist and roadmap type information is available in github trackers:
+Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community/milestone/5).
+
+Inofficial wishlist and roadmap type information is also available in github trackers:
 
 - **`@deck.gl-community/editable-layers`**
   - [Tracker](https://github.com/visgl/deck.gl-community/issues/38)

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -175,6 +175,26 @@ const config = {
                   }
                 }
               ]
+            },
+            // Modules using TypeScript `declare` class fields need allowDeclareFields
+            {
+              test: /\.[jt]sx?$/,
+              include: [resolve('../modules/three/src'), resolve('../modules/arrow-layers/src')],
+              use: [
+                {
+                  loader: require.resolve('babel-loader'),
+                  options: {
+                    babelrc: false,
+                    configFile: false,
+                    presets: [
+                      [
+                        require.resolve('@babel/preset-typescript'),
+                        {isTSX: true, allExtensions: true, allowDeclareFields: true}
+                      ]
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
## Summary
Follow-up to #598. The first Actions-driven website deploy surfaced two issues and I'm also bumping Node:

1. **Website build failed** with `SyntaxError: The 'declare' modifier is only allowed when the 'allowDeclareFields' option of @babel/preset-typescript is enabled` on `modules/three/src/tree-layer/tree-layer.ts`. The existing webpack rule in `website/docusaurus.config.js` already sets `allowDeclareFields: true` but only for `widgets` + `editable-layers`. Added a second rule covering `three` and `arrow-layers` — both use the canonical deck.gl `declare state` pattern. No preact JSX transform for those (they have no TSX).
2. **Broken-link error** in the production build: `whats-new.md` linked to `/docs/modules/basemap-layers/api-reference/basemap-layer`, which doesn't exist yet (no `docs/modules/basemap-layers/` directory). Unlinked the reference — keeps the text, unblocks the build. The missing doc is a separate content gap worth tracking.
3. **Bumped Node 20 → 24** across `website.yml`, `test.yml`, `release.yml` per project direction.

Locally verified: `yarn build` in `website/` now succeeds end-to-end.

## Test plan
- [ ] Actions `website` workflow run on this branch goes green end-to-end (build + deploy)
- [ ] Deployed site renders the `TreeLayer` example under `docs/modules/three` without a runtime error on the narrowed `state` type
- [ ] `test.yml` lint + test jobs still pass under Node 24