### PR TITLE
feat(website): add landing page hero image

### DIFF
--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -4,8 +4,19 @@ import styled from 'styled-components';
 import Layout from '@theme/Layout';
 
 import {Home} from '../components';
-// import HeroExample from '../examples/home-demo';
-const HeroExample = () => <div />;
+
+const HeroImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+`;
+
+const HeroExample = () => {
+  const src = useBaseUrl('/images/hero-editable-3d-tiles.png');
+  return <HeroImage src={src} alt="deck.gl-community editable 3D tiles over the Grand Canyon" />;
+};
 
 const FeatureImage = styled.div`
   position: absolute;


### PR DESCRIPTION
## Summary
Replaces the empty landing-page hero with a screenshot of the editable 3D tiles example (Grand Canyon scene with drawn features). Rendered as a cover-fit `<img>` inside the existing absolute-positioned `HeroExampleContainer`, so the banner title and tagline stay on top.

The screenshot's bottom 32px (attribution / UI strip) was cropped before saving so nothing textual competes with the overlaid hero copy.

## Test plan
- [ ] Visit the landing page — hero image fills the banner behind the title on desktop and mobile
- [ ] No attribution strip or other text artifact at the bottom of the banner