### PR TITLE
feat(website): set hero image as default social preview (og:image)

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -12,7 +12,7 @@ const {resolve} = require('path');
 const config = {
   title: 'deck.gl-community',
   tagline: 'Unofficial layers, basemaps and add-ons for deck.gl',
-  url: 'https://deck.gl-community',
+  url: 'https://visgl.github.io',
   baseUrl: '/deck.gl-community/', // process.env.STAGING ? '/deck.gl-community/' : '/',
   onBrokenLinks: 'throw',
   markdown: {
@@ -216,6 +216,7 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      image: 'images/hero-editable-3d-tiles.png',
       navbar: {
         title: 'deck.gl-community',
         logo: {

--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -4,8 +4,19 @@ import styled from 'styled-components';
 import Layout from '@theme/Layout';
 
 import {Home} from '../components';
-// import HeroExample from '../examples/home-demo';
-const HeroExample = () => <div />;
+
+const HeroImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+`;
+
+const HeroExample = () => {
+  const src = useBaseUrl('/images/hero-editable-3d-tiles.png');
+  return <HeroImage src={src} alt="deck.gl-community editable 3D tiles over the Grand Canyon" />;
+};
 
 const FeatureImage = styled.div`
   position: absolute;


### PR DESCRIPTION
## Summary
Follow-up to #603. Two fixes:

1. **`themeConfig.image`** points at the new hero so every shared URL gets a proper Open Graph / Twitter card preview (used by Slack, Twitter/X, LinkedIn, Discord, iMessage, etc.).
2. **Site `url`** was set to `https://deck.gl-community` (not a valid URL). Changed to `https://visgl.github.io` — the actual hostname. Without this, the absolute `og:image` URL would resolve wrong and previews wouldn't fetch.

## Test plan
- [ ] After deploy, share `https://visgl.github.io/deck.gl-community/` in Slack / a tweet / LinkedIn — preview shows the Grand Canyon hero
- [ ] Meta tag inspector (e.g. metatags.io) shows `og:image = https://visgl.github.io/deck.gl-community/images/hero-editable-3d-tiles.png` and `twitter:card = summary_large_image`