### PR TITLE
fix(editable-layers): correct SelectionLayer polygon picking for elongated lassos

### DIFF
--- a/modules/editable-layers/src/editable-layers/selection-layer.ts
+++ b/modules/editable-layers/src/editable-layers/selection-layer.ts
@@ -4,17 +4,15 @@
 
 /* eslint-env browser */
 
-import type {CompositeLayerProps, DefaultProps} from '@deck.gl/core';
+import type {CompositeLayerProps, DefaultProps, Layer, PickingInfo} from '@deck.gl/core';
 import {CompositeLayer} from '@deck.gl/core';
-import {PolygonLayer} from '@deck.gl/layers';
-import {featureCollection, polygon} from '@turf/helpers';
-import turfBuffer from '@turf/buffer';
-import turfDifference from '@turf/difference';
+import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
+import {point, polygon} from '@turf/helpers';
 
-import {EditableGeoJsonLayer} from './editable-geojson-layer';
-import {DrawRectangleMode} from '../edit-modes/draw-rectangle-mode';
 import {DrawPolygonMode} from '../edit-modes/draw-polygon-mode';
+import {DrawRectangleMode} from '../edit-modes/draw-rectangle-mode';
 import {ViewMode} from '../edit-modes/view-mode';
+import {EditableGeoJsonLayer} from './editable-geojson-layer';
 
 export const SELECTION_TYPE = {
   NONE: null,
@@ -49,9 +47,7 @@ const EMPTY_DATA = {
   features: []
 };
 
-const EXPANSION_KM = 50;
 const LAYER_ID_GEOJSON = 'selection-geojson';
-const LAYER_ID_BLOCKER = 'selection-blocker';
 
 const PASS_THROUGH_PROPS = [
   'lineWidthScale',
@@ -75,17 +71,12 @@ const PASS_THROUGH_PROPS = [
   'getTentativeFillColor',
   'getTentativeLineWidth'
 ];
+
 export class SelectionLayer<DataT, ExtraPropsT> extends CompositeLayer<
   ExtraPropsT & Required<SelectionLayerProps<DataT>>
 > {
   static layerName = 'SelectionLayer';
   static defaultProps = defaultProps;
-
-  state: {
-    pendingPolygonSelection: {
-      bigPolygon: ReturnType<typeof turfDifference>;
-    };
-  } = undefined!;
 
   _selectRectangleObjects(coordinates: any) {
     const {layerIds, onSelect} = this.props;
@@ -104,57 +95,26 @@ export class SelectionLayer<DataT, ExtraPropsT> extends CompositeLayer<
 
   _selectPolygonObjects(coordinates: any) {
     const {layerIds, onSelect} = this.props;
-    const mousePoints = coordinates[0].map(c => this.context.viewport.project(c));
+    const selectionPolygon = polygon(coordinates);
 
-    const allX = mousePoints.map(mousePoint => mousePoint[0]);
-    const allY = mousePoints.map(mousePoint => mousePoint[1]);
-    const x = Math.min(...allX);
-    const y = Math.min(...allY);
-    const maxX = Math.max(...allX);
-    const maxY = Math.max(...allY);
-
-    // Use a polygon to hide the outside, because pickObjects()
-    // does not support polygons
-    const landPointsPoly = polygon(coordinates);
-    const bigBuffer = turfBuffer(landPointsPoly, EXPANSION_KM);
-    let bigPolygon;
-    try {
-      // turfDifference throws an exception if the polygon
-      // intersects with itself (TODO: check if true in all versions)
-      bigPolygon = turfDifference(featureCollection([bigBuffer, landPointsPoly]));
-    } catch (e) {
-      // invalid selection polygon
-      console.log('turfDifference() error', e); // eslint-disable-line
-      return;
-    }
-
-    this.setState({
-      pendingPolygonSelection: {
-        bigPolygon
-      }
-    });
-
-    const blockerId = `${this.props.id}-${LAYER_ID_BLOCKER}`;
-
-    // HACK, find a better way
-    setTimeout(() => {
-      const pickingInfos = this.context.deck.pickObjects({
-        x,
-        y,
-        width: maxX - x,
-        height: maxY - y,
-        layerIds: [blockerId, ...layerIds]
+    const pickingInfos: SelectionPickingInfo[] = this.context.layerManager
+      .getLayers()
+      .filter(layer => layerIds.includes(layer.id))
+      .flatMap(layer => {
+        const data = layer.props.data;
+        if (!Array.isArray(data)) return [];
+        return data.flatMap((object, index): SelectionPickingInfo[] => {
+          const position = extractPosition(layer, object, index, data);
+          if (position === null) return [];
+          if (!booleanPointInPolygon(point(position), selectionPolygon)) return [];
+          return [{object, layer, index}];
+        });
       });
 
-      onSelect({
-        pickingInfos: pickingInfos.filter(item => item.layer.id !== this.props.id)
-      });
-    }, 250);
+    onSelect({pickingInfos});
   }
 
   renderLayers() {
-    const {pendingPolygonSelection} = this.state;
-
     const mode = MODE_MAP[this.props.selectionType] || ViewMode;
     const modeConfig = MODE_CONFIG_MAP[this.props.selectionType];
 
@@ -163,7 +123,7 @@ export class SelectionLayer<DataT, ExtraPropsT> extends CompositeLayer<
       if (this.props[p] !== undefined) inheritedProps[p] = this.props[p];
     });
 
-    const layers: any[] = [
+    return [
       new EditableGeoJsonLayer(
         this.getSubLayerProps({
           id: LAYER_ID_GEOJSON,
@@ -187,29 +147,41 @@ export class SelectionLayer<DataT, ExtraPropsT> extends CompositeLayer<
         })
       )
     ];
-
-    if (pendingPolygonSelection) {
-      const {bigPolygon} = pendingPolygonSelection as any;
-      layers.push(
-        new PolygonLayer(
-          this.getSubLayerProps({
-            id: LAYER_ID_BLOCKER,
-            pickable: true,
-            stroked: false,
-            opacity: 1.0,
-            data: [bigPolygon],
-            getLineColor: _obj => [0, 0, 0, 1],
-            getFillColor: _obj => [0, 0, 0, 1],
-            getPolygon: o => o.geometry.coordinates
-          })
-        )
-      );
-    }
-
-    return layers;
   }
 
   shouldUpdateState({changeFlags: {stateChanged, propsOrDataChanged}}: Record<string, any>) {
     return stateChanged || propsOrDataChanged;
   }
+}
+
+type SelectionPickingInfo = Pick<PickingInfo, 'object' | 'layer' | 'index'>;
+
+function extractPosition(
+  layer: Layer,
+  object: unknown,
+  index: number,
+  data: unknown
+): [number, number] | null {
+  const props = layer.props;
+  if ('getPosition' in props && typeof props.getPosition === 'function') {
+    const result = props.getPosition(object, {index, data, target: []});
+    if (Array.isArray(result) && typeof result[0] === 'number' && typeof result[1] === 'number') {
+      return [result[0], result[1]];
+    }
+  }
+  if (typeof object === 'object' && object !== null) {
+    if ('position' in object) {
+      const p = object.position;
+      if (Array.isArray(p) && typeof p[0] === 'number' && typeof p[1] === 'number') {
+        return [p[0], p[1]];
+      }
+    }
+    if ('coordinates' in object) {
+      const c = object.coordinates;
+      if (Array.isArray(c) && typeof c[0] === 'number' && typeof c[1] === 'number') {
+        return [c[0], c[1]];
+      }
+    }
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary

Fixes false-positive selection in `SelectionLayer`'s polygon mode for elongated/diagonal/concave lassos by replacing the GPU-pick + buffered-blocker mechanism with a CPU point-in-polygon test.

## The bug

When using `SelectionLayer({selectionType: 'polygon', ...})`, pins that sit *outside* the drawn lasso are returned in `onSelect({pickingInfos})` as if they were inside. The failure is reliable for any lasso whose bounding box extends more than ~50 km past its own edges — long thin lassos, diagonal lassos, and concave shapes.

### Repro

1. Render a `ScatterplotLayer` of pins spread across a continent (e.g. the existing Manhattan demo, but at a wider zoom).
2. Add a `SelectionLayer` with `selectionType: 'polygon'`.
3. Draw a long thin lasso diagonally across the map.
4. Inspect `onSelect({pickingInfos})`: pins clearly outside the drawn polygon are included.

## Root cause

`_selectPolygonObjects` does this:

1. Builds a "blocker" polygon — a `turfBuffer(lasso, EXPANSION_KM = 50)` polygon with the lasso subtracted (`turfDifference`).
2. Calls `deck.pickObjects({bbox: lassoBoundingBox, layerIds: [blockerId, ...layerIds]})` after a `setTimeout(250)` for the blocker to render.
3. Filters the picks.

The blocker is what's meant to mask out pins outside the polygon. But:

- The buffer is fixed at 50 km. Any lasso whose bbox extends >50 km past its edges has gaps where the blocker doesn't cover, and pins in those gaps get picked even though they're outside the lasso polygon.
- The `setTimeout(250)` is a race; the source acknowledges it: `// HACK, find a better way` (line 139).
- The picking framebuffer also drops overlapping pins at the same pixel (related issue, [nebula.gl#297](https://github.com/uber/nebula.gl/issues/297)).

[nebula.gl#132](https://github.com/uber/nebula.gl/issues/132) ("Fix concave lasso select bug") has been open since 2018 with a noted TODO: "more proper implementation than the setTimeout hack." This PR is that implementation.

## The fix

Replace the GPU-pick + blocker mechanism with a direct CPU point-in-polygon test:

1. Take the drawn polygon coordinates.
2. For every layer named in `layerIds`, iterate its `data`.
3. Resolve each datum's position via `layer.props.getPosition(...)`, with `object.position` / `object.coordinates` fallbacks.
4. Run `@turf/boolean-point-in-polygon` (already a dependency) against the polygon.
5. Emit a pickingInfo `{object, layer, index}` for each match.

The result is exact, synchronous, and free of the buffer, framebuffer, and timing constraints.

## Scope

The new implementation supports layers exposing per-datum positions — `ScatterplotLayer`, `IconLayer`, `TextLayer`, `ColumnLayer`, etc. This matches:

- The layer type in [the docs example](https://github.com/visgl/deck.gl-community/blob/master/docs/modules/editable-layers/api-reference/layers/selection-layer.md) (`ScatterplotLayer`).
- The layer type in `examples/editable-layers/sf/app.tsx` and `examples/editable-layers/advanced/src/example.tsx` (`EditableGeoJsonLayer`).

The previous implementation incidentally returned pickingInfos for `PathLayer` / `PolygonLayer` / `ArcLayer` via GPU picking, but the results were never meaningful — the 50 km blocker meant the lasso shape barely applied to those geometries anyway. Polygon-mode support for non-point layers was never documented, and no example demonstrates it. If maintainers want explicit support later, that's a separate feature with its own UX decisions (intersection vs containment for paths, etc.).