### PR TITLE
feat(panels) Various panel updates

### DIFF
--- a/docs/modules/panels/api-reference/command-manager.md
+++ b/docs/modules/panels/api-reference/command-manager.md
@@ -1,0 +1,61 @@
+# CommandManager
+
+<p className="badges">
+  <img src="https://img.shields.io/badge/from-v9.3-green.svg?style=flat-square" alt="from v9.3" />
+</p>
+
+`CommandManager` is a shared command registry for shortcuts, widgets, and host
+automation surfaces. It stores command metadata separately from command
+handlers so UI surfaces can list commands without receiving the raw
+implementations.
+
+## Import
+
+```ts
+import {
+  CommandManager,
+  commandManager,
+  type CommandDefinition,
+  type CommandDescriptor
+} from '@deck.gl-community/panels';
+```
+
+## Usage
+
+```ts
+const manager = new CommandManager();
+
+const unregister = manager.registerCommand({
+  id: 'view.reset',
+  label: 'Reset view',
+  description: 'Reset the current viewport.',
+  do: () => resetView()
+});
+
+manager.executeCommand('view.reset');
+unregister();
+```
+
+## Automation
+
+Commands default to `exposure: 'user'`. Use `exposure: 'automation'` or
+`exposure: 'all'` when a host automation surface should be able to execute a
+command through `executeCommandAsync`.
+
+```ts
+manager.registerCommand({
+  id: 'selection.clear',
+  label: 'Clear selection',
+  exposure: 'all',
+  do: () => clearSelection()
+});
+```
+
+## Remarks
+
+- `listCommands({exposure: 'user'})` includes user commands and commands with
+  `exposure: 'all'`.
+- `executeCommandAsync` validates command exposure and optional argument
+  schemas before invoking a command.
+- `installAutomation` records host-provided automation surfaces for docs or
+  command help panels.

--- a/docs/modules/panels/api-reference/panel-modal.md
+++ b/docs/modules/panels/api-reference/panel-modal.md
@@ -50,7 +50,14 @@ type PanelModalProps = PanelContainerProps & {
   triggerLabel?: string;
   triggerIcon?: string;
   showTitleBar?: boolean;
+  presentation?: 'modal' | 'floating';
+  draggable?: boolean;
+  dragHandleSelector?: string;
+  dialogStyle?: JSX.CSSProperties;
+  dialogPlacement?: 'center' | 'left';
+  contentStyle?: JSX.CSSProperties;
   hideTrigger?: boolean;
+  hideCloseButton?: boolean;
   button?: boolean;
   defaultOpen?: boolean;
   open?: boolean;
@@ -65,6 +72,11 @@ type PanelModalProps = PanelContainerProps & {
 - Accepts one reusable panel definition.
 - Supports controlled and uncontrolled open state.
 - Closes on backdrop click and `Escape`.
+- Use `presentation: 'floating'` for non-blocking dialogs.
+- Use `dialogPlacement: 'left'`, `dialogStyle`, and `contentStyle` to tune
+  larger custom dialogs.
+- Set `hideCloseButton` when panel content renders its own
+  `data-modal-widget-close="true"` close control.
 - `openShortcuts` are installed through `deck.eventManager` when available and
   open the modal without importing deck.gl into `@deck.gl-community/panels`.
 - `shortcuts` are also registered through the same manager and keep their own

--- a/docs/modules/panels/api-reference/settings-manager.md
+++ b/docs/modules/panels/api-reference/settings-manager.md
@@ -1,0 +1,58 @@
+# SettingsManager
+
+<p className="badges">
+  <img src="https://img.shields.io/badge/from-v9.3-green.svg?style=flat-square" alt="from v9.3" />
+</p>
+
+`SettingsManager` is a UI-agnostic helper for tracking settings snapshots,
+emitting structured change descriptors, and persisting descriptor-backed values
+to local storage.
+
+## Import
+
+```ts
+import {
+  SettingsManager,
+  settingsManager,
+  type SettingsChangeDescriptor,
+  type SettingsManagerOnChange
+} from '@deck.gl-community/panels';
+```
+
+## Usage
+
+```ts
+const manager = new SettingsManager();
+
+manager.setSettingDefinitions(
+  new Map(schema.sections.flatMap((section) => section.settings.map((setting) => [setting.name, setting])))
+);
+
+manager.setCurrentSettings(settings);
+manager.setOnSettingsChange((nextSettings, changedSettings) => {
+  console.log(nextSettings, changedSettings);
+});
+
+manager.setSettingValue('render.opacity', 0.5);
+```
+
+## Persistence
+
+```ts
+manager.setLocalStoragePersistence({
+  storageKey: 'my-settings'
+});
+```
+
+Settings persist to local storage by default. Set `persist: 'url'` or
+`persist: 'none'` on a setting descriptor when a value should not be written by
+the local-storage persistence path.
+
+## Remarks
+
+- `setSettingValue` resolves values through the registered descriptor before
+  emitting changes.
+- `setSettings` accepts a full settings snapshot and emits one descriptor per
+  known value that changed.
+- `getSettingsWithLocalStorage` overlays stored values onto a caller-provided
+  settings snapshot.

--- a/docs/modules/panels/api-reference/settings-panel.md
+++ b/docs/modules/panels/api-reference/settings-panel.md
@@ -45,6 +45,11 @@ type SettingsPanelProps = {
 };
 ```
 
+Settings schema descriptors may include `group` for richer panels,
+`persist: 'local-storage' | 'url' | 'none'` for manager persistence policy, and
+numeric descriptors may include `sliderDebounceMs` to apply a trailing debounce
+to range-slider input events while keeping direct numeric entry immediate.
+
 ## See Also
 
 - [Using Panels](../developer-guide/using-panels.md)
@@ -54,3 +59,5 @@ type SettingsPanelProps = {
 - Reuses the shared schema-driven controls as a panel.
 - Tracks section collapse state while the panel stays mounted.
 - Supports nested dot-path setting names and change descriptors in `onSettingsChange`.
+- Pair with [SettingsManager](./settings-manager.md) when settings snapshots
+  should emit structured change descriptors or persist through local storage.

--- a/docs/modules/panels/api-reference/studio-settings-panel.md
+++ b/docs/modules/panels/api-reference/studio-settings-panel.md
@@ -1,0 +1,58 @@
+# StudioSettingsPanel
+
+<p className="badges">
+  <img src="https://img.shields.io/badge/from-v9.3-green.svg?style=flat-square" alt="from v9.3" />
+</p>
+
+`StudioSettingsPanel` renders a dense schema-driven settings surface with a
+section rail, compact mode, grouped settings, and a visual dependency-shape
+selector for a `lineRoutingMode` setting.
+
+## Import
+
+```ts
+import {
+  StudioSettingsPanel,
+  createStudioSettingsPanel,
+  type StudioSettingsPanelProps
+} from '@deck.gl-community/panels';
+```
+
+## Props
+
+```ts
+type StudioSettingsPanelProps = {
+  schema: SettingsSchema;
+  applicationSchema?: SettingsSchema;
+  fontFamily?: string;
+  settings: SettingsState;
+  onSettingsChange?: SettingsManagerOnChange;
+  presetLabel?: string;
+};
+```
+
+`schema` supplies visualization controls. `applicationSchema` is rendered as a
+separate rail group for app-level controls. Setting descriptors may include
+`group` to organize rows within a section and `sliderDebounceMs` for numeric
+range controls.
+
+## Panel Factory
+
+```ts
+const panel = createStudioSettingsPanel({
+  schema,
+  settings,
+  onSettingsChange: manager.setSettings.bind(manager)
+});
+```
+
+The factory returns a deck-independent `Panel` object that can be used with
+`PanelModal`, `PanelSidebar`, or any panel container.
+
+## Remarks
+
+- The panel is deck.gl-independent and lives in `@deck.gl-community/panels`.
+- The close button emits `data-modal-widget-close="true"` so `PanelModal` can
+  close from content when built-in modal chrome is hidden.
+- Compact mode is remembered in `localStorage` under the
+  `deck.gl-community:studio-settings:navigation-collapsed` key.

--- a/docs/modules/panels/sidebar.json
+++ b/docs/modules/panels/sidebar.json
@@ -19,6 +19,8 @@
         "modules/panels/api-reference/panel-manager",
         "modules/panels/api-reference/panel-theme",
         "modules/panels/api-reference/toast-manager",
+        "modules/panels/api-reference/settings-manager",
+        "modules/panels/api-reference/command-manager",
         "modules/panels/api-reference/keyboard-shortcuts-manager",
         "modules/panels/api-reference/url-manager"
       ]
@@ -35,6 +37,7 @@
         "modules/panels/api-reference/markdown-panel",
         "modules/panels/api-reference/stats-panel",
         "modules/panels/api-reference/settings-panel",
+        "modules/panels/api-reference/studio-settings-panel",
         "modules/panels/api-reference/documentation-links-panel",
         "modules/panels/api-reference/text-editor-panel",
         "modules/panels/api-reference/url-parameters-panel"

--- a/docs/modules/widgets/api-reference/modal-widget.md
+++ b/docs/modules/widgets/api-reference/modal-widget.md
@@ -50,7 +50,14 @@ type ModalPanelWidgetProps = WidgetProps & {
   title?: string;
   triggerLabel?: string;
   triggerIcon?: string;
+  presentation?: 'modal' | 'floating';
+  draggable?: boolean;
+  dragHandleSelector?: string;
+  dialogStyle?: JSX.CSSProperties;
+  dialogPlacement?: 'center' | 'left';
+  contentStyle?: JSX.CSSProperties;
   hideTrigger?: boolean;
+  hideCloseButton?: boolean;
   button?: boolean;
   defaultOpen?: boolean;
   open?: boolean;
@@ -64,4 +71,6 @@ type ModalPanelWidgetProps = WidgetProps & {
 - Can render with the built-in icon trigger or be controlled externally.
 - Supports controlled and uncontrolled open state.
 - Closes on backdrop click and `Escape`.
+- Supports non-blocking floating dialogs, left-biased placement, custom dialog
+  sizing, and content-rendered close controls.
 - Raises its placement container while open so the dialog stays above neighboring widgets.

--- a/docs/modules/widgets/api-reference/omni-box-widget.md
+++ b/docs/modules/widgets/api-reference/omni-box-widget.md
@@ -17,7 +17,8 @@ import {
   OmniBoxWidget,
   type OmniBoxOption,
   type OmniBoxOptionProvider,
-  type OmniBoxRenderOptionArgs
+  type OmniBoxRenderOptionArgs,
+  type OmniBoxResultsSummaryArgs
 } from '@deck.gl-community/widgets';
 ```
 
@@ -42,6 +43,12 @@ export type OmniBoxRenderOptionArgs = {
   isActive: boolean;
   query: string;
 };
+
+export type OmniBoxResultsSummaryArgs = {
+  readonly query: string;
+  readonly options: ReadonlyArray<OmniBoxOption>;
+  readonly mode: 'search' | 'command' | 'history';
+};
 ```
 
 ## Props
@@ -60,6 +67,7 @@ type OmniBoxWidgetProps = WidgetProps & {
   topOffsetPx?: number;
   getOptions?: OmniBoxOptionProvider;
   renderOption?: (args: OmniBoxRenderOptionArgs) => ComponentChildren;
+  renderResultsSummary?: (args: OmniBoxResultsSummaryArgs) => ComponentChildren;
   onSelectOption?: (option: OmniBoxOption) => void;
   onActiveOptionChange?: (option: OmniBoxOption | null) => void;
   onNavigateOption?: (option: OmniBoxOption) => void;
@@ -78,6 +86,7 @@ const widget = new OmniBoxWidget({
   queryHistoryStorageKey: 'example-search-history',
   minQueryLength: 1,
   getOptions: (query) => searchItems(query),
+  renderResultsSummary: ({options}) => `${options.length} matches`,
   onSelectOption: (option) => selectItem((option.data as any).id),
   onNavigateOption: (option) => previewItem((option.data as any).id)
 });
@@ -97,4 +106,5 @@ This widget is intentionally generic. Callers provide search options, selection 
 - Can render a compact slash anchor button while closed.
 - Can keep the result list open after selection with `closeOnSelect: false`.
 - Can remember recent selected queries in `localStorage`.
+- Can render a caller-provided summary row above the dropdown results.
 - Closes on blur after a short delay so option clicks can still land.

--- a/docs/modules/widgets/api-reference/settings-panel.md
+++ b/docs/modules/widgets/api-reference/settings-panel.md
@@ -43,6 +43,10 @@ type SettingsPanelProps = {
 };
 ```
 
+Settings descriptors may include `group` for richer panels,
+`persist: 'local-storage' | 'url' | 'none'` for manager persistence policy, and
+numeric descriptors may include `sliderDebounceMs` for trailing range-slider
+debounce.
 
 ## Usage
 
@@ -57,3 +61,6 @@ Use `SettingsPanel` when a settings form should live inside `SidebarPanelWidget`
 - Reuses the shared schema-driven controls inside the panel composition model.
 - Tracks section collapse state while the panel stays mounted.
 - Supports nested dot-path setting names and change descriptors in `onSettingsChange`.
+- Pair with `SettingsManager` from `@deck.gl-community/panels` when settings
+  snapshots should emit structured change descriptors or persist through local
+  storage.

--- a/docs/modules/widgets/api-reference/studio-settings-widget.md
+++ b/docs/modules/widgets/api-reference/studio-settings-widget.md
@@ -1,0 +1,49 @@
+# StudioSettingsWidget
+
+<p className="badges">
+  <img src="https://img.shields.io/badge/from-v9.3-green.svg?style=flat-square" alt="from v9.3" />
+</p>
+
+`StudioSettingsWidget` helpers create and update a floating deck widget around
+`StudioSettingsPanel`.
+
+## Import
+
+```ts
+import {
+  createStudioSettingsWidget,
+  updateStudioSettingsWidget,
+  type StudioSettingsWidgetProps
+} from '@deck.gl-community/widgets';
+```
+
+## Usage
+
+```ts
+const widget = createStudioSettingsWidget({
+  schema,
+  settings,
+  onSettingsChange,
+  placement: 'top-left'
+});
+
+deck.setProps({widgets: [widget]});
+```
+
+`createStudioSettingsWidget` returns a `ModalPanelWidget` configured as a
+non-blocking floating modal. It uses the Studio panel's header as the drag
+handle and hides the modal chrome close button because the panel renders its
+own close action.
+
+## Updating
+
+```ts
+updateStudioSettingsWidget(widget, {
+  schema,
+  settings: nextSettings,
+  onSettingsChange
+});
+```
+
+Use `updateStudioSettingsWidget` when the schema or settings snapshot changes
+and the deck widget instance should be preserved.

--- a/docs/modules/widgets/sidebar.json
+++ b/docs/modules/widgets/sidebar.json
@@ -54,6 +54,7 @@
             "modules/widgets/api-reference/box-widget",
             "modules/widgets/api-reference/full-screen-panel-widget",
             "modules/widgets/api-reference/modal-widget",
+            "modules/widgets/api-reference/studio-settings-widget",
             "modules/widgets/api-reference/sidebar-widget"
           ]
         }

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -15,8 +15,19 @@ A new module for deck-independent panel composition and small application UI.
 - `ArrowTablePanel` - NEW reusable panel for bounded Apache Arrow table previews with a row-limit summary.
 - `ArrowSchemaPanel` - NEW reusable panel for Apache Arrow schema inspection, including schema and field metadata with JSON metadata formatting.
 - `SplitterPanel` - NEW composite panel for resizing two panel groups horizontally or vertically.
+- `StudioSettingsPanel` - NEW schema-driven settings surface with grouped controls, compact navigation, and visual routing-shape controls.
+- `SettingsManager` - NEW UI-agnostic helper for settings snapshots, structured change descriptors, and descriptor-aware local storage persistence.
+- `CommandManager` - NEW shared command registry for keyboard shortcuts, widgets, and host automation surfaces.
 - Panel APIs now use panel terminology throughout `@deck.gl-community/panels`; deck.gl widget-facing wrappers remain in `@deck.gl-community/widgets`.
 - Composite panels now accept ordered `Panel[]` arrays, shell containers render direct `panel` inputs, and the redundant descriptor/`WidgetHost` surfaces are removed.
+- `PanelModal` now supports floating non-blocking dialogs, draggable dialog handles, left placement, custom dialog/content styles, and content-rendered close controls.
+- `SettingsPanel` numeric range inputs can apply descriptor-level trailing debounce via `sliderDebounceMs`.
+
+### `@deck.gl-community/widgets`
+
+- `createStudioSettingsWidget` and `updateStudioSettingsWidget` - NEW helpers for hosting `StudioSettingsPanel` in a floating deck widget.
+- `OmniBoxWidget` now accepts `renderResultsSummary` for rendering a compact caller-provided summary above dropdown results.
+- `ModalPanelWidget` inherits floating, draggable, custom-styled modal support from `PanelModal`.
 
 ## v9.3
 

--- a/modules/panels/src/index.ts
+++ b/modules/panels/src/index.ts
@@ -6,7 +6,12 @@ export {PanelContainer} from './panel-container';
 export type {PanelContainerProps, PanelPlacement} from './panel-container';
 export {PanelManager, type PanelManagerProps} from './panel-manager';
 export {PanelBox, type PanelBoxProps} from './panel-components/panel-box';
-export {PanelModal, type PanelModalProps} from './panel-components/panel-modal';
+export {
+  PanelModal,
+  type PanelModalDialogPlacement,
+  type PanelModalPresentation,
+  type PanelModalProps
+} from './panel-components/panel-modal';
 export {PanelSidebar, type PanelSidebarProps} from './panel-components/panel-sidebar';
 export {PanelFullScreen, type PanelFullScreenProps} from './panel-components/panel-full-screen';
 
@@ -45,6 +50,16 @@ export {
 } from './panels/panel-containers';
 
 export {SettingsPanel, type SettingsPanelProps} from './panels/settings-panel';
+export {
+  StudioSettingsIcon,
+  StudioSettingsPanel,
+  createStudioSettingsPanel,
+  type StudioDependencyShape,
+  type StudioSettingsIconName,
+  type StudioSettingsIconProps,
+  type StudioSettingsPanelProps,
+  type StudioSettingsTabId
+} from './panels/studio-settings-panel';
 export {StatsPanel, type StatsPanelProps} from './panels/stats-panel';
 export {BinaryDataPanel, type BinaryDataPanelProps} from './panels/binary-data-panel';
 export {
@@ -100,11 +115,49 @@ export {
 } from './panels/toast-manager';
 
 export {
+  buildInitialCollapsedState,
+  clamp,
+  filterSettingsSchemaByPersistence,
+  getDefaultValue,
+  getInitialCollapsedState,
+  getSectionKey,
+  getSettingPersistenceTarget,
+  getValueAtPath,
+  mergeCollapsedState,
+  normalizeOption,
+  partitionSettingsSchemaByPersistence,
+  resolveSettingValue,
+  setValueAtPath,
+  type PartitionedSettingsSchema,
   type SettingDescriptor,
+  type SettingOption,
+  type SettingPersistenceTarget,
+  type SettingType,
+  type SettingValue,
+  type SettingsOption,
   type SettingsSchema,
   type SettingsSectionDescriptor,
   type SettingsState
 } from './lib/settings/settings';
+export {
+  SettingsManager,
+  settingsManager,
+  type SettingsChangeDescriptor,
+  type SettingsManagerLocalStorageConfig,
+  type SettingsManagerOnChange
+} from './lib/settings/settings-manager';
+export {
+  CommandManager,
+  commandManager,
+  type CommandArgsSchema,
+  type CommandAutomationSupport,
+  type CommandDefinition,
+  type CommandDescriptor,
+  type CommandState,
+  type ExecuteCommandAsyncOptions,
+  type InstallCommandAutomationOptions,
+  type ListCommandsOptions
+} from './lib/commands/command-manager';
 export {
   type KeyboardShortcutDisplayPair,
   type KeyboardShortcutDisplaySection,

--- a/modules/panels/src/lib/commands/command-manager.test.ts
+++ b/modules/panels/src/lib/commands/command-manager.test.ts
@@ -1,0 +1,223 @@
+import {describe, expect, it, vi} from 'vitest';
+import {z} from 'zod';
+
+import {CommandManager} from './command-manager';
+
+describe('CommandManager', () => {
+  it('lists command metadata and filters by exposure', () => {
+    const manager = new CommandManager();
+    manager.registerCommand({
+      id: 'test.user',
+      label: 'User',
+      do: () => undefined
+    });
+    manager.registerCommand({
+      id: 'test.automation',
+      label: 'Automation',
+      description: 'Externally visible test command.',
+      exposure: 'automation',
+      argsSchema: z.object({value: z.string()}),
+      do: () => undefined
+    });
+    manager.registerCommand({
+      id: 'test.all',
+      label: 'All',
+      exposure: 'all',
+      do: () => undefined
+    });
+
+    expect(manager.listCommands()).toEqual([
+      {
+        id: 'test.user',
+        label: 'User',
+        description: undefined,
+        exposure: 'user',
+        acceptsArgs: false,
+        isEnabled: true
+      },
+      {
+        id: 'test.automation',
+        label: 'Automation',
+        description: 'Externally visible test command.',
+        exposure: 'automation',
+        acceptsArgs: true,
+        isEnabled: true
+      },
+      {
+        id: 'test.all',
+        label: 'All',
+        description: undefined,
+        exposure: 'all',
+        acceptsArgs: false,
+        isEnabled: true
+      }
+    ]);
+    expect(manager.listCommands({exposure: 'user'}).map(command => command.id)).toEqual([
+      'test.user',
+      'test.all'
+    ]);
+    expect(manager.listCommands({exposure: 'automation'}).map(command => command.id)).toEqual([
+      'test.automation',
+      'test.all'
+    ]);
+    expect(manager.getCommand('test.automation')).toMatchObject({
+      id: 'test.automation',
+      exposure: 'automation',
+      acceptsArgs: true
+    });
+  });
+
+  it('executes and undoes synchronous commands', () => {
+    const manager = new CommandManager();
+    const handleDo = vi.fn();
+    const handleUndo = vi.fn();
+    const state = {source: 'test'};
+
+    manager.registerCommand({
+      id: 'test.sync',
+      do: handleDo,
+      undo: handleUndo
+    });
+
+    manager.executeCommand('test.sync', state);
+    manager.undoCommand('test.sync', state);
+    manager.executeCommand('test.missing', state);
+    manager.undoCommand('test.missing', state);
+
+    expect(handleDo).toHaveBeenCalledTimes(1);
+    expect(handleDo).toHaveBeenCalledWith(state);
+    expect(handleUndo).toHaveBeenCalledTimes(1);
+    expect(handleUndo).toHaveBeenCalledWith(state);
+  });
+
+  it('unregisters only the command implementation that created the cleanup callback', () => {
+    const manager = new CommandManager();
+    const first = vi.fn();
+    const second = vi.fn();
+    const unregisterFirst = manager.registerCommand({id: 'test.replace', do: first});
+    const unregisterSecond = manager.registerCommand({id: 'test.replace', do: second});
+
+    unregisterFirst();
+    manager.executeCommand('test.replace');
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+
+    unregisterSecond();
+    expect(manager.hasCommand('test.replace')).toBe(false);
+  });
+
+  it('installs automation globals and records support metadata', () => {
+    const manager = new CommandManager();
+    const target: Record<string, unknown> = {};
+    const facade = {version: 1};
+    const uninstall = manager.installAutomation('deckTools', facade, {
+      id: 'test.deck-tools',
+      label: 'Deck tools automation',
+      requestType: 'deck-tools:command',
+      responseType: 'deck-tools:result',
+      target
+    });
+
+    expect(target.deckTools).toBe(facade);
+    expect(manager.listAutomationSupport()).toEqual([
+      {
+        id: 'test.deck-tools',
+        label: 'Deck tools automation',
+        description: undefined,
+        globalName: 'deckTools',
+        requestType: 'deck-tools:command',
+        responseType: 'deck-tools:result'
+      }
+    ]);
+
+    uninstall();
+
+    expect(target.deckTools).toBeUndefined();
+    expect(manager.listAutomationSupport()).toEqual([]);
+  });
+
+  it('executes automation commands with parsed arguments', async () => {
+    const manager = new CommandManager();
+    manager.registerCommand({
+      id: 'test.echo',
+      exposure: 'automation',
+      argsSchema: z.object({value: z.string()}),
+      do: args => ({echoed: args?.value})
+    });
+
+    await expect(
+      manager.executeCommandAsync('test.echo', {value: 'ok'}, {exposure: 'automation'})
+    ).resolves.toEqual({echoed: 'ok'});
+  });
+
+  it('rejects commands that are missing, user-only, invalid, disabled, or throwing', async () => {
+    const manager = new CommandManager();
+    manager.registerCommand({id: 'test.user', do: () => undefined});
+    manager.registerCommand({
+      id: 'test.invalid',
+      exposure: 'automation',
+      argsSchema: z.object({value: z.string()}),
+      do: () => undefined
+    });
+    manager.registerCommand({
+      id: 'test.disabled',
+      exposure: 'automation',
+      isEnabled: () => false,
+      do: () => undefined
+    });
+    manager.registerCommand({
+      id: 'test.throwing',
+      exposure: 'automation',
+      do: () => {
+        throw new Error('boom');
+      }
+    });
+
+    const missingResult = await manager.executeCommandAsync(
+      'test.missing',
+      {},
+      {exposure: 'automation'}
+    );
+    expect(missingResult).toMatchObject({
+      message: 'Command not found: test.missing'
+    });
+
+    const userOnlyResult = await manager.executeCommandAsync(
+      'test.user',
+      {},
+      {exposure: 'automation'}
+    );
+    expect(userOnlyResult).toMatchObject({
+      message: 'Command is not exposed as automation.'
+    });
+
+    const invalidResult = await manager.executeCommandAsync(
+      'test.invalid',
+      {value: 1},
+      {exposure: 'automation'}
+    );
+    expect(invalidResult).toMatchObject({
+      message: 'Invalid arguments for command: test.invalid'
+    });
+    expect(invalidResult).toBeInstanceOf(Error);
+    expect((invalidResult as Error).cause).toBeInstanceOf(Error);
+
+    const disabledResult = await manager.executeCommandAsync(
+      'test.disabled',
+      {},
+      {exposure: 'automation'}
+    );
+    expect(disabledResult).toMatchObject({
+      message: 'Command is disabled: test.disabled'
+    });
+
+    const throwingResult = await manager.executeCommandAsync(
+      'test.throwing',
+      {},
+      {exposure: 'automation'}
+    );
+    expect(throwingResult).toMatchObject({
+      message: 'boom'
+    });
+  });
+});

--- a/modules/panels/src/lib/commands/command-manager.ts
+++ b/modules/panels/src/lib/commands/command-manager.ts
@@ -1,0 +1,268 @@
+/** Caller-provided payload passed into command execution and undo handlers. */
+export type CommandState = Record<string, unknown>;
+
+/** Minimal parser contract used to validate command arguments without coupling to one schema lib. */
+export type CommandArgsSchema = {
+  /** Parses one unknown argument payload. */
+  safeParse: (value: unknown) =>
+    | {
+        /** Whether parsing succeeded. */
+        success: true;
+        /** Parsed command arguments. */
+        data: CommandState;
+      }
+    | {
+        /** Whether parsing succeeded. */
+        success: false;
+        /** Parser-specific validation details. */
+        error: unknown;
+      };
+};
+
+/** Defines one named command implementation. */
+export type CommandDefinition = {
+  /** Stable command identifier used by shortcuts and widgets. */
+  id: string;
+  /** Human-readable command label used by automation and help surfaces. */
+  label?: string;
+  /** Longer command description used by automation and help surfaces. */
+  description?: string;
+  /** Visibility policy for user-facing UI surfaces and external automation. */
+  exposure?: 'user' | 'automation' | 'all';
+  /** Optional schema used to validate command arguments before execution. */
+  argsSchema?: CommandArgsSchema;
+  /** Runtime guard for whether the command may execute with the current app state. */
+  isEnabled?: (state?: CommandState) => boolean;
+  /** Executes the command with optional caller-provided state. */
+  do: (state?: CommandState) => unknown | Promise<unknown>;
+  /** Reverses the command with optional caller-provided state. */
+  undo?: (state?: CommandState) => unknown | Promise<unknown>;
+};
+
+/** Public command metadata derived from a command definition, without handlers or raw schemas. */
+export type CommandDescriptor = Pick<CommandDefinition, 'id' | 'label' | 'description'> & {
+  /** Visibility policy for user-facing UI surfaces and external automation. */
+  exposure: NonNullable<CommandDefinition['exposure']>;
+  /** Whether the command has an argument schema. */
+  acceptsArgs: boolean;
+  /** Whether the command is enabled before evaluating any caller-provided args. */
+  isEnabled: boolean;
+};
+
+/** Host-provided automation surface metadata rendered in command documentation. */
+export type CommandAutomationSupport = {
+  /** Stable automation surface id. */
+  id: string;
+  /** Human-readable automation surface label. */
+  label: string;
+  /** Brief description of what the automation surface exposes. */
+  description?: string;
+  /** Browser global name, when the host installs one. */
+  globalName?: string;
+  /** postMessage request type, when the host supports message-based commands. */
+  requestType?: string;
+  /** postMessage response type, when the host supports message-based commands. */
+  responseType?: string;
+};
+
+/** Options for installing a host automation global. */
+export type InstallCommandAutomationOptions = Omit<
+  CommandAutomationSupport,
+  'id' | 'label' | 'globalName'
+> & {
+  /** Stable automation surface id. Defaults to the global name. */
+  id?: string;
+  /** Human-readable automation surface label. Defaults to the global name. */
+  label?: string;
+  /** Object receiving the automation global. Defaults to `globalThis`. */
+  target?: Record<string, unknown>;
+};
+
+/** Filter options for command listing. */
+export type ListCommandsOptions = {
+  /** Optional exposure filter. */
+  exposure?: CommandDescriptor['exposure'];
+};
+
+/** Options for structured async command execution. */
+export type ExecuteCommandAsyncOptions = {
+  /** Required command exposure for this execution path. */
+  exposure?: CommandDescriptor['exposure'];
+};
+
+/** Registry and dispatcher for app commands shared by shortcuts and widgets. */
+export class CommandManager {
+  /** Registered command implementations keyed by stable command id. */
+  readonly #commands = new Map<string, CommandDefinition>();
+  /** Registered host automation surfaces keyed by stable surface id. */
+  readonly #automationSupport = new Map<string, CommandAutomationSupport>();
+
+  /** Registers or replaces one command implementation. */
+  registerCommand(command: CommandDefinition): () => void {
+    this.#commands.set(command.id, command);
+    return () => {
+      if (this.#commands.get(command.id) === command) {
+        this.#commands.delete(command.id);
+      }
+    };
+  }
+
+  /** Returns whether a command id currently has an implementation. */
+  hasCommand(id: string): boolean {
+    return this.#commands.has(id);
+  }
+
+  /** Installs one host automation global and returns a cleanup callback. */
+  installAutomation(
+    globalName: string,
+    value: unknown,
+    options: InstallCommandAutomationOptions
+  ): () => void {
+    const target = options.target ?? (globalThis as unknown as Record<string, unknown>);
+    const support = {
+      id: options.id ?? globalName,
+      label: options.label ?? globalName,
+      description: options.description,
+      globalName,
+      requestType: options.requestType,
+      responseType: options.responseType
+    };
+    target[globalName] = value;
+    this.#automationSupport.set(support.id, support);
+    return () => {
+      if (this.#automationSupport.get(support.id) === support) {
+        this.#automationSupport.delete(support.id);
+      }
+      if (target[globalName] === value) {
+        delete target[globalName];
+      }
+    };
+  }
+
+  /** Lists host automation surfaces known to this command manager. */
+  listAutomationSupport(): CommandAutomationSupport[] {
+    return [...this.#automationSupport.values()].map(support => ({...support}));
+  }
+
+  /** Lists command metadata, optionally filtered by exposure. */
+  listCommands(options: ListCommandsOptions = {}): CommandDescriptor[] {
+    const commands: CommandDescriptor[] = [];
+    for (const command of this.#commands.values()) {
+      const exposure = command.exposure ?? 'user';
+      const descriptor = {
+        id: command.id,
+        label: command.label,
+        description: command.description,
+        exposure,
+        acceptsArgs: Boolean(command.argsSchema),
+        isEnabled: command.isEnabled ? command.isEnabled() : true
+      };
+      const matchesExposure =
+        !options.exposure ||
+        exposure === options.exposure ||
+        (exposure === 'all' && options.exposure !== 'all');
+      if (!matchesExposure) {
+        continue;
+      }
+      commands.push(descriptor);
+    }
+    return commands;
+  }
+
+  /** Returns public command metadata for one command id. */
+  getCommand(id: string): CommandDescriptor | null {
+    const command = this.#commands.get(id);
+    return command
+      ? {
+          id: command.id,
+          label: command.label,
+          description: command.description,
+          exposure: command.exposure ?? 'user',
+          acceptsArgs: Boolean(command.argsSchema),
+          isEnabled: command.isEnabled ? command.isEnabled() : true
+        }
+      : null;
+  }
+
+  /** Executes a registered command and returns the handler result or an error. */
+  executeCommand(id: string, state?: CommandState): unknown | Error {
+    const command = this.#commands.get(id);
+    if (!command) {
+      return new Error(`Command not found: ${id}`);
+    }
+    let parsedState = state;
+    if (command.argsSchema) {
+      const parsed = command.argsSchema.safeParse(state);
+      if (parsed.success === false) {
+        return new Error(`Invalid arguments for command: ${id}`, {cause: parsed.error});
+      }
+      parsedState = parsed.data;
+    }
+    if (command.isEnabled && !command.isEnabled(parsedState)) {
+      return new Error(`Command is disabled: ${id}`);
+    }
+    try {
+      return command.do(parsedState);
+    } catch (error) {
+      return error instanceof Error ? error : new Error(String(error), {cause: error});
+    }
+  }
+
+  /** Executes a registered command's undo handler and returns the handler result or an error. */
+  undoCommand(id: string, state?: CommandState): unknown | Error {
+    const command = this.#commands.get(id);
+    if (!command) {
+      return new Error(`Command not found: ${id}`);
+    }
+    if (!command.undo) {
+      return new Error(`Command has no undo handler: ${id}`);
+    }
+    try {
+      return command.undo(state);
+    } catch (error) {
+      return error instanceof Error ? error : new Error(String(error), {cause: error});
+    }
+  }
+
+  /** Executes a command asynchronously and returns the awaited handler result or an error. */
+  async executeCommandAsync(
+    id: string,
+    state?: CommandState,
+    options: ExecuteCommandAsyncOptions = {}
+  ): Promise<unknown | Error> {
+    const command = this.#commands.get(id);
+    if (!command) {
+      return new Error(`Command not found: ${id}`);
+    }
+    const exposure = command.exposure ?? 'user';
+    const matchesExposure =
+      !options.exposure ||
+      exposure === options.exposure ||
+      (exposure === 'all' && options.exposure !== 'all');
+    if (!matchesExposure) {
+      return new Error(`Command is not exposed as ${options.exposure}.`);
+    }
+
+    let parsedState = state;
+    if (command.argsSchema) {
+      const parsed = command.argsSchema.safeParse(state);
+      if (parsed.success === false) {
+        return new Error(`Invalid arguments for command: ${id}`, {cause: parsed.error});
+      }
+      parsedState = parsed.data;
+    }
+
+    if (command.isEnabled && !command.isEnabled(parsedState)) {
+      return new Error(`Command is disabled: ${id}`);
+    }
+
+    try {
+      return await command.do(parsedState);
+    } catch (error) {
+      return error instanceof Error ? error : new Error(String(error), {cause: error});
+    }
+  }
+}
+
+/** Shared command manager used by deck widgets and shortcut bindings. */
+export const commandManager = new CommandManager();

--- a/modules/panels/src/lib/settings/settings-manager.test.ts
+++ b/modules/panels/src/lib/settings/settings-manager.test.ts
@@ -1,0 +1,329 @@
+import {describe, expect, it, vi} from 'vitest';
+
+import {SettingsManager} from './settings-manager';
+
+import type {SettingDescriptor} from './settings';
+
+describe('SettingsManager', () => {
+  it('overlays stored local storage settings unless a descriptor opts out', () => {
+    const manager = new SettingsManager();
+    const storage = makeMemoryStorage({
+      'panel-settings': JSON.stringify({
+        interactionMode: 'drag-to-pan',
+        layoutDensity: 'compact'
+      })
+    });
+    const interactionDescriptor: SettingDescriptor = {
+      name: 'interactionMode',
+      type: 'select',
+      options: ['drag-to-zoom', 'drag-to-pan']
+    };
+    const layoutDescriptor: SettingDescriptor = {
+      name: 'layoutDensity',
+      type: 'select',
+      persist: 'url',
+      options: ['comfortable', 'compact']
+    };
+
+    manager.setLocalStoragePersistence({
+      storageKey: 'panel-settings',
+      getStorage: () => storage
+    });
+
+    expect(
+      manager.getSettingsWithLocalStorage(
+        {interactionMode: 'drag-to-zoom', layoutDensity: 'comfortable'},
+        new Map([
+          ['interactionMode', interactionDescriptor],
+          ['layoutDensity', layoutDescriptor]
+        ])
+      )
+    ).toEqual({
+      interactionMode: 'drag-to-pan',
+      layoutDensity: 'comfortable'
+    });
+  });
+
+  it('normalizes invalid stored select values using descriptor options', () => {
+    const manager = new SettingsManager();
+    const storage = makeMemoryStorage({
+      'panel-settings': JSON.stringify({
+        interactionMode: 'removed-mode'
+      })
+    });
+    const interactionDescriptor: SettingDescriptor = {
+      name: 'interactionMode',
+      type: 'select',
+      options: ['drag-to-zoom', 'drag-to-pan']
+    };
+
+    manager.setLocalStoragePersistence({
+      storageKey: 'panel-settings',
+      getStorage: () => storage
+    });
+
+    expect(
+      manager.getSettingsWithLocalStorage(
+        {interactionMode: 'drag-to-zoom'},
+        new Map([['interactionMode', interactionDescriptor]])
+      )
+    ).toEqual({
+      interactionMode: 'drag-to-zoom'
+    });
+  });
+
+  it('persists settings to local storage by default', () => {
+    const manager = new SettingsManager();
+    const storage = makeMemoryStorage();
+    const interactionDescriptor: SettingDescriptor = {
+      name: 'interactionMode',
+      type: 'select',
+      options: ['drag-to-zoom', 'drag-to-pan']
+    };
+    const layoutDescriptor: SettingDescriptor = {
+      name: 'layoutDensity',
+      type: 'select',
+      options: ['comfortable', 'compact']
+    };
+
+    manager.setLocalStoragePersistence({
+      storageKey: 'panel-settings',
+      getStorage: () => storage
+    });
+    manager.setCurrentSettings({
+      interactionMode: 'drag-to-zoom',
+      layoutDensity: 'comfortable'
+    });
+    manager.setSettingDefinitions(
+      new Map([
+        ['interactionMode', interactionDescriptor],
+        ['layoutDensity', layoutDescriptor]
+      ])
+    );
+
+    manager.setSettings({
+      interactionMode: 'drag-to-pan',
+      layoutDensity: 'compact'
+    });
+
+    expect(storage.getItem('panel-settings')).toBe(
+      '{"interactionMode":"drag-to-pan","layoutDensity":"compact"}'
+    );
+  });
+
+  it('does not persist settings that explicitly opt out of local storage', () => {
+    const manager = new SettingsManager();
+    const storage = makeMemoryStorage();
+    const interactionDescriptor: SettingDescriptor = {
+      name: 'interactionMode',
+      type: 'select',
+      options: ['drag-to-zoom', 'drag-to-pan']
+    };
+    const layoutDescriptor: SettingDescriptor = {
+      name: 'layoutDensity',
+      type: 'select',
+      persist: 'url',
+      options: ['comfortable', 'compact']
+    };
+
+    manager.setLocalStoragePersistence({
+      storageKey: 'panel-settings',
+      getStorage: () => storage
+    });
+    manager.setCurrentSettings({
+      interactionMode: 'drag-to-zoom',
+      layoutDensity: 'comfortable'
+    });
+    manager.setSettingDefinitions(
+      new Map([
+        ['interactionMode', interactionDescriptor],
+        ['layoutDensity', layoutDescriptor]
+      ])
+    );
+
+    manager.setSettings({
+      interactionMode: 'drag-to-pan',
+      layoutDensity: 'compact'
+    });
+
+    expect(storage.getItem('panel-settings')).toBe('{"interactionMode":"drag-to-pan"}');
+  });
+
+  it('keeps persisted settings when partial widget updates omit them', () => {
+    const manager = new SettingsManager();
+    const storage = makeMemoryStorage({
+      'panel-settings': JSON.stringify({interactionMode: 'drag-to-pan'})
+    });
+    const interactionDescriptor: SettingDescriptor = {
+      name: 'interactionMode',
+      type: 'select',
+      options: ['drag-to-zoom', 'drag-to-pan']
+    };
+    const overviewDescriptor: SettingDescriptor = {
+      name: 'showOverview',
+      type: 'boolean'
+    };
+
+    manager.setLocalStoragePersistence({
+      storageKey: 'panel-settings',
+      getStorage: () => storage
+    });
+    manager.setCurrentSettings({
+      interactionMode: 'drag-to-pan',
+      showOverview: false
+    });
+    manager.setSettingDefinitions(
+      new Map([
+        ['interactionMode', interactionDescriptor],
+        ['showOverview', overviewDescriptor]
+      ])
+    );
+
+    manager.setSettings({showOverview: true});
+
+    expect(storage.getItem('panel-settings')).toBe(
+      '{"interactionMode":"drag-to-pan","showOverview":true}'
+    );
+  });
+
+  it('emits changes when a setting value changes', () => {
+    const manager = new SettingsManager();
+    const descriptor: SettingDescriptor = {
+      name: 'colorSchemeId',
+      type: 'select',
+      label: 'Color scheme',
+      options: ['a', 'b']
+    };
+
+    manager.setCurrentSettings({colorSchemeId: 'a'});
+    manager.setSettingDefinitions(new Map([['colorSchemeId', descriptor]]));
+
+    const onChange = vi.fn();
+    manager.setOnSettingsChange(onChange);
+
+    manager.setSettingValue('colorSchemeId', 'b');
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const [nextSettings, changedSettings] = onChange.mock.calls[0];
+    expect(nextSettings).toMatchObject({colorSchemeId: 'b'});
+    expect(changedSettings?.[0]).toMatchObject({
+      type: 'setting',
+      name: 'colorSchemeId',
+      previousValue: 'a',
+      nextValue: 'b',
+      descriptor
+    });
+  });
+
+  it('emits resolved descriptor values when a settings snapshot contains stale values', () => {
+    const manager = new SettingsManager();
+    const descriptor: SettingDescriptor = {
+      name: 'colorSchemeId',
+      type: 'select',
+      label: 'Color scheme',
+      options: ['a', 'b']
+    };
+
+    manager.setCurrentSettings({colorSchemeId: 'a'});
+    manager.setSettingDefinitions(new Map([['colorSchemeId', descriptor]]));
+
+    const onChange = vi.fn();
+    manager.setOnSettingsChange(onChange);
+
+    manager.setSettings({colorSchemeId: 'removed'});
+
+    expect(onChange).not.toHaveBeenCalled();
+
+    manager.setSettings({colorSchemeId: 'b'});
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const [nextSettings, changedSettings] = onChange.mock.calls[0];
+    expect(nextSettings).toMatchObject({colorSchemeId: 'b'});
+    expect(changedSettings?.[0]).toMatchObject({
+      type: 'setting',
+      name: 'colorSchemeId',
+      previousValue: 'a',
+      nextValue: 'b',
+      descriptor
+    });
+  });
+
+  it('skips emitting when no values change', () => {
+    const manager = new SettingsManager();
+    const descriptor: SettingDescriptor = {
+      name: 'layoutDensity',
+      type: 'select',
+      options: ['compact', 'comfortable']
+    };
+
+    manager.setCurrentSettings({layoutDensity: 'compact'});
+    manager.setSettingDefinitions(new Map([['layoutDensity', descriptor]]));
+
+    const onChange = vi.fn();
+    manager.setOnSettingsChange(onChange);
+
+    manager.setSettingValue('layoutDensity', 'compact');
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('computes change descriptors on setSettings', () => {
+    const manager = new SettingsManager();
+    const descriptor: SettingDescriptor = {
+      name: 'showOverview',
+      type: 'boolean'
+    };
+
+    manager.setCurrentSettings({showOverview: false});
+    manager.setSettingDefinitions(new Map([['showOverview', descriptor]]));
+
+    const onChange = vi.fn();
+    manager.setOnSettingsChange(onChange);
+
+    manager.setSettings({showOverview: true});
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const [, changedSettings] = onChange.mock.calls[0];
+    expect(changedSettings?.[0]).toMatchObject({
+      type: 'setting',
+      name: 'showOverview',
+      previousValue: false,
+      nextValue: true,
+      descriptor
+    });
+  });
+
+  it('notifies every registered change listener', () => {
+    const manager = new SettingsManager();
+    const descriptor: SettingDescriptor = {
+      name: 'colorSchemeId',
+      type: 'select',
+      options: ['a', 'b']
+    };
+    const firstListener = vi.fn();
+    const secondListener = vi.fn();
+
+    manager.setCurrentSettings({colorSchemeId: 'a'});
+    manager.setSettingDefinitions(new Map([['colorSchemeId', descriptor]]));
+    manager.setOnSettingsChange(firstListener);
+    manager.setOnSettingsChange(secondListener);
+
+    manager.setSettingValue('colorSchemeId', 'b');
+
+    expect(firstListener).toHaveBeenCalledTimes(1);
+    expect(secondListener).toHaveBeenCalledTimes(1);
+  });
+});
+
+function makeMemoryStorage(initialValues: Record<string, string> = {}) {
+  const values = new Map(Object.entries(initialValues));
+  return {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      values.delete(key);
+    })
+  } satisfies Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+}

--- a/modules/panels/src/lib/settings/settings-manager.ts
+++ b/modules/panels/src/lib/settings/settings-manager.ts
@@ -1,0 +1,324 @@
+import {
+  getSettingPersistenceTarget,
+  getValueAtPath,
+  resolveSettingValue,
+  setValueAtPath
+} from './settings';
+
+import type {SettingDescriptor, SettingsState, SettingValue} from './settings';
+
+/**
+ * Describes one tracked setting value transition emitted by a settings manager update.
+ */
+export type SettingsChangeDescriptor<Name extends string = string, Value = unknown> = {
+  /** Runtime discriminator for settings change event variants. */
+  type: 'setting';
+  /** Dot-path name of the setting that changed. */
+  name: Name;
+  /** Value before the change was applied. */
+  previousValue: Value | undefined;
+  /** Value after the change was applied. */
+  nextValue: Value;
+  /** Descriptor registered for the setting when available. */
+  descriptor?: SettingDescriptor<Name>;
+};
+
+/**
+ * Listener invoked after the manager applies one settings update.
+ */
+export type SettingsManagerOnChange<
+  Change extends SettingsChangeDescriptor = SettingsChangeDescriptor
+> = (
+  /** Full settings snapshot after the update. */
+  settings: SettingsState,
+  /** Tracked setting transitions included in this update. */
+  changedSettings?: Change[]
+) => void;
+
+type SettingDescriptorByName = Map<string, SettingDescriptor>;
+
+export type SettingsManagerLocalStorageConfig = {
+  /** Browser local storage key that stores settings unless the descriptor explicitly opts out. */
+  storageKey: string;
+  /** Optional storage provider used by tests or non-browser integrations. */
+  getStorage?: () => Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> | null | undefined;
+};
+
+/**
+ * Coordinates settings snapshots, change emission, and descriptor-aware local persistence.
+ */
+export class SettingsManager<Change extends SettingsChangeDescriptor = SettingsChangeDescriptor> {
+  #currentSettings: SettingsState = {};
+  #localStorageConfig?: SettingsManagerLocalStorageConfig;
+  #onSettingsChangeHandlers = new Set<SettingsManagerOnChange<Change>>();
+  #settingDefinitions: SettingDescriptorByName = new Map<string, SettingDescriptor>();
+
+  /**
+   * Configures the storage location used for descriptor-level local storage persistence.
+   */
+  setLocalStoragePersistence(config: SettingsManagerLocalStorageConfig | undefined): void {
+    this.#localStorageConfig = config;
+  }
+
+  /**
+   * Returns `settings` with stored values overlaid for descriptors persisted to local storage.
+   */
+  getSettingsWithLocalStorage(
+    settings: SettingsState,
+    definitionsByName: SettingDescriptorByName = this.#settingDefinitions
+  ): SettingsState {
+    const localStorageSettings = this.getLocalStorageSettings(definitionsByName);
+    let nextSettings = settings;
+
+    for (const [name, value] of Object.entries(localStorageSettings)) {
+      nextSettings = setValueAtPath(nextSettings, name, value);
+    }
+
+    return nextSettings;
+  }
+
+  /**
+   * Returns local storage values for descriptors persisted to local storage.
+   */
+  getLocalStorageSettings(
+    definitionsByName: SettingDescriptorByName = this.#settingDefinitions
+  ): Record<string, SettingValue> {
+    const storedValues = this.#readLocalStorageSettings();
+    const settings: Record<string, SettingValue> = {};
+
+    for (const [name, descriptor] of definitionsByName) {
+      const value = storedValues[name];
+      if (shouldPersistSetting(descriptor) && isSettingValue(value)) {
+        const storedSetting = setValueAtPath({}, name, value);
+        settings[name] = resolveSettingValue(descriptor, storedSetting);
+      }
+    }
+
+    return settings;
+  }
+
+  /**
+   * Replaces the current in-memory settings snapshot without emitting change events.
+   */
+  setCurrentSettings(settings: SettingsState): void {
+    this.#currentSettings = this.#resolveKnownSettings(settings);
+  }
+
+  /**
+   * Registers one change listener and returns an unsubscribe function.
+   */
+  setOnSettingsChange(handler: SettingsManagerOnChange<Change> | undefined): () => void {
+    if (!handler) {
+      return () => {
+        return;
+      };
+    }
+
+    this.#onSettingsChangeHandlers.add(handler);
+
+    return () => {
+      this.#onSettingsChangeHandlers.delete(handler);
+    };
+  }
+
+  /**
+   * Replaces the descriptor registry used for change tracking and persistence policy lookup.
+   */
+  setSettingDefinitions(definitionsByName: SettingDescriptorByName): void {
+    this.#settingDefinitions = new Map(definitionsByName);
+  }
+
+  /**
+   * Emits one settings change event and persists descriptor-backed values when needed.
+   */
+  emitSettingsChange(nextSettings: SettingsState, changedSettings?: Change[]): void {
+    const resolvedNextSettings = this.#resolveKnownSettings(nextSettings);
+    const resolvedChangedSettings =
+      changedSettings ?? this.#computeChangedSettings(resolvedNextSettings);
+
+    if (resolvedChangedSettings.length === 0) {
+      this.#currentSettings = resolvedNextSettings;
+      return;
+    }
+
+    this.#currentSettings = resolvedNextSettings;
+    this.#writeLocalStorageSettings(resolvedChangedSettings, resolvedNextSettings);
+    this.#onSettingsChangeHandlers.forEach(handler =>
+      handler(resolvedNextSettings, resolvedChangedSettings)
+    );
+  }
+
+  /**
+   * Applies one individual setting value change by dot-path.
+   */
+  setSettingValue(name: string, nextValue: unknown): void {
+    const descriptor = this.#settingDefinitions.get(name);
+    const candidateSettings = setValueAtPath(
+      this.#currentSettings,
+      name,
+      isSettingValue(nextValue) ? nextValue : ''
+    );
+    const resolvedNextValue = descriptor
+      ? resolveSettingValue(descriptor, candidateSettings)
+      : nextValue;
+    const previousValue = getValueAtPath(this.#currentSettings, name);
+    if (Object.is(previousValue, resolvedNextValue)) {
+      return;
+    }
+
+    const nextSettings = setValueAtPath(
+      this.#currentSettings,
+      name,
+      resolvedNextValue as SettingValue
+    );
+    const changedSettings: Change[] = [
+      {
+        type: 'setting',
+        name,
+        previousValue,
+        nextValue: resolvedNextValue,
+        descriptor
+      } as Change
+    ];
+
+    this.emitSettingsChange(nextSettings, changedSettings);
+  }
+
+  /**
+   * Applies one full settings snapshot and emits tracked changes.
+   */
+  setSettings(nextSettings: SettingsState): void {
+    this.emitSettingsChange(nextSettings);
+  }
+
+  /**
+   * Applies one full settings snapshot received from a widget callback.
+   * @deprecated Use setSettings instead.
+   */
+  setFromWidget(nextSettings: SettingsState): void {
+    this.setSettings(nextSettings);
+  }
+
+  #computeChangedSettings(nextSettings: SettingsState): Change[] {
+    const changedSettings: Change[] = [];
+
+    for (const [name, descriptor] of this.#settingDefinitions) {
+      const previousValue = getValueAtPath(this.#currentSettings, name);
+      const nextValue = getValueAtPath(nextSettings, name);
+
+      if (!Object.is(previousValue, nextValue)) {
+        changedSettings.push({
+          type: 'setting',
+          name,
+          previousValue,
+          nextValue,
+          descriptor
+        } as Change);
+      }
+    }
+
+    return changedSettings;
+  }
+
+  #resolveKnownSettings(settings: SettingsState): SettingsState {
+    let resolvedSettings = settings;
+
+    for (const [name, descriptor] of this.#settingDefinitions) {
+      if (getValueAtPath(settings, name) === undefined) {
+        continue;
+      }
+      resolvedSettings = setValueAtPath(
+        resolvedSettings,
+        name,
+        resolveSettingValue(descriptor, resolvedSettings)
+      );
+    }
+
+    return resolvedSettings;
+  }
+
+  #getStorage(): Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> | null {
+    if (this.#localStorageConfig?.getStorage) {
+      return this.#localStorageConfig.getStorage() ?? null;
+    }
+
+    if (typeof window === 'undefined') {
+      return null;
+    }
+
+    return window.localStorage;
+  }
+
+  #readLocalStorageSettings(): Record<string, unknown> {
+    const storageKey = this.#localStorageConfig?.storageKey;
+    const storage = this.#getStorage();
+    if (!storageKey || !storage) {
+      return {};
+    }
+
+    try {
+      const raw = storage.getItem(storageKey);
+      if (!raw) {
+        return {};
+      }
+      const parsed = JSON.parse(raw);
+      return isRecord(parsed) ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+
+  #writeLocalStorageSettings(
+    changedSettings: SettingsChangeDescriptor[],
+    nextSettings: SettingsState
+  ): void {
+    const storageKey = this.#localStorageConfig?.storageKey;
+    const storage = this.#getStorage();
+    if (!storageKey || !storage) {
+      return;
+    }
+
+    const storedSettings = this.#readLocalStorageSettings();
+    let changedPersistedSettings = false;
+
+    for (const change of changedSettings) {
+      if (!shouldPersistSetting(change.descriptor)) {
+        continue;
+      }
+
+      const nextValue = getValueAtPath(nextSettings, change.name);
+      if (isSettingValue(nextValue)) {
+        changedPersistedSettings = true;
+        storedSettings[change.name] = nextValue;
+      }
+    }
+
+    if (!changedPersistedSettings) {
+      return;
+    }
+
+    try {
+      if (Object.keys(storedSettings).length === 0) {
+        storage.removeItem(storageKey);
+        return;
+      }
+      storage.setItem(storageKey, JSON.stringify(storedSettings));
+    } catch {
+      // Ignore storage quota and privacy-mode failures.
+    }
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isSettingValue(value: unknown): value is SettingValue {
+  return typeof value === 'boolean' || typeof value === 'number' || typeof value === 'string';
+}
+
+function shouldPersistSetting(descriptor: SettingDescriptor | undefined): boolean {
+  return getSettingPersistenceTarget(descriptor) === 'local-storage';
+}
+
+export const settingsManager = new SettingsManager();

--- a/modules/panels/src/lib/settings/settings.ts
+++ b/modules/panels/src/lib/settings/settings.ts
@@ -1,26 +1,48 @@
+/** Primitive value supported by schema-driven settings controls. */
 export type SettingValue = boolean | number | string;
 
-export type SettingsOption =
-  | SettingValue
+/** Built-in control kinds supported by settings panels. */
+export type SettingType = 'boolean' | 'number' | 'string' | 'select';
+
+/** Persistence bucket used by settings managers and URL integrations. */
+export type SettingPersistenceTarget = 'local-storage' | 'url' | 'none';
+
+/** One selectable setting option, either as a raw value or label/value pair. */
+export type SettingOption<Value extends SettingValue = SettingValue> =
+  | Value
   | {
       label: string;
-      value: SettingValue;
+      value: Value;
     };
 
-export type SettingDescriptor = {
+/** Backwards-compatible alias for selectable setting options. */
+export type SettingsOption<Value extends SettingValue = SettingValue> = SettingOption<Value>;
+
+/** Describes one schema-driven setting control. */
+export type SettingDescriptor<
+  Name extends string = string,
+  Value extends SettingValue = SettingValue
+> = {
   /** Path in the settings object (dot notation supported). */
-  name: string;
+  name: Name;
   /** Human-friendly label shown in the control list. Defaults to `name`. */
   label?: string;
+  /** Optional visual group label used by richer settings panels. */
+  group?: string;
+  /** Persistence target used by settings managers and URL/shareable-link integrations. */
+  persist?: SettingPersistenceTarget;
   description?: string;
-  type: 'boolean' | 'number' | 'string' | 'select';
+  type: SettingType;
   min?: number;
   max?: number;
   step?: number;
-  options?: SettingsOption[];
-  defaultValue?: SettingValue;
+  /** Optional trailing debounce, in milliseconds, for numeric range-slider input events. */
+  sliderDebounceMs?: number;
+  options?: readonly SettingOption<Value>[];
+  defaultValue?: Value;
 };
 
+/** Describes one section of a settings schema. */
 export type SettingsSectionDescriptor = {
   /** Optional stable id for preserving collapse state across re-renders. */
   id?: string;
@@ -31,13 +53,36 @@ export type SettingsSectionDescriptor = {
   settings: SettingDescriptor[];
 };
 
+/** Full schema rendered by settings panels and consumed by settings managers. */
 export type SettingsSchema = {
   title?: string;
   sections: SettingsSectionDescriptor[];
 };
 
+/** Runtime settings snapshot keyed by setting path or nested object keys. */
 export type SettingsState = Record<string, unknown>;
 
+/** Settings schema split by each supported persistence target. */
+export type PartitionedSettingsSchema = Record<SettingPersistenceTarget, SettingsSchema>;
+
+/** Returns the value at `path` in a nested settings object without throwing. */
+export function getValueAtPath(settings: SettingsState, path: string): unknown {
+  const segments = parsePath(path);
+  if (!segments.length) {
+    return undefined;
+  }
+
+  let current: unknown = settings;
+  for (const segment of segments) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[segment];
+  }
+  return current;
+}
+
+/** Clamps a numeric setting value within optional bounds. */
 export function clamp(value: number, min?: number, max?: number): number {
   let clamped = value;
   if (Number.isFinite(min)) {
@@ -49,6 +94,7 @@ export function clamp(value: number, min?: number, max?: number): number {
   return clamped;
 }
 
+/** Returns a copy of `settings` with a primitive value written at `path`. */
 export function setValueAtPath(
   settings: SettingsState,
   path: string,
@@ -82,10 +128,27 @@ export function setValueAtPath(
   return nextSettings;
 }
 
+/** Returns the stable key used to preserve state for one settings section. */
 export function getSectionKey(section: SettingsSectionDescriptor, index: number): string {
-  return section.id ?? section.name ?? `section-${index}`;
+  const id = section.id?.trim();
+  if (id) {
+    return id;
+  }
+
+  const name = section.name?.trim();
+  if (name) {
+    return name;
+  }
+
+  return `section-${index}`;
 }
 
+/** Returns whether a section should start collapsed, defaulting to `true`. */
+export function getInitialCollapsedState(section: SettingsSectionDescriptor): boolean {
+  return section.initiallyCollapsed ?? true;
+}
+
+/** Builds initial collapsed state keyed by settings section id, name, or index. */
 export function buildInitialCollapsedState(
   sections: SettingsSectionDescriptor[]
 ): Record<string, boolean> {
@@ -95,6 +158,7 @@ export function buildInitialCollapsedState(
   }, {});
 }
 
+/** Normalizes a setting option into a label/value pair. */
 export function normalizeOption(option: SettingsOption): {
   label: string;
   value: SettingValue;
@@ -102,16 +166,90 @@ export function normalizeOption(option: SettingsOption): {
   if (isRecord(option) && 'label' in option && 'value' in option) {
     return {
       label: String(option.label),
-      value: option.value
+      value: option.value as SettingValue
     };
   }
 
   return {
     label: String(option),
-    value: option
+    value: option as SettingValue
   };
 }
 
+/** Returns the canonical persistence target for a setting descriptor. */
+export function getSettingPersistenceTarget(
+  setting: SettingDescriptor | undefined
+): SettingPersistenceTarget {
+  if (!setting) {
+    return 'local-storage';
+  }
+
+  if (setting.persist) {
+    return setting.persist;
+  }
+
+  return 'local-storage';
+}
+
+/** Returns a schema filtered to settings that match one persistence target. */
+export function filterSettingsSchemaByPersistence(
+  schema: SettingsSchema,
+  persist: SettingPersistenceTarget
+): SettingsSchema {
+  return {
+    ...schema,
+    sections: schema.sections.flatMap(section => {
+      const settings = section.settings.filter(
+        setting => getSettingPersistenceTarget(setting) === persist
+      );
+      return settings.length > 0
+        ? [
+            {
+              ...section,
+              settings
+            }
+          ]
+        : [];
+    })
+  };
+}
+
+/** Partitions one schema into per-persistence filtered schema copies. */
+export function partitionSettingsSchemaByPersistence(
+  schema: SettingsSchema
+): PartitionedSettingsSchema {
+  return {
+    'local-storage': filterSettingsSchemaByPersistence(schema, 'local-storage'),
+    url: filterSettingsSchemaByPersistence(schema, 'url'),
+    none: filterSettingsSchemaByPersistence(schema, 'none')
+  };
+}
+
+/** Returns a typed default value for a setting when explicit value is missing. */
+export function getDefaultValue(setting: SettingDescriptor): SettingValue {
+  if (setting.defaultValue !== undefined) {
+    return setting.defaultValue;
+  }
+
+  if (setting.type === 'boolean') {
+    return false;
+  }
+
+  if (setting.type === 'number') {
+    return Number.isFinite(setting.min) ? (setting.min as number) : 0;
+  }
+
+  if (setting.type === 'select') {
+    if (setting.options?.length) {
+      return normalizeOption(setting.options[0]).value;
+    }
+    return '';
+  }
+
+  return '';
+}
+
+/** Resolves the effective setting value from a settings snapshot and descriptor defaults. */
 // eslint-disable-next-line complexity
 export function resolveSettingValue(
   setting: SettingDescriptor,
@@ -159,6 +297,7 @@ export function resolveSettingValue(
   return typeof defaultValue === 'string' ? defaultValue : String(defaultValue);
 }
 
+/** Merges previous collapsed state with current section defaults. */
 export function mergeCollapsedState(
   previous: Record<string, boolean>,
   sections: SettingsSectionDescriptor[]
@@ -182,47 +321,4 @@ function parsePath(path: string): string[] {
     .split('.')
     .map(segment => segment.trim())
     .filter(Boolean);
-}
-
-function getValueAtPath(settings: SettingsState, path: string): unknown {
-  const segments = parsePath(path);
-  if (!segments.length) {
-    return undefined;
-  }
-
-  let current: unknown = settings;
-  for (const segment of segments) {
-    if (!isRecord(current)) {
-      return undefined;
-    }
-    current = current[segment];
-  }
-  return current;
-}
-
-function getInitialCollapsedState(section: SettingsSectionDescriptor): boolean {
-  return section.initiallyCollapsed ?? true;
-}
-
-function getDefaultValue(setting: SettingDescriptor): SettingValue {
-  if (setting.defaultValue !== undefined) {
-    return setting.defaultValue;
-  }
-
-  if (setting.type === 'boolean') {
-    return false;
-  }
-
-  if (setting.type === 'number') {
-    return Number.isFinite(setting.min) ? setting.min : 0;
-  }
-
-  if (setting.type === 'select') {
-    if (setting.options?.length) {
-      return normalizeOption(setting.options[0]).value;
-    }
-    return '';
-  }
-
-  return '';
 }

--- a/modules/panels/src/panel-components/panel-modal.test.tsx
+++ b/modules/panels/src/panel-components/panel-modal.test.tsx
@@ -1,0 +1,113 @@
+/** @jsxImportSource preact */
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {PanelModal} from './panel-modal';
+
+import type {Panel} from '../panels/panel-types';
+import type {PanelModalProps} from './panel-modal';
+
+const panel: Panel = {
+  id: 'help',
+  title: 'Help',
+  content: <div>help content</div>
+};
+
+function renderModal(props: Partial<PanelModalProps> = {}) {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  const modal = new PanelModal({
+    panel,
+    defaultOpen: true,
+    ...props
+  });
+  modal.onRenderHTML(root);
+  return {
+    root,
+    modal,
+    cleanup() {
+      modal.onRemove();
+      root.remove();
+    }
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('PanelModal', () => {
+  it('supports left dialog placement and caller-provided dialog/content styles', () => {
+    const {root, cleanup} = renderModal({
+      button: true,
+      dialogPlacement: 'left',
+      dialogStyle: {width: '400px'},
+      contentStyle: {padding: '0px'}
+    });
+
+    const dialog = root.querySelector<HTMLElement>('[role="dialog"]');
+    const wrapper = dialog?.parentElement as HTMLElement;
+    const content = dialog?.lastElementChild as HTMLElement;
+
+    expect(wrapper.style.justifyContent).toBe('flex-start');
+    expect(wrapper.style.padding).toBe('24px');
+    expect(dialog?.style.width).toBe('400px');
+    expect(content.style.padding).toBe('0px');
+
+    cleanup();
+  });
+
+  it('hides built-in close chrome and lets panel content close the modal', () => {
+    const contentPanel: Panel = {
+      id: 'closer',
+      title: 'Closer',
+      content: (
+        <button type="button" data-modal-widget-close="true">
+          close from content
+        </button>
+      )
+    };
+    const onOpenChange = vi.fn();
+    const {root, cleanup} = renderModal({
+      panel: contentPanel,
+      hideCloseButton: true,
+      onOpenChange
+    });
+
+    expect(root.querySelector('[aria-label="Close"]')).toBeNull();
+    root.querySelector<HTMLButtonElement>('[data-modal-widget-close="true"]')?.click();
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(root.textContent).not.toContain('close from content');
+
+    cleanup();
+  });
+
+  it('marks the trigger active while the modal is open', () => {
+    const {root, cleanup} = renderModal({button: true});
+
+    const trigger = root.querySelector<HTMLButtonElement>('.deck-widget-icon-button');
+    expect(trigger?.className).toContain('deck-widget-button-active');
+
+    cleanup();
+  });
+
+  it('can drag the dialog from the title bar', async () => {
+    const {root, cleanup} = renderModal({
+      draggable: true
+    });
+
+    const dialog = root.querySelector<HTMLElement>('[role="dialog"]');
+    const header = root.querySelector<HTMLElement>('[data-modal-widget-header="true"]');
+    header?.dispatchEvent(
+      new MouseEvent('pointerdown', {bubbles: true, button: 0, clientX: 10, clientY: 20})
+    );
+    document.dispatchEvent(new MouseEvent('pointermove', {clientX: 20, clientY: 45}));
+    await Promise.resolve();
+
+    expect(dialog?.parentElement?.style.transform).toBe('translate(10px, 25px)');
+
+    document.dispatchEvent(new MouseEvent('pointerup'));
+    cleanup();
+  });
+});

--- a/modules/panels/src/panel-components/panel-modal.tsx
+++ b/modules/panels/src/panel-components/panel-modal.tsx
@@ -1,6 +1,7 @@
 /* eslint react/react-in-jsx-scope: 0 */
 /** @jsxImportSource preact */
 import {render} from 'preact';
+import {useCallback, useEffect, useRef, useState} from 'preact/hooks';
 import {KeyboardShortcutsManager} from '../keyboard-shortcuts/keyboard-shortcuts-manager';
 import {PanelContainer, type PanelContainerProps, type PanelPlacement} from '../panel-container';
 import {PanelThemeScope} from '../panels/panel-theme-scope';
@@ -9,6 +10,19 @@ import type {KeyboardShortcut} from '../keyboard-shortcuts/keyboard-shortcuts';
 import type {KeyboardShortcutEventManager} from '../keyboard-shortcuts/keyboard-shortcuts-manager';
 import type {Panel} from '../panels/panel-types';
 import type {JSX} from 'preact';
+
+type ModalDragState = {
+  startX: number;
+  startY: number;
+  originX: number;
+  originY: number;
+};
+
+/** Initial screen placement modes for an open modal dialog wrapper. */
+export type PanelModalDialogPlacement = 'center' | 'left';
+
+/** Controls whether the modal blocks pointer interaction outside the dialog. */
+export type PanelModalPresentation = 'modal' | 'floating';
 
 /**
  * Props for {@link PanelModal}.
@@ -26,8 +40,22 @@ export type PanelModalProps = PanelContainerProps & {
   triggerIcon?: string;
   /** Whether to render modal title bar chrome. */
   showTitleBar?: boolean;
+  /** Controls whether the open panel blocks pointer interaction outside itself. */
+  presentation?: PanelModalPresentation;
+  /** Whether the dialog can be dragged by its title bar or configured drag handle. */
+  draggable?: boolean;
+  /** Optional selector for the element that starts a dialog drag. */
+  dragHandleSelector?: string;
+  /** Optional inline style merged into the dialog panel. */
+  dialogStyle?: JSX.CSSProperties;
+  /** Initial screen placement for the dialog wrapper. */
+  dialogPlacement?: PanelModalDialogPlacement;
+  /** Optional inline style merged into the dialog body. */
+  contentStyle?: JSX.CSSProperties;
   /** Whether the trigger should be hidden. */
   hideTrigger?: boolean;
+  /** Hides modal chrome close controls when content renders its own close action. */
+  hideCloseButton?: boolean;
   /** Legacy compatibility flag that maps to a visible trigger button. */
   button?: boolean;
   /** Initial open state for uncontrolled usage. */
@@ -46,6 +74,16 @@ const DEFAULT_TRIGGER_ICON = '▦';
 
 function stopPropagation(event: Event): void {
   event.stopPropagation();
+}
+
+function isModalDragHandleTarget(target: Element, dragHandleSelector?: string): boolean {
+  if (target.closest('button,a,input,select,textarea,[role="button"],[role="option"]')) {
+    return false;
+  }
+  if (dragHandleSelector) {
+    return Boolean(target.closest(dragHandleSelector));
+  }
+  return Boolean(target.closest('[data-modal-widget-header="true"]'));
 }
 
 function getDeckCanvasElement(deck: unknown): HTMLElement | null {
@@ -82,6 +120,13 @@ function PanelModalView({
   triggerLabel,
   triggerIcon,
   showTitleBar,
+  presentation,
+  draggable,
+  dragHandleSelector,
+  dialogStyle,
+  dialogPlacement,
+  contentStyle,
+  hideCloseButton,
   open,
   onOpenChange
 }: {
@@ -91,16 +136,95 @@ function PanelModalView({
   triggerIcon: string;
   triggerLabel: string;
   showTitleBar: boolean;
+  presentation: PanelModalPresentation;
+  draggable: boolean;
+  dragHandleSelector?: string;
+  dialogStyle?: JSX.CSSProperties;
+  dialogPlacement: PanelModalDialogPlacement;
+  contentStyle?: JSX.CSSProperties;
+  hideCloseButton: boolean;
   open: boolean;
   onOpenChange: (next: boolean) => void;
 }) {
+  const dragState = useRef<ModalDragState | null>(null);
+  const [dragOffset, setDragOffset] = useState({x: 0, y: 0});
+
+  const handlePointerMove = useCallback((event: PointerEvent) => {
+    const state = dragState.current;
+    if (!state) {
+      return;
+    }
+    setDragOffset({
+      x: state.originX + event.clientX - state.startX,
+      y: state.originY + event.clientY - state.startY
+    });
+  }, []);
+  const handlePointerUp = useCallback(() => {
+    dragState.current = null;
+    document.removeEventListener('pointermove', handlePointerMove);
+    document.removeEventListener('pointerup', handlePointerUp);
+  }, [handlePointerMove]);
+
+  useEffect(() => {
+    if (open) {
+      return;
+    }
+    handlePointerUp();
+    setDragOffset(current => (current.x === 0 && current.y === 0 ? current : {x: 0, y: 0}));
+  }, [handlePointerUp, open]);
+
+  useEffect(
+    () => () => {
+      handlePointerUp();
+    },
+    [handlePointerUp]
+  );
+
+  const panelStyle =
+    presentation === 'floating'
+      ? {...MODAL_FLOATING_DIALOG_PANEL_STYLE, ...dialogStyle}
+      : {...MODAL_DIALOG_PANEL_STYLE, ...dialogStyle};
+  const wrapperStyle = getModalDialogWrapperStyle(dialogPlacement, dragOffset);
+  const bodyStyle =
+    presentation === 'floating'
+      ? {...MODAL_FLOATING_CONTENT_STYLE, ...contentStyle}
+      : {...MODAL_CONTENT_STYLE, ...contentStyle};
+
+  const handleDialogPointerDown = (event: JSX.TargetedPointerEvent<HTMLDivElement>) => {
+    if (!draggable || event.button !== 0 || !(event.target instanceof Element)) {
+      return;
+    }
+    if (!isModalDragHandleTarget(event.target, dragHandleSelector)) {
+      return;
+    }
+    event.preventDefault();
+    dragState.current = {
+      startX: event.clientX,
+      startY: event.clientY,
+      originX: dragOffset.x,
+      originY: dragOffset.y
+    };
+    document.addEventListener('pointermove', handlePointerMove);
+    document.addEventListener('pointerup', handlePointerUp);
+  };
+  const handleDialogClick = (event: JSX.TargetedMouseEvent<HTMLDivElement>) => {
+    if (!(event.target instanceof Element)) {
+      return;
+    }
+    if (event.target.closest('[data-modal-widget-close="true"]')) {
+      onOpenChange(false);
+    }
+  };
+
   return (
     <div>
       {!hideTrigger && (
         <div className="deck-widget-button">
           <button
             type="button"
-            className="deck-widget-icon-button"
+            className={
+              open ? 'deck-widget-icon-button deck-widget-button-active' : 'deck-widget-icon-button'
+            }
             style={MODAL_TRIGGER_STYLE}
             aria-label={open ? `Close ${triggerLabel}` : `Open ${triggerLabel}`}
             onClick={() => onOpenChange(!open)}
@@ -115,31 +239,44 @@ function PanelModalView({
 
       {open && (
         <>
-          <button
-            type="button"
-            style={OVERLAY_BACKDROP_STYLE}
-            onPointerDown={() => onOpenChange(false)}
-            onClick={() => onOpenChange(false)}
-          />
-          <div style={MODAL_DIALOG_WRAPPER_STYLE}>
-            <div style={MODAL_DIALOG_PANEL_STYLE}>
+          {presentation === 'modal' ? (
+            <button
+              type="button"
+              style={OVERLAY_BACKDROP_STYLE}
+              onPointerDown={() => onOpenChange(false)}
+              onPointerUp={() => onOpenChange(false)}
+              onClick={() => onOpenChange(false)}
+            />
+          ) : null}
+          <div style={wrapperStyle}>
+            <div
+              style={panelStyle}
+              role="dialog"
+              aria-label={title}
+              onPointerDown={handleDialogPointerDown}
+              onClick={handleDialogClick}
+            >
               {showTitleBar ? (
-                <div style={MODAL_HEADER_STYLE}>
+                <div data-modal-widget-header="true" style={MODAL_HEADER_STYLE}>
                   <span style={MODAL_HEADER_TITLE_STYLE}>{title}</span>
-                  <button
-                    type="button"
-                    aria-label="Close"
-                    style={MODAL_CLOSE_BUTTON_STYLE}
-                    onPointerDown={stopPropagation}
-                    onPointerUp={() => onOpenChange(false)}
-                  >
-                    ×
-                  </button>
+                  {hideCloseButton ? null : (
+                    <button
+                      type="button"
+                      aria-label="Close"
+                      data-modal-widget-close="true"
+                      style={MODAL_CLOSE_BUTTON_STYLE}
+                      onPointerDown={stopPropagation}
+                      onPointerUp={() => onOpenChange(false)}
+                    >
+                      ×
+                    </button>
+                  )}
                 </div>
-              ) : (
+              ) : hideCloseButton ? null : (
                 <button
                   type="button"
                   aria-label="Close"
+                  data-modal-widget-close="true"
                   style={MODAL_FLOATING_CLOSE_BUTTON_STYLE}
                   onPointerDown={stopPropagation}
                   onPointerUp={() => onOpenChange(false)}
@@ -147,7 +284,7 @@ function PanelModalView({
                   ×
                 </button>
               )}
-              <div style={MODAL_CONTENT_STYLE}>
+              <div style={bodyStyle}>
                 {panel ? <PanelThemeScope panel={panel}>{panel.content}</PanelThemeScope> : null}
               </div>
             </div>
@@ -170,7 +307,14 @@ export class PanelModal extends PanelContainer<PanelModalProps> {
     triggerLabel: 'Open panel',
     triggerIcon: DEFAULT_TRIGGER_ICON,
     showTitleBar: true,
+    presentation: 'modal',
+    draggable: false,
+    dragHandleSelector: undefined!,
+    dialogStyle: undefined!,
+    dialogPlacement: 'center',
+    contentStyle: undefined!,
     hideTrigger: false,
+    hideCloseButton: false,
     button: false,
     defaultOpen: false,
     onOpenChange: undefined!,
@@ -186,7 +330,14 @@ export class PanelModal extends PanelContainer<PanelModalProps> {
   triggerLabel = PanelModal.defaultProps.triggerLabel;
   triggerIcon = PanelModal.defaultProps.triggerIcon;
   showTitleBar = PanelModal.defaultProps.showTitleBar;
+  presentation: PanelModalPresentation = PanelModal.defaultProps.presentation;
+  draggable = PanelModal.defaultProps.draggable;
+  dragHandleSelector: string | undefined = PanelModal.defaultProps.dragHandleSelector;
+  dialogStyle: JSX.CSSProperties | undefined = PanelModal.defaultProps.dialogStyle;
+  dialogPlacement: PanelModalDialogPlacement = PanelModal.defaultProps.dialogPlacement;
+  contentStyle: JSX.CSSProperties | undefined = PanelModal.defaultProps.contentStyle;
   hideTrigger = PanelModal.defaultProps.hideTrigger;
+  hideCloseButton = PanelModal.defaultProps.hideCloseButton;
   isOpen = false;
   #hasOpenStateInitialized = false;
   #panel: Panel | undefined = PanelModal.defaultProps.panel;
@@ -222,8 +373,29 @@ export class PanelModal extends PanelContainer<PanelModalProps> {
     if (props.showTitleBar !== undefined) {
       this.showTitleBar = props.showTitleBar;
     }
+    if (props.presentation !== undefined) {
+      this.presentation = props.presentation;
+    }
+    if (props.draggable !== undefined) {
+      this.draggable = props.draggable;
+    }
+    if (props.dragHandleSelector !== undefined) {
+      this.dragHandleSelector = props.dragHandleSelector;
+    }
+    if (props.dialogStyle !== undefined) {
+      this.dialogStyle = props.dialogStyle;
+    }
+    if (props.dialogPlacement !== undefined) {
+      this.dialogPlacement = props.dialogPlacement;
+    }
+    if (props.contentStyle !== undefined) {
+      this.contentStyle = props.contentStyle;
+    }
     if (props.hideTrigger !== undefined || props.button !== undefined) {
       this.hideTrigger = props.button !== undefined ? !props.button : (props.hideTrigger ?? false);
+    }
+    if (props.hideCloseButton !== undefined) {
+      this.hideCloseButton = props.hideCloseButton;
     }
     if (props.title !== undefined) {
       this.title = props.title;
@@ -365,6 +537,13 @@ export class PanelModal extends PanelContainer<PanelModalProps> {
         triggerLabel={this.triggerLabel}
         triggerIcon={this.triggerIcon}
         showTitleBar={this.showTitleBar}
+        presentation={this.presentation}
+        draggable={this.draggable}
+        dragHandleSelector={this.dragHandleSelector}
+        dialogStyle={this.dialogStyle}
+        dialogPlacement={this.dialogPlacement}
+        contentStyle={this.contentStyle}
+        hideCloseButton={this.hideCloseButton}
         open={this.isOpen}
         onOpenChange={this.#handleOpenChange}
       />,
@@ -426,6 +605,28 @@ const MODAL_DIALOG_WRAPPER_STYLE: JSX.CSSProperties = {
   zIndex: 31
 };
 
+function getModalDialogWrapperStyle(
+  dialogPlacement: PanelModalDialogPlacement,
+  dragOffset: {x: number; y: number}
+): JSX.CSSProperties {
+  const placementStyle =
+    dialogPlacement === 'left'
+      ? {
+          justifyContent: 'flex-start',
+          padding: '24px'
+        }
+      : {};
+  const transformStyle =
+    dragOffset.x === 0 && dragOffset.y === 0
+      ? {}
+      : {transform: `translate(${dragOffset.x}px, ${dragOffset.y}px)`};
+  return {
+    ...MODAL_DIALOG_WRAPPER_STYLE,
+    ...placementStyle,
+    ...transformStyle
+  };
+}
+
 const MODAL_DIALOG_PANEL_STYLE: JSX.CSSProperties = {
   pointerEvents: 'auto',
   width: 'min(90vw, 760px)',
@@ -438,7 +639,23 @@ const MODAL_DIALOG_PANEL_STYLE: JSX.CSSProperties = {
   boxShadow: 'var(--menu-shadow, 0px 12px 30px rgba(0,0,0,0.25))',
   overflow: 'hidden',
   display: 'flex',
-  flexDirection: 'column'
+  flexDirection: 'column',
+  position: 'relative'
+};
+
+const MODAL_FLOATING_DIALOG_PANEL_STYLE: JSX.CSSProperties = {
+  pointerEvents: 'auto',
+  width: 'fit-content',
+  maxWidth: 'calc(100vw - 48px)',
+  maxHeight: 'min(88vh, 88dvh)',
+  border: 'none',
+  background: 'transparent',
+  color: 'var(--menu-text, rgb(24, 24, 26))',
+  boxShadow: 'none',
+  overflow: 'visible',
+  display: 'flex',
+  flexDirection: 'column',
+  position: 'relative'
 };
 
 const MODAL_HEADER_STYLE: JSX.CSSProperties = {
@@ -483,4 +700,10 @@ const MODAL_CONTENT_STYLE: JSX.CSSProperties = {
   flex: 1,
   overflow: 'auto',
   padding: '10px'
+};
+
+const MODAL_FLOATING_CONTENT_STYLE: JSX.CSSProperties = {
+  flex: 1,
+  overflow: 'visible',
+  padding: '0'
 };

--- a/modules/panels/src/panels/settings-panel.test.tsx
+++ b/modules/panels/src/panels/settings-panel.test.tsx
@@ -27,6 +27,7 @@ const TEST_SCHEMA: SettingsSchema = {
           min: 0,
           max: 1,
           step: 0.1,
+          sliderDebounceMs: 20,
           description: 'Adjust alpha for rendered paths.'
         }
       ]
@@ -40,7 +41,7 @@ const TEST_SCHEMA: SettingsSchema = {
           label: 'Mode',
           type: 'select',
           options: ['all', 'critical-path', 'selected-only'],
-          description: 'Control which traces remain visible.'
+          description: 'Control which items remain visible.'
         }
       ]
     }
@@ -179,8 +180,44 @@ describe('SettingsPanel', () => {
 
     const numberInput = getRequiredInput(root, 'input[type="number"]');
     expect(numberInput.getAttribute('style')).toContain('var(--button-backdrop-filter');
+    expect(numberInput.style.height).toBe('28px');
+    expect(numberInput.style.padding).toBe('2px 6px');
 
     cleanup();
+  });
+
+  it('debounces range slider changes when requested by the setting descriptor', async () => {
+    vi.useFakeTimers();
+    const handleSettingsChange = vi.fn<(settings: SettingsState) => void>();
+    const {root, cleanup} = renderSettingsPanel({onSettingsChange: handleSettingsChange});
+
+    try {
+      const sectionToggle = getRequiredButton(root, 'button[aria-expanded]');
+      sectionToggle.click();
+      await Promise.resolve();
+
+      const rangeInput = getRequiredInput(root, 'input[type="range"]');
+      rangeInput.value = '0.7';
+      rangeInput.dispatchEvent(new Event('input', {bubbles: true}));
+      await Promise.resolve();
+
+      expect(handleSettingsChange).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          render: expect.objectContaining({opacity: 0.7})
+        })
+      );
+
+      await vi.advanceTimersByTimeAsync(20);
+
+      expect(handleSettingsChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          render: expect.objectContaining({opacity: 0.7})
+        })
+      );
+    } finally {
+      cleanup();
+      vi.useRealTimers();
+    }
   });
 
   // eslint-disable-next-line max-statements

--- a/modules/panels/src/panels/settings-panel.tsx
+++ b/modules/panels/src/panels/settings-panel.tsx
@@ -1,6 +1,6 @@
 /* eslint react/react-in-jsx-scope: 0 */
 /** @jsxImportSource preact */
-import {useEffect, useMemo, useState} from 'preact/hooks';
+import {useEffect, useMemo, useRef, useState} from 'preact/hooks';
 
 import {
   buildInitialCollapsedState,
@@ -135,7 +135,10 @@ const RANGE_INPUT_STYLE: JSX.CSSProperties = {
 const NUMBER_INPUT_STYLE: JSX.CSSProperties = {
   ...INPUT_STYLE,
   width: '84px',
-  flexShrink: 0
+  flexShrink: 0,
+  height: '28px',
+  lineHeight: '16px',
+  padding: '2px 6px'
 };
 
 const CHECKBOX_STYLE: JSX.CSSProperties = {
@@ -170,6 +173,14 @@ type StringSettingControlProps = {
   label: string;
   value: string;
   onApply: (nextValue: string) => void;
+};
+
+type NumberSettingControlProps = {
+  inputId: string;
+  label: string;
+  setting: SettingDescriptor;
+  value: number;
+  onValueChange: (nextValue: SettingValue) => void;
 };
 
 function StringSettingControl({inputId, label, value, onApply}: StringSettingControlProps) {
@@ -254,6 +265,116 @@ function StringSettingControl({inputId, label, value, onApply}: StringSettingCon
   );
 }
 
+function NumberSettingControl({
+  inputId,
+  label,
+  setting,
+  value,
+  onValueChange
+}: NumberSettingControlProps) {
+  const showRange = Number.isFinite(setting.min) && Number.isFinite(setting.max);
+  const numericValue = clamp(value, setting.min, setting.max);
+  const sliderDebounceMs = getSliderDebounceMs(setting);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [draftValue, setDraftValue] = useState(numericValue);
+
+  useEffect(() => {
+    setDraftValue(numericValue);
+  }, [numericValue]);
+
+  useEffect(
+    () => () => {
+      clearPendingSliderChange(debounceTimerRef);
+    },
+    []
+  );
+
+  const commitValue = (nextValue: number): void => {
+    if (!Number.isFinite(nextValue)) {
+      return;
+    }
+    const clampedValue = clamp(nextValue, setting.min, setting.max);
+    clearPendingSliderChange(debounceTimerRef);
+    setDraftValue(clampedValue);
+    onValueChange(clampedValue);
+  };
+
+  const scheduleSliderValue = (nextValue: number): void => {
+    if (!Number.isFinite(nextValue)) {
+      return;
+    }
+    const clampedValue = clamp(nextValue, setting.min, setting.max);
+    setDraftValue(clampedValue);
+    if (sliderDebounceMs <= 0) {
+      onValueChange(clampedValue);
+      return;
+    }
+
+    clearPendingSliderChange(debounceTimerRef);
+    debounceTimerRef.current = setTimeout(() => {
+      debounceTimerRef.current = null;
+      onValueChange(clampedValue);
+    }, sliderDebounceMs);
+  };
+
+  if (!showRange) {
+    return (
+      <input
+        id={inputId}
+        type="number"
+        step={String(setting.step ?? 1)}
+        value={String(draftValue)}
+        onInput={event => commitValue(Number(event.currentTarget.value))}
+        onChange={event => commitValue(Number(event.currentTarget.value))}
+        aria-label={label}
+        style={INPUT_STYLE}
+      />
+    );
+  }
+
+  return (
+    <div style={{display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0, width: '100%'}}>
+      <input
+        id={inputId}
+        type="range"
+        min={String(setting.min)}
+        max={String(setting.max)}
+        step={String(setting.step ?? 1)}
+        value={String(draftValue)}
+        onInput={event => scheduleSliderValue(Number(event.currentTarget.value))}
+        aria-label={label}
+        style={RANGE_INPUT_STYLE}
+      />
+      <input
+        type="number"
+        min={Number.isFinite(setting.min) ? String(setting.min) : undefined}
+        max={Number.isFinite(setting.max) ? String(setting.max) : undefined}
+        step={String(setting.step ?? 1)}
+        value={String(draftValue)}
+        onInput={event => commitValue(Number(event.currentTarget.value))}
+        onChange={event => commitValue(Number(event.currentTarget.value))}
+        aria-label={`${label} numeric value`}
+        style={NUMBER_INPUT_STYLE}
+      />
+    </div>
+  );
+}
+
+function getSliderDebounceMs(setting: SettingDescriptor): number {
+  if (!Number.isFinite(setting.sliderDebounceMs)) {
+    return 0;
+  }
+  return Math.max(0, setting.sliderDebounceMs as number);
+}
+
+function clearPendingSliderChange(timerRef: {current: ReturnType<typeof setTimeout> | null}): void {
+  if (timerRef.current == null) {
+    return;
+  }
+  clearTimeout(timerRef.current);
+  timerRef.current = null;
+}
+
 // eslint-disable-next-line complexity
 function SettingsControl({setting, value, onValueChange}: SettingsControlProps) {
   const label = setting.label ?? setting.name;
@@ -262,13 +383,6 @@ function SettingsControl({setting, value, onValueChange}: SettingsControlProps) 
 
   const handleBooleanChange: JSX.GenericEventHandler<HTMLInputElement> = event => {
     onValueChange(event.currentTarget.checked);
-  };
-
-  const handleNumberChange = (nextValue: number) => {
-    if (!Number.isFinite(nextValue)) {
-      return;
-    }
-    onValueChange(clamp(nextValue, setting.min, setting.max));
   };
 
   let control: JSX.Element;
@@ -286,45 +400,13 @@ function SettingsControl({setting, value, onValueChange}: SettingsControlProps) 
       />
     );
   } else if (setting.type === 'number') {
-    const numericValue = Number(value);
-    const showRange = Number.isFinite(setting.min) && Number.isFinite(setting.max);
-
-    control = showRange ? (
-      <div style={{display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0, width: '100%'}}>
-        <input
-          id={inputId}
-          type="range"
-          min={String(setting.min)}
-          max={String(setting.max)}
-          step={String(setting.step ?? 1)}
-          value={String(numericValue)}
-          onInput={event => handleNumberChange(Number(event.currentTarget.value))}
-          onChange={event => handleNumberChange(Number(event.currentTarget.value))}
-          aria-label={label}
-          style={RANGE_INPUT_STYLE}
-        />
-        <input
-          type="number"
-          min={Number.isFinite(setting.min) ? String(setting.min) : undefined}
-          max={Number.isFinite(setting.max) ? String(setting.max) : undefined}
-          step={String(setting.step ?? 1)}
-          value={String(numericValue)}
-          onInput={event => handleNumberChange(Number(event.currentTarget.value))}
-          onChange={event => handleNumberChange(Number(event.currentTarget.value))}
-          aria-label={`${label} numeric value`}
-          style={NUMBER_INPUT_STYLE}
-        />
-      </div>
-    ) : (
-      <input
-        id={inputId}
-        type="number"
-        step={String(setting.step ?? 1)}
-        value={String(numericValue)}
-        onInput={event => handleNumberChange(Number(event.currentTarget.value))}
-        onChange={event => handleNumberChange(Number(event.currentTarget.value))}
-        aria-label={label}
-        style={INPUT_STYLE}
+    control = (
+      <NumberSettingControl
+        inputId={inputId}
+        label={label}
+        setting={setting}
+        value={Number(value)}
+        onValueChange={onValueChange}
       />
     );
   } else if (setting.type === 'select') {

--- a/modules/panels/src/panels/studio-settings-panel.test.tsx
+++ b/modules/panels/src/panels/studio-settings-panel.test.tsx
@@ -1,0 +1,323 @@
+/** @jsxImportSource preact */
+import {render} from 'preact';
+import {act} from 'preact/test-utils';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {StudioSettingsPanel, createStudioSettingsPanel} from './studio-settings-panel';
+
+import type {SettingsSchema, SettingsState} from '../lib/settings/settings';
+
+const TEST_SCHEMA: SettingsSchema = {
+  title: 'Visualization Settings',
+  sections: [
+    {
+      id: 'colors',
+      name: 'Colors',
+      settings: [
+        {
+          name: 'colorSchemeId',
+          label: 'Item Colors',
+          description: 'Color items by semantic category',
+          type: 'select',
+          defaultValue: 'category',
+          options: [
+            {label: 'Category', value: 'category'},
+            {label: 'Item Type', value: 'item-type'}
+          ]
+        },
+        {
+          name: 'highlightFadeFactor',
+          label: 'Highlight',
+          description: 'Background emphasis opacity',
+          type: 'number',
+          min: 0,
+          max: 1,
+          step: 0.01,
+          sliderDebounceMs: 75,
+          defaultValue: 0.2
+        }
+      ]
+    },
+    {
+      id: 'layout',
+      name: 'Layout',
+      settings: [
+        {
+          name: 'maxVisibleRowsUnlimited',
+          label: 'Row Limit',
+          description: 'Maximum rows per group before collapsing',
+          type: 'boolean',
+          defaultValue: true
+        }
+      ]
+    },
+    {
+      id: 'dependencies',
+      name: 'Dependencies',
+      settings: [
+        {
+          name: 'localDependencyMode',
+          label: 'Local',
+          description: 'Same-level dependency visibility',
+          type: 'select',
+          defaultValue: 'warnings',
+          options: ['all', 'warnings', 'none']
+        },
+        {
+          name: 'lineRoutingMode',
+          label: 'Shape',
+          type: 'select',
+          defaultValue: 'straight',
+          options: [
+            {label: 'Straight', value: 'straight'},
+            {label: 'Arc', value: 'curve'}
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+const TEST_APPLICATION_SCHEMA: SettingsSchema = {
+  sections: [
+    {
+      id: 'application',
+      name: 'Application',
+      settings: [
+        {
+          name: 'timezone',
+          label: 'Timezone',
+          description: 'Choose which timezone is used for timeline timestamps.',
+          type: 'select',
+          defaultValue: 'UTC',
+          options: ['UTC', 'Local']
+        }
+      ]
+    }
+  ]
+};
+
+const TEST_SETTINGS: SettingsState = {
+  colorSchemeId: 'category',
+  highlightFadeFactor: 0.2,
+  maxVisibleRowsUnlimited: true,
+  localDependencyMode: 'warnings',
+  lineRoutingMode: 'straight',
+  timezone: 'UTC'
+};
+
+function renderStudioPanel(
+  onSettingsChange = vi.fn(),
+  props: Partial<Parameters<typeof StudioSettingsPanel>[0]> = {}
+) {
+  const root = document.createElement('div');
+  document.body.append(root);
+  render(
+    <StudioSettingsPanel
+      schema={TEST_SCHEMA}
+      applicationSchema={TEST_APPLICATION_SCHEMA}
+      settings={TEST_SETTINGS}
+      onSettingsChange={onSettingsChange}
+      {...props}
+    />,
+    root
+  );
+  return root;
+}
+
+function getButtonByText(text: string): HTMLButtonElement {
+  const button = Array.from(document.body.querySelectorAll('button')).find(candidate =>
+    candidate.textContent?.includes(text)
+  ) as HTMLButtonElement | undefined;
+  expect(button).toBeTruthy();
+  return button as HTMLButtonElement;
+}
+
+function getButtonByLabel(root: HTMLElement, label: string): HTMLButtonElement {
+  const button = root.querySelector(`button[aria-label="${label}"]`) as HTMLButtonElement | null;
+  expect(button).toBeTruthy();
+  return button as HTMLButtonElement;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.body.innerHTML = '';
+  window.localStorage.clear();
+});
+
+describe('StudioSettingsPanel', () => {
+  it('renders schema tabs and exposes a panel factory', () => {
+    const root = renderStudioPanel();
+
+    expect(root.textContent).toContain('Colors');
+    expect(root.textContent).toContain('Layout');
+    expect(root.textContent).toContain('Dependencies');
+    expect(root.textContent).toContain('Visualization');
+    expect(root.textContent).toContain('Application');
+    expect(root.firstElementChild).toBeTruthy();
+
+    const panel = createStudioSettingsPanel({
+      schema: TEST_SCHEMA,
+      settings: TEST_SETTINGS
+    });
+    expect(panel).toMatchObject({id: 'studio-settings-panel', title: 'Settings'});
+    expect(panel.content).toBeTruthy();
+  });
+
+  it('renders application settings in a separate rail group', async () => {
+    const onSettingsChange = vi.fn();
+    const root = renderStudioPanel(onSettingsChange);
+
+    getButtonByText('Application').click();
+    await Promise.resolve();
+
+    expect(root.textContent).toContain('Timezone');
+    getButtonByLabel(root, 'Timezone').click();
+    await Promise.resolve();
+    getButtonByText('Local').click();
+    await Promise.resolve();
+
+    expect(onSettingsChange).toHaveBeenLastCalledWith(
+      {...TEST_SETTINGS, timezone: 'Local'},
+      expect.arrayContaining([expect.objectContaining({name: 'timezone', nextValue: 'Local'})])
+    );
+  });
+
+  it('collapses navigation into one scrollable settings pane and remembers the mode', async () => {
+    const root = renderStudioPanel();
+    const collapseToggle = getButtonByLabel(root, 'Collapse settings dialog');
+    const header = root.querySelector('[data-studio-settings-drag-handle="true"]') as HTMLElement;
+
+    expect(header.style.height).toBe('58px');
+    expect(collapseToggle.getAttribute('aria-pressed')).toBe('false');
+    expect(collapseToggle.textContent).toBe('Expanded');
+    expect(getButtonByLabel(root, 'Close').getAttribute('data-modal-widget-close')).toBe('true');
+    expect(root.querySelector('nav[aria-label="Visualization settings sections"]')).toBeTruthy();
+
+    collapseToggle.click();
+    await Promise.resolve();
+
+    expect(getButtonByLabel(root, 'Expand settings dialog').textContent).toBe('Compact');
+    expect(root.querySelector('nav[aria-label="Visualization settings sections"]')).toBeNull();
+    expect(root.querySelector('main[aria-label="All settings sections"]')).toBeTruthy();
+    expect(root.textContent).toContain('Item Colors');
+    expect(root.textContent).toContain('Row Limit');
+    expect(root.textContent).toContain('Timezone');
+    expect(root.textContent).not.toContain('Color items by semantic category');
+    expect(
+      window.localStorage.getItem('deck.gl-community:studio-settings:navigation-collapsed')
+    ).toBe('true');
+
+    render(null, root);
+    root.remove();
+    const reopenedRoot = renderStudioPanel();
+    await Promise.resolve();
+
+    expect(getButtonByLabel(reopenedRoot, 'Expand settings dialog').textContent).toBe('Compact');
+    getButtonByLabel(reopenedRoot, 'Expand settings dialog').click();
+    await Promise.resolve();
+
+    expect(getButtonByLabel(reopenedRoot, 'Collapse settings dialog')).toBeTruthy();
+    expect(
+      window.localStorage.getItem('deck.gl-community:studio-settings:navigation-collapsed')
+    ).toBe('false');
+  });
+
+  it('emits updated settings for select, boolean, and number controls', async () => {
+    const onSettingsChange = vi.fn();
+    const root = renderStudioPanel(onSettingsChange);
+
+    getButtonByLabel(root, 'Item Colors').click();
+    await Promise.resolve();
+    getButtonByText('Item Type').click();
+    await Promise.resolve();
+
+    expect(onSettingsChange).toHaveBeenLastCalledWith(
+      {...TEST_SETTINGS, colorSchemeId: 'item-type'},
+      expect.arrayContaining([
+        expect.objectContaining({name: 'colorSchemeId', nextValue: 'item-type'})
+      ])
+    );
+
+    const numberInput = root.querySelector(
+      'input[aria-label="Highlight value"]'
+    ) as HTMLInputElement;
+    numberInput.value = '0.5';
+    numberInput.dispatchEvent(new Event('input', {bubbles: true}));
+    await Promise.resolve();
+
+    expect(onSettingsChange).toHaveBeenLastCalledWith(
+      {...TEST_SETTINGS, colorSchemeId: 'item-type', highlightFadeFactor: 0.5},
+      expect.arrayContaining([
+        expect.objectContaining({name: 'highlightFadeFactor', nextValue: 0.5})
+      ])
+    );
+
+    getButtonByText('Layout').click();
+    await Promise.resolve();
+    getButtonByText('Enabled').click();
+    await Promise.resolve();
+
+    expect(onSettingsChange).toHaveBeenLastCalledWith(
+      {
+        ...TEST_SETTINGS,
+        colorSchemeId: 'item-type',
+        highlightFadeFactor: 0.5,
+        maxVisibleRowsUnlimited: false
+      },
+      expect.arrayContaining([
+        expect.objectContaining({name: 'maxVisibleRowsUnlimited', nextValue: false})
+      ])
+    );
+  });
+
+  it('debounces range-slider setting changes while keeping the input responsive', async () => {
+    vi.useFakeTimers();
+    const onSettingsChange = vi.fn();
+    const root = renderStudioPanel(onSettingsChange);
+
+    const rangeInput = root.querySelector(
+      'input[aria-label="Highlight slider"]'
+    ) as HTMLInputElement;
+    await act(async () => {
+      rangeInput.value = '0.4';
+      rangeInput.dispatchEvent(new Event('input', {bubbles: true}));
+      await Promise.resolve();
+    });
+
+    expect(onSettingsChange).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(75);
+
+    expect(onSettingsChange).toHaveBeenLastCalledWith(
+      {...TEST_SETTINGS, highlightFadeFactor: 0.4},
+      expect.arrayContaining([
+        expect.objectContaining({name: 'highlightFadeFactor', nextValue: 0.4})
+      ])
+    );
+  });
+
+  it('renders dependency shape toggles and updates lineRoutingMode on click', async () => {
+    const onSettingsChange = vi.fn();
+    const root = renderStudioPanel(onSettingsChange);
+
+    getButtonByText('Dependencies').click();
+    await Promise.resolve();
+
+    expect(root.textContent).toContain('Straight');
+    expect(root.textContent).toContain('Arc');
+    expect(root.textContent).not.toContain('Step');
+    expect(getButtonByText('Straight').getAttribute('aria-pressed')).toBe('true');
+    expect(getButtonByText('Arc').getAttribute('aria-pressed')).toBe('false');
+
+    getButtonByText('Arc').click();
+    await Promise.resolve();
+
+    expect(onSettingsChange).toHaveBeenLastCalledWith(
+      {...TEST_SETTINGS, lineRoutingMode: 'curve'},
+      expect.arrayContaining([
+        expect.objectContaining({name: 'lineRoutingMode', nextValue: 'curve'})
+      ])
+    );
+  });
+});

--- a/modules/panels/src/panels/studio-settings-panel.tsx
+++ b/modules/panels/src/panels/studio-settings-panel.tsx
@@ -1,0 +1,1513 @@
+/** @jsxImportSource preact */
+
+import {useEffect, useMemo, useRef, useState} from 'preact/hooks';
+
+import {
+  clamp,
+  getDefaultValue,
+  getSectionKey,
+  normalizeOption,
+  resolveSettingValue,
+  setValueAtPath
+} from '../lib/settings/settings';
+import {SelectComponent} from '../preact/select-component';
+
+import type {
+  SettingsChangeDescriptor,
+  SettingsManagerOnChange
+} from '../lib/settings/settings-manager';
+import type {
+  SettingDescriptor,
+  SettingsSchema,
+  SettingsSectionDescriptor,
+  SettingsState,
+  SettingValue
+} from '../lib/settings/settings';
+import type {Panel} from './panel-types';
+import type {ComponentChildren, JSX} from 'preact';
+
+/** Studio settings tab id derived from the backing settings schema section key. */
+export type StudioSettingsTabId = string;
+
+/** Visual dependency routing card variants supported by the settings panel. */
+export type StudioDependencyShape = 'straight' | 'arc' | 'step';
+
+/** Inline SVG icons available to the Studio settings panel. */
+export type StudioSettingsIconName =
+  | 'settings'
+  | 'layout'
+  | 'filter'
+  | 'branch'
+  | 'compare'
+  | 'path'
+  | 'chevron';
+
+/** Props accepted by the Studio SVG icon renderer. */
+export type StudioSettingsIconProps = {
+  /** Icon glyph name. Unknown names fall back to the settings glyph. */
+  name: StudioSettingsIconName;
+  /** Square icon size in CSS pixels. */
+  size?: number;
+  /** Optional inline style merged into the SVG node. */
+  style?: JSX.CSSProperties;
+};
+
+/** Props accepted by the schema-driven Studio settings panel. */
+export type StudioSettingsPanelProps = {
+  /** Settings schema that supplies available controls. */
+  schema: SettingsSchema;
+  /** Optional local-storage-backed application settings shown in a separate rail group. */
+  applicationSchema?: SettingsSchema;
+  /** Optional font family applied to the whole settings panel. */
+  fontFamily?: string;
+  /** Current settings snapshot read by each control. */
+  settings: SettingsState;
+  /** Existing settings manager callback invoked after each control change. */
+  onSettingsChange?: SettingsManagerOnChange;
+  /** Optional static preset label shown in the tab rail. */
+  presetLabel?: string;
+};
+
+/** Creates a panel wrapper for the Studio settings panel. */
+export function createStudioSettingsPanel(props: StudioSettingsPanelProps): Panel {
+  return {
+    id: 'studio-settings-panel',
+    title: 'Settings',
+    content: <StudioSettingsPanel {...props} />
+  };
+}
+
+/** Renders a schema-driven settings panel styled with deck widget theme variables. */
+export function StudioSettingsPanel({
+  schema,
+  applicationSchema,
+  fontFamily,
+  settings,
+  onSettingsChange,
+  presetLabel
+}: StudioSettingsPanelProps) {
+  const [activeTabId, setActiveTabId] = useState<StudioSettingsTabId>('');
+  const [isNavigationCollapsed, setIsNavigationCollapsed] = useState(
+    readPersistedNavigationCollapsed
+  );
+  const [localSettings, setLocalSettings] = useState(settings);
+  const previousSettingsRef = useRef(settings);
+  const model = useMemo(
+    () => buildPanelModel(schema, applicationSchema),
+    [applicationSchema, schema]
+  );
+  const activeTab = model.tabs.find(tab => tab.id === activeTabId) ?? model.tabs[0];
+  const selectedTabId = activeTab?.id ?? '';
+  const lineRoutingSetting = model.settingsByName.get(LINE_ROUTING_MODE_SETTING);
+
+  useEffect(() => {
+    if (previousSettingsRef.current === settings) {
+      return;
+    }
+    previousSettingsRef.current = settings;
+    setLocalSettings(settings);
+  }, [settings]);
+
+  /** Applies one setting value to local panel state and the existing manager callback. */
+  function applySetting(setting: SettingDescriptor, value: SettingValue): void {
+    const nextSettings = setValueAtPath(localSettings, setting.name, value);
+    const previousValue = resolveSettingValue(setting, localSettings);
+    const changedSetting: SettingsChangeDescriptor = {
+      type: 'setting',
+      name: setting.name,
+      previousValue,
+      nextValue: value,
+      descriptor: setting
+    };
+    setLocalSettings(nextSettings);
+    onSettingsChange?.(nextSettings, [changedSetting]);
+  }
+
+  function applyNavigationCollapsed(nextCollapsed: boolean): void {
+    setIsNavigationCollapsed(nextCollapsed);
+    writePersistedNavigationCollapsed(nextCollapsed);
+  }
+
+  function renderSettingsSection(tab: TabDefinition, compact: boolean): ComponentChildren {
+    return (
+      <div key={tab.id} style={STYLES.sectionStackItem}>
+        <Section title={tab.title} eyebrow={tab.eyebrow}>
+          {tab.settings.length > 0 ? (
+            <SettingGroups
+              tab={tab}
+              settings={localSettings}
+              compact={compact}
+              onChange={(setting, value) => applySetting(setting, value)}
+            />
+          ) : (
+            <div style={STYLES.emptyState}>No settings in this section.</div>
+          )}
+        </Section>
+        {tab.hasLineRoutingSetting && lineRoutingSetting ? (
+          <DependencyShapeSection
+            setting={lineRoutingSetting}
+            settings={localSettings}
+            onChange={value => applySetting(lineRoutingSetting, value)}
+          />
+        ) : null}
+      </div>
+    );
+  }
+
+  const navigation = (
+    <nav style={STYLES.rail} aria-label="Visualization settings sections">
+      {model.tabGroups.map(group => (
+        <div key={group.id} style={STYLES.railGroup}>
+          {group.label ? <div style={STYLES.railGroupTitle}>{group.label}</div> : null}
+          <div style={STYLES.tabList}>
+            {group.tabs.map(tab => (
+              <button
+                key={tab.id}
+                type="button"
+                aria-pressed={selectedTabId === tab.id}
+                style={selectedTabId === tab.id ? STYLES.tabButtonActive : STYLES.tabButton}
+                onClick={() => setActiveTabId(tab.id)}
+              >
+                <StudioSettingsIcon name={tab.icon} size={16} />
+                <span>{tab.label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+      {presetLabel ? (
+        <div style={STYLES.preset}>
+          <div style={STYLES.presetEyebrow}>Preset</div>
+          <div style={STYLES.presetCard}>{presetLabel}</div>
+        </div>
+      ) : null}
+    </nav>
+  );
+
+  return (
+    <div
+      style={{
+        ...(isNavigationCollapsed ? STYLES.shellCollapsed : STYLES.shell),
+        fontFamily: fontFamily ?? STYLES.shell.fontFamily
+      }}
+    >
+      <header data-studio-settings-drag-handle="true" style={STYLES.header}>
+        <div style={STYLES.headerTopRow}>
+          <div style={STYLES.headerTitle}>
+            <StudioSettingsIcon name="settings" size={21} />
+            <h1 style={STYLES.heading}>Settings</h1>
+          </div>
+          <div style={STYLES.headerActions}>
+            <button
+              type="button"
+              aria-label={
+                isNavigationCollapsed ? 'Expand settings dialog' : 'Collapse settings dialog'
+              }
+              aria-pressed={isNavigationCollapsed}
+              title={isNavigationCollapsed ? 'Expand settings dialog' : 'Collapse settings dialog'}
+              style={
+                isNavigationCollapsed
+                  ? STYLES.navigationModeButtonActive
+                  : STYLES.navigationModeButton
+              }
+              onClick={() => applyNavigationCollapsed(!isNavigationCollapsed)}
+            >
+              {isNavigationCollapsed ? 'Compact' : 'Expanded'}
+            </button>
+            <button
+              type="button"
+              aria-label="Close"
+              data-modal-widget-close="true"
+              style={STYLES.headerCloseButton}
+            >
+              ×
+            </button>
+          </div>
+        </div>
+      </header>
+      <div style={isNavigationCollapsed ? STYLES.bodyCollapsed : STYLES.body}>
+        {isNavigationCollapsed ? null : navigation}
+        {isNavigationCollapsed ? (
+          <main style={STYLES.mainCollapsed} aria-label="All settings sections">
+            {model.tabs.map(tab => renderSettingsSection(tab, true))}
+          </main>
+        ) : (
+          <main style={STYLES.main}>
+            {activeTab ? (
+              renderSettingsSection(activeTab, false)
+            ) : (
+              <Section title="Settings">
+                <div style={STYLES.emptyState}>No settings in this section.</div>
+              </Section>
+            )}
+          </main>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Renders one local SVG icon used by the Studio settings panel. */
+export function StudioSettingsIcon({name, size = 18, style}: StudioSettingsIconProps): JSX.Element {
+  const normalizedName = STUDIO_ICON_NAMES.has(name) ? name : 'settings';
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      style={{width: size, height: size, flex: '0 0 auto', ...style}}
+    >
+      {normalizedName === 'settings' ? (
+        <g>
+          <path d="M12 15.5A3.5 3.5 0 1 0 12 8a3.5 3.5 0 0 0 0 7.5Z" />
+          <path d="M19.4 15a1.7 1.7 0 0 0 .34 1.88l.04.04a2 2 0 0 1-2.83 2.83l-.04-.04a1.7 1.7 0 0 0-1.88-.34 1.7 1.7 0 0 0-1.03 1.56V21a2 2 0 0 1-4 0v-.07a1.7 1.7 0 0 0-1.03-1.56 1.7 1.7 0 0 0-1.88.34l-.04.04a2 2 0 0 1-2.83-2.83l.04-.04A1.7 1.7 0 0 0 4.6 15a1.7 1.7 0 0 0-1.56-1.03H3a2 2 0 0 1 0-4h.07A1.7 1.7 0 0 0 4.6 8.94a1.7 1.7 0 0 0-.34-1.88l-.04-.04a2 2 0 0 1 2.83-2.83l.04.04a1.7 1.7 0 0 0 1.88.34A1.7 1.7 0 0 0 10 3.07V3a2 2 0 0 1 4 0v.07a1.7 1.7 0 0 0 1.03 1.56 1.7 1.7 0 0 0 1.88-.34l.04-.04a2 2 0 0 1 2.83 2.83l-.04.04a1.7 1.7 0 0 0-.34 1.88 1.7 1.7 0 0 0 1.56 1.03H21a2 2 0 0 1 0 4h-.07A1.7 1.7 0 0 0 19.4 15Z" />
+        </g>
+      ) : null}
+      {normalizedName === 'layout' ? (
+        <g>
+          <rect x="3" y="4" width="7" height="7" rx="1.5" />
+          <rect x="14" y="4" width="7" height="7" rx="1.5" />
+          <rect x="3" y="15" width="18" height="5" rx="1.5" />
+        </g>
+      ) : null}
+      {normalizedName === 'filter' ? (
+        <g>
+          <path d="M4 5h16" />
+          <path d="M7 12h10" />
+          <path d="M10 19h4" />
+        </g>
+      ) : null}
+      {normalizedName === 'branch' ? (
+        <g>
+          <circle cx="6" cy="6" r="3" />
+          <circle cx="18" cy="6" r="3" />
+          <circle cx="18" cy="18" r="3" />
+          <path d="M9 6h4.5A4.5 4.5 0 0 1 18 10.5V15" />
+        </g>
+      ) : null}
+      {normalizedName === 'compare' ? (
+        <g>
+          <path d="M7 4v16" />
+          <path d="M17 4v16" />
+          <path d="M3 8h8" />
+          <path d="M13 16h8" />
+        </g>
+      ) : null}
+      {normalizedName === 'path' ? (
+        <g>
+          <path d="M5 19C7 7 17 17 19 5" />
+          <circle cx="5" cy="19" r="2" />
+          <circle cx="19" cy="5" r="2" />
+        </g>
+      ) : null}
+      {normalizedName === 'chevron' ? <path d="m6 9 6 6 6-6" /> : null}
+    </svg>
+  );
+}
+
+type TabDefinition = {
+  /** Stable tab id derived from the backing section key. */
+  id: StudioSettingsTabId;
+  /** Label rendered in the left rail tab button. */
+  label: string;
+  /** Main heading shown for the active tab. */
+  title: string;
+  /** Optional short category label rendered above the tab heading. */
+  eyebrow?: string;
+  /** Icon rendered next to the tab label. */
+  icon: StudioSettingsIconName;
+  /** Setting descriptors rendered inside this tab. */
+  settings: SettingDescriptor[];
+  /** Whether this tab should render the visual dependency shape selector. */
+  hasLineRoutingSetting: boolean;
+};
+
+type TabGroupDefinition = {
+  /** Stable id for one rail grouping. */
+  id: string;
+  /** Optional heading rendered above grouped tabs. */
+  label?: string;
+  /** Tabs rendered inside this rail grouping. */
+  tabs: TabDefinition[];
+};
+
+type PanelModel = {
+  /** Flat tab list used for active-tab lookup. */
+  tabs: TabDefinition[];
+  /** Grouped tab list rendered in the left rail. */
+  tabGroups: TabGroupDefinition[];
+  /** Settings indexed by dot-path name for special-case schema controls. */
+  settingsByName: Map<string, SettingDescriptor>;
+};
+
+/** Navigation layout used by the Studio settings panel. */
+type DependencyShapeOption = {
+  /** Visual shape key rendered by the SVG preview. */
+  shape: StudioDependencyShape;
+  /** Card title shown under the SVG preview. */
+  title: string;
+  /** Short card hint shown under the title. */
+  subtitle: string;
+  /** Backing schema value written to the settings state. */
+  value: SettingValue;
+};
+
+type SettingGroup = {
+  /** Heading shown above a related group of settings. */
+  title: string;
+  /** Settings rendered under this group heading. */
+  settings: SettingDescriptor[];
+};
+
+const LINE_ROUTING_MODE_SETTING = 'lineRoutingMode';
+const STUDIO_SETTINGS_NAVIGATION_COLLAPSED_STORAGE_KEY =
+  'deck.gl-community:studio-settings:navigation-collapsed';
+const STUDIO_ICON_NAMES = new Set<StudioSettingsIconName>([
+  'settings',
+  'layout',
+  'filter',
+  'branch',
+  'compare',
+  'path',
+  'chevron'
+]);
+
+const DEPENDENCY_SHAPE_LABELS: Record<StudioDependencyShape, {title: string; subtitle: string}> = {
+  straight: {title: 'Straight', subtitle: 'minimal'},
+  arc: {title: 'Arc', subtitle: 'flow'},
+  step: {title: 'Step', subtitle: 'orthogonal'}
+};
+
+/** Renders one section container. */
+function Section({
+  title,
+  eyebrow,
+  children
+}: {
+  title: string;
+  eyebrow?: string;
+  children: ComponentChildren;
+}) {
+  return (
+    <section style={STYLES.section}>
+      <div style={STYLES.sectionHeader}>
+        {eyebrow ? <div style={STYLES.eyebrow}>{eyebrow}</div> : null}
+        <h2 style={STYLES.sectionTitle}>{title}</h2>
+      </div>
+      <div style={STYLES.sectionBody}>{children}</div>
+    </section>
+  );
+}
+
+/** Renders visual setting groups inside one schema-backed Studio section. */
+function SettingGroups({
+  tab,
+  settings,
+  compact,
+  onChange
+}: {
+  tab: TabDefinition | undefined;
+  settings: SettingsState;
+  compact: boolean;
+  onChange: (setting: SettingDescriptor, value: SettingValue) => void;
+}) {
+  return (
+    <>
+      {getSettingGroups(tab).map(group => (
+        <div key={group.title} style={STYLES.settingGroup}>
+          <div style={STYLES.settingGroupTitle}>{group.title}</div>
+          <div style={STYLES.settingGroupBody}>
+            {group.settings.map(setting => (
+              <SettingControl
+                key={setting.name}
+                setting={setting}
+                settings={settings}
+                compact={compact}
+                onChange={value => onChange(setting, value)}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}
+
+/** Builds display groups from schema-owned setting group metadata. */
+function getSettingGroups(tab: TabDefinition | undefined): SettingGroup[] {
+  if (!tab) {
+    return [];
+  }
+  const groups: SettingGroup[] = [];
+  const groupByTitle = new Map<string, SettingGroup>();
+  tab.settings.forEach(setting => {
+    const title = setting.group?.trim() || tab.title;
+    let group = groupByTitle.get(title);
+    if (!group) {
+      group = {title, settings: []};
+      groupByTitle.set(title, group);
+      groups.push(group);
+    }
+    group.settings.push(setting);
+  });
+  return groups;
+}
+
+/** Renders a setting row based on one schema descriptor. */
+function SettingControl({
+  setting,
+  settings,
+  compact,
+  onChange
+}: {
+  setting: SettingDescriptor;
+  settings: SettingsState;
+  compact: boolean;
+  onChange: (value: SettingValue) => void;
+}) {
+  const value = resolveSettingValue(setting, settings);
+  if (setting.type === 'select') {
+    return <SelectControl setting={setting} value={value} compact={compact} onChange={onChange} />;
+  }
+  if (setting.type === 'boolean') {
+    return (
+      <BooleanControl
+        setting={setting}
+        value={Boolean(value)}
+        compact={compact}
+        onChange={onChange}
+      />
+    );
+  }
+  if (setting.type === 'number') {
+    return (
+      <NumberControl
+        setting={setting}
+        value={Number(value)}
+        compact={compact}
+        onChange={onChange}
+      />
+    );
+  }
+  return (
+    <StringControl setting={setting} value={String(value)} compact={compact} onChange={onChange} />
+  );
+}
+
+/** Renders a select setting row. */
+function SelectControl({
+  setting,
+  value,
+  compact,
+  onChange
+}: {
+  setting: SettingDescriptor;
+  value: SettingValue;
+  compact: boolean;
+  onChange: (value: SettingValue) => void;
+}) {
+  const options = (setting.options ?? [getDefaultValue(setting)]).map(normalizeOption);
+  return (
+    <SettingRow setting={setting} compact={compact}>
+      <SelectComponent
+        id={`studio-settings-${setting.name.replace(/[^a-z0-9_-]+/gi, '-')}`}
+        label={setting.label ?? setting.name}
+        value={value}
+        options={options}
+        onValueChange={onChange}
+      />
+    </SettingRow>
+  );
+}
+
+/** Renders a boolean setting row. */
+function BooleanControl({
+  setting,
+  value,
+  compact,
+  onChange
+}: {
+  setting: SettingDescriptor;
+  value: boolean;
+  compact: boolean;
+  onChange: (value: SettingValue) => void;
+}) {
+  return (
+    <SettingRow setting={setting} compact={compact}>
+      <button
+        type="button"
+        aria-pressed={value}
+        style={value ? STYLES.switchButtonActive : STYLES.switchButton}
+        onClick={() => onChange(!value)}
+      >
+        <span style={STYLES.switchText}>{value ? 'Enabled' : 'Disabled'}</span>
+        <span style={value ? STYLES.switchTrackActive : STYLES.switchTrack}>
+          <span style={value ? STYLES.switchKnobActive : STYLES.switchKnob} />
+        </span>
+      </button>
+    </SettingRow>
+  );
+}
+
+/** Renders a number setting row. */
+function NumberControl({
+  setting,
+  value,
+  compact,
+  onChange
+}: {
+  setting: SettingDescriptor;
+  value: number;
+  compact: boolean;
+  onChange: (value: SettingValue) => void;
+}) {
+  const min = Number.isFinite(setting.min) ? (setting.min as number) : 0;
+  const max = Number.isFinite(setting.max) ? (setting.max as number) : Math.max(value, 100);
+  const step = setting.step ?? 'any';
+  const boundedValue = clamp(value, min, max);
+  const sliderDebounceMs = getSliderDebounceMs(setting);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [draftValue, setDraftValue] = useState(boundedValue);
+
+  useEffect(() => {
+    setDraftValue(boundedValue);
+  }, [boundedValue]);
+
+  useEffect(
+    () => () => {
+      clearPendingSliderChange(debounceTimerRef);
+    },
+    []
+  );
+
+  function commitValue(nextValue: number): void {
+    clearPendingSliderChange(debounceTimerRef);
+    setDraftValue(nextValue);
+    onChange(nextValue);
+  }
+
+  function scheduleSliderValue(nextValue: number): void {
+    setDraftValue(nextValue);
+    if (sliderDebounceMs <= 0) {
+      onChange(nextValue);
+      return;
+    }
+
+    clearPendingSliderChange(debounceTimerRef);
+    debounceTimerRef.current = setTimeout(() => {
+      debounceTimerRef.current = null;
+      onChange(nextValue);
+    }, sliderDebounceMs);
+  }
+
+  return (
+    <SettingRow setting={setting} compact={compact}>
+      <div style={STYLES.numberGrid}>
+        <input
+          aria-label={`${setting.label ?? setting.name} slider`}
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={draftValue}
+          style={STYLES.range}
+          onInput={event => scheduleSliderValue(Number(event.currentTarget.value))}
+        />
+        <input
+          aria-label={`${setting.label ?? setting.name} value`}
+          type="number"
+          min={min}
+          max={max}
+          step={step}
+          value={draftValue}
+          style={STYLES.numberInput}
+          onInput={event => commitValue(Number(event.currentTarget.value))}
+        />
+      </div>
+    </SettingRow>
+  );
+}
+
+/** Returns the trailing debounce duration for range slider changes. */
+function getSliderDebounceMs(setting: SettingDescriptor): number {
+  if (!Number.isFinite(setting.sliderDebounceMs)) {
+    return 0;
+  }
+  return Math.max(0, setting.sliderDebounceMs as number);
+}
+
+/** Clears any pending debounced range slider commit. */
+function clearPendingSliderChange(timerRef: {current: ReturnType<typeof setTimeout> | null}): void {
+  if (timerRef.current == null) {
+    return;
+  }
+  clearTimeout(timerRef.current);
+  timerRef.current = null;
+}
+
+/** Renders a string fallback setting row. */
+function StringControl({
+  setting,
+  value,
+  compact,
+  onChange
+}: {
+  setting: SettingDescriptor;
+  value: string;
+  compact: boolean;
+  onChange: (value: SettingValue) => void;
+}) {
+  return (
+    <SettingRow setting={setting} compact={compact}>
+      <input
+        aria-label={setting.label ?? setting.name}
+        type="text"
+        value={value}
+        style={STYLES.textInput}
+        onInput={event => onChange(event.currentTarget.value)}
+      />
+    </SettingRow>
+  );
+}
+
+/** Renders one pill-shaped setting row. */
+function SettingRow({
+  setting,
+  compact,
+  children
+}: {
+  setting: SettingDescriptor;
+  compact: boolean;
+  children: ComponentChildren;
+}) {
+  return (
+    <div style={compact ? STYLES.settingPillCollapsed : STYLES.settingPill}>
+      <div style={STYLES.settingMeta}>
+        <div style={STYLES.settingLabel}>{setting.label ?? humanizeSettingName(setting.name)}</div>
+        {!compact && setting.description ? (
+          <div style={STYLES.settingHint}>{setting.description}</div>
+        ) : null}
+      </div>
+      <div style={STYLES.settingControl}>{children}</div>
+    </div>
+  );
+}
+
+/** Renders the dependency shape card section for lineRoutingMode. */
+function DependencyShapeSection({
+  setting,
+  settings,
+  onChange
+}: {
+  setting: SettingDescriptor;
+  settings: SettingsState;
+  onChange: (value: SettingValue) => void;
+}) {
+  const value = resolveSettingValue(setting, settings);
+  const selectedShape = shapeFromRoutingValue(value);
+  const shapeOptions = getDependencyShapeOptions(setting);
+  return (
+    <section style={STYLES.shapeSection}>
+      <div style={STYLES.shapeHeader}>
+        <div>
+          <h2 style={STYLES.shapeTitle}>Shape</h2>
+          <p style={STYLES.shapeDescription}>Pick the dependency language visually.</p>
+        </div>
+        <StudioSettingsIcon name="branch" size={26} style={STYLES.shapeIcon} />
+      </div>
+      <div style={STYLES.shapeGrid}>
+        {shapeOptions.map(option => (
+          <DependencyShapeCard
+            key={option.shape}
+            option={option}
+            selected={option.shape === selectedShape}
+            onClick={() => onChange(option.value)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/** Renders one SVG dependency routing preview card. */
+function DependencyShapeCard({
+  option,
+  selected,
+  onClick
+}: {
+  option: DependencyShapeOption;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      style={selected ? STYLES.shapeCardSelected : STYLES.shapeCard}
+      onClick={onClick}
+    >
+      <DependencyShapePreview shape={option.shape} />
+      <div style={STYLES.shapeCardFooter}>
+        <div>
+          <div style={STYLES.shapeCardTitle}>{option.title}</div>
+          <div style={STYLES.shapeCardSubtitle}>{option.subtitle}</div>
+        </div>
+        <span style={selected ? STYLES.radioSelected : STYLES.radio}>
+          <span style={selected ? STYLES.radioDotSelected : STYLES.radioDot} />
+        </span>
+      </div>
+    </button>
+  );
+}
+
+/** Renders an SVG preview for one dependency routing shape. */
+function DependencyShapePreview({shape}: {shape: StudioDependencyShape}) {
+  const path =
+    shape === 'arc'
+      ? 'M24 34C46 10 82 10 104 34'
+      : shape === 'step'
+        ? 'M24 34H58V18H104'
+        : 'M24 34H104';
+  return (
+    <svg viewBox="0 0 128 56" fill="none" aria-hidden="true" style={STYLES.shapePreview}>
+      <rect x="12" y="28" width="30" height="14" rx="4" style={STYLES.endpointPill} />
+      <rect x="86" y="28" width="30" height="14" rx="4" style={STYLES.endpointPill} />
+      <path d={path} style={STYLES.dependencyPath} />
+      <circle cx="24" cy="34" r="4.5" style={STYLES.endpointDot} />
+      <circle cx="104" cy="34" r="4.5" style={STYLES.endpointDot} />
+    </svg>
+  );
+}
+
+/** Builds tab settings and lookup maps from visualization and application schemas. */
+function buildPanelModel(schema: SettingsSchema, applicationSchema?: SettingsSchema): PanelModel {
+  const settingsByName = new Map<string, SettingDescriptor>();
+  const visualizationTabs = buildTabsFromSchema(schema, 'visualization', settingsByName);
+  const applicationTabs = applicationSchema
+    ? buildTabsFromSchema(applicationSchema, 'application', settingsByName)
+    : [];
+  const tabs = [...visualizationTabs, ...applicationTabs];
+  const tabGroups: TabGroupDefinition[] = [
+    {id: 'visualization', label: 'Visualization', tabs: visualizationTabs},
+    {
+      id: 'application',
+      label: 'Application',
+      tabs: applicationTabs
+    }
+  ].filter(group => group.tabs.length > 0);
+
+  if (tabs.length > 0) {
+    return {
+      tabs,
+      tabGroups,
+      settingsByName
+    };
+  }
+
+  const fallbackTab = {
+    id: 'settings',
+    label: 'Settings',
+    title: schema.title ?? 'Settings',
+    icon: 'settings' as const,
+    settings: [],
+    hasLineRoutingSetting: false
+  };
+
+  return {
+    tabs: [fallbackTab],
+    tabGroups: [{id: 'visualization', tabs: [fallbackTab]}],
+    settingsByName
+  };
+}
+
+/** Builds tabs from one schema and records settings by name. */
+function buildTabsFromSchema(
+  schema: SettingsSchema,
+  tabIdPrefix: string,
+  settingsByName: Map<string, SettingDescriptor>
+): TabDefinition[] {
+  return schema.sections.flatMap((section, index) => {
+    const settings = section.settings.filter(setting => {
+      settingsByName.set(setting.name, setting);
+      return setting.name !== LINE_ROUTING_MODE_SETTING;
+    });
+    const hasLineRoutingSetting = section.settings.some(
+      setting => setting.name === LINE_ROUTING_MODE_SETTING
+    );
+    if (settings.length === 0 && !hasLineRoutingSetting) {
+      return [];
+    }
+    return [
+      {
+        id: `${tabIdPrefix}:${getSectionKey(section, index)}`,
+        label: getSectionLabel(section, index),
+        title: getSectionLabel(section, index),
+        eyebrow: section.description,
+        icon: getSectionIcon(section),
+        settings,
+        hasLineRoutingSetting
+      }
+    ];
+  });
+}
+
+/** Returns a display label for one schema section. */
+function getSectionLabel(section: SettingsSectionDescriptor, index: number): string {
+  const name = section.name.trim();
+  return name || `Settings ${index + 1}`;
+}
+
+/** Selects an icon for one schema section without changing its grouping. */
+function getSectionIcon(section: SettingsSectionDescriptor): StudioSettingsIconName {
+  const searchable = `${section.id ?? ''} ${section.name}`.toLowerCase();
+  if (searchable.includes('depend')) {
+    return 'branch';
+  }
+  if (
+    searchable.includes('item') ||
+    searchable.includes('feature') ||
+    searchable.includes('render') ||
+    searchable.includes('filter') ||
+    searchable.includes('layout') ||
+    searchable.includes('color')
+  ) {
+    return 'layout';
+  }
+  if (searchable.includes('compare')) {
+    return 'compare';
+  }
+  if (searchable.includes('path') || searchable.includes('animation')) {
+    return 'path';
+  }
+  return 'settings';
+}
+
+/** Builds shape options from the lineRoutingMode setting descriptor. */
+function getDependencyShapeOptions(setting: SettingDescriptor): DependencyShapeOption[] {
+  const normalizedOptions = (setting.options ?? ['straight', 'curve']).map(normalizeOption);
+  const optionsByShape = new Map<StudioDependencyShape, DependencyShapeOption>();
+  normalizedOptions.forEach(option => {
+    const shape = shapeFromRoutingValue(option.value);
+    if (optionsByShape.has(shape)) {
+      return;
+    }
+    const labels = DEPENDENCY_SHAPE_LABELS[shape];
+    optionsByShape.set(shape, {
+      shape,
+      title: labels.title,
+      subtitle: labels.subtitle,
+      value: option.value
+    });
+  });
+  return (['straight', 'arc', 'step'] as const).flatMap(shape => {
+    const existing = optionsByShape.get(shape);
+    return existing ? [existing] : [];
+  });
+}
+
+/** Reads the persisted compact settings-panel mode. */
+function readPersistedNavigationCollapsed(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  return window.localStorage.getItem(STUDIO_SETTINGS_NAVIGATION_COLLAPSED_STORAGE_KEY) === 'true';
+}
+
+/** Stores the compact settings-panel mode for later openings. */
+function writePersistedNavigationCollapsed(collapsed: boolean): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.setItem(
+    STUDIO_SETTINGS_NAVIGATION_COLLAPSED_STORAGE_KEY,
+    collapsed ? 'true' : 'false'
+  );
+}
+
+/** Maps a lineRoutingMode value to the visual shape card id. */
+function shapeFromRoutingValue(value: unknown): StudioDependencyShape {
+  const valueText = String(value).toLowerCase();
+  if (valueText === 'step' || valueText.includes('step')) {
+    return 'step';
+  }
+  if (valueText === 'curve' || valueText === 'arc' || valueText.includes('arc')) {
+    return 'arc';
+  }
+  return 'straight';
+}
+
+/** Converts a camel-case or dotted setting path into a readable label. */
+function humanizeSettingName(name: string): string {
+  const leafName = name.split('.').pop() ?? name;
+  return leafName
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b\w/g, match => match.toUpperCase());
+}
+
+const STYLES = {
+  shell: {
+    width: 'min(calc(100vw - 56px), 720px)',
+    height: 'min(calc(100vh - 56px), 680px)',
+    maxHeight: 'min(calc(100vh - 56px), 680px)',
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+    borderRadius: 'var(--menu-corner-radius, 22px)',
+    border: 'var(--menu-border, 1px solid rgba(148, 163, 184, 0.28))',
+    background: 'var(--menu-background, #334155)',
+    color: 'var(--menu-text, #e2e8f0)',
+    boxShadow: 'var(--menu-shadow, 0 24px 60px rgba(0, 0, 0, 0.35))',
+    fontFamily: 'var(--font-family, system-ui, sans-serif)'
+  },
+  shellCollapsed: {
+    width: 'min(calc(100vw - 56px), 420px)',
+    height: 'min(calc(100vh - 56px), 680px)',
+    maxHeight: 'min(calc(100vh - 56px), 680px)',
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+    borderRadius: 'var(--menu-corner-radius, 22px)',
+    border: 'var(--menu-border, 1px solid rgba(148, 163, 184, 0.28))',
+    background: 'var(--menu-background, #334155)',
+    color: 'var(--menu-text, #e2e8f0)',
+    boxShadow: 'var(--menu-shadow, 0 24px 60px rgba(0, 0, 0, 0.35))',
+    fontFamily: 'var(--font-family, system-ui, sans-serif)'
+  },
+  header: {
+    height: 58,
+    minHeight: 58,
+    maxHeight: 58,
+    flex: '0 0 58px',
+    boxSizing: 'border-box',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '0 18px',
+    borderBottom: 'var(--menu-border, 1px solid rgba(15, 23, 42, 0.35))',
+    background: 'var(--button-background, rgba(15, 23, 42, 0.16))',
+    cursor: 'grab',
+    userSelect: 'none'
+  },
+  headerTopRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    width: '100%',
+    minWidth: 0
+  },
+  headerTitle: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 10,
+    height: 24,
+    minWidth: 0,
+    color: 'var(--button-text, #dbeafe)'
+  },
+  headerActions: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    flex: '0 0 auto'
+  },
+  heading: {
+    margin: 0,
+    fontSize: 14,
+    fontWeight: 800,
+    lineHeight: '18px',
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase'
+  },
+  navigationModeButton: {
+    appearance: 'none',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: 74,
+    height: 24,
+    border: '1px solid var(--menu-border-color, rgba(148, 163, 184, 0.26))',
+    borderRadius: 7,
+    background: 'var(--menu-background, rgba(15, 23, 42, 0.12))',
+    color: 'var(--menu-text, #e2e8f0)',
+    boxShadow: 'none',
+    font: 'inherit',
+    fontSize: 12,
+    fontWeight: 650,
+    lineHeight: 1,
+    outline: 'none',
+    padding: '0 10px',
+    cursor: 'pointer'
+  },
+  navigationModeButtonActive: {
+    appearance: 'none',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: 74,
+    height: 24,
+    border: '1px solid var(--menu-border-color, rgba(148, 163, 184, 0.3))',
+    borderRadius: 7,
+    background: 'var(--menu-item-hover, rgba(15, 23, 42, 0.2))',
+    color: 'var(--menu-text, #f8fafc)',
+    boxShadow: 'none',
+    font: 'inherit',
+    fontSize: 12,
+    fontWeight: 650,
+    lineHeight: 1,
+    outline: 'none',
+    padding: '0 10px',
+    cursor: 'pointer'
+  },
+  headerCloseButton: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 34,
+    height: 30,
+    border: 'none',
+    borderRadius: 10,
+    background: 'transparent',
+    color: 'var(--button-text, #94a3b8)',
+    font: 'inherit',
+    fontSize: 23,
+    lineHeight: 1,
+    padding: 0,
+    cursor: 'pointer'
+  },
+  body: {
+    display: 'grid',
+    gridTemplateColumns: '160px minmax(0, 1fr)',
+    flex: '1 1 auto',
+    minHeight: 0,
+    overflow: 'hidden'
+  },
+  bodyCollapsed: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0, 1fr)',
+    flex: '1 1 auto',
+    minHeight: 0,
+    overflow: 'hidden'
+  },
+  rail: {
+    borderRight: 'var(--menu-border, 1px solid rgba(15, 23, 42, 0.28))',
+    padding: 12,
+    overflowY: 'auto'
+  },
+  railGroup: {
+    display: 'grid',
+    gap: 6,
+    marginBottom: 14
+  },
+  railGroupTitle: {
+    padding: '0 8px',
+    color: 'var(--button-text, #94a3b8)',
+    fontSize: 10,
+    fontWeight: 820,
+    letterSpacing: '0.12em',
+    textAlign: 'center',
+    textTransform: 'uppercase'
+  },
+  tabList: {
+    display: 'grid',
+    gap: 3,
+    padding: 5,
+    borderRadius: 16,
+    background: 'var(--menu-item-hover, rgba(15, 23, 42, 0.22))'
+  },
+  tabButton: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 10,
+    width: '100%',
+    minHeight: 34,
+    border: '1px solid transparent',
+    borderRadius: 11,
+    padding: '0 10px',
+    background: 'transparent',
+    color: 'var(--button-text, #94a3b8)',
+    font: 'inherit',
+    fontSize: 13,
+    fontWeight: 700,
+    textAlign: 'left',
+    cursor: 'pointer'
+  },
+  tabButtonActive: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 10,
+    width: '100%',
+    minHeight: 34,
+    border: 'var(--menu-border, 1px solid rgba(103, 232, 249, 0.45))',
+    borderRadius: 11,
+    padding: '0 10px',
+    background: 'var(--button-background, rgba(103, 232, 249, 0.14))',
+    color: 'var(--button-icon-hover, #cffafe)',
+    font: 'inherit',
+    fontSize: 13,
+    fontWeight: 760,
+    textAlign: 'left',
+    cursor: 'pointer'
+  },
+  preset: {
+    marginTop: 18,
+    borderRadius: 20,
+    border: 'var(--menu-border, 1px solid rgba(148, 163, 184, 0.18))',
+    background: 'var(--menu-item-hover, rgba(15, 23, 42, 0.18))',
+    padding: 14
+  },
+  presetEyebrow: {
+    marginBottom: 10,
+    fontSize: 11,
+    fontWeight: 800,
+    letterSpacing: '0.12em',
+    textTransform: 'uppercase',
+    color: 'var(--button-text, #94a3b8)'
+  },
+  presetCard: {
+    borderRadius: 14,
+    border: 'var(--menu-border, 1px solid rgba(103, 232, 249, 0.28))',
+    background: 'var(--button-background, rgba(103, 232, 249, 0.12))',
+    color: 'var(--button-icon-hover, #cffafe)',
+    padding: '12px 14px',
+    fontSize: 14,
+    fontWeight: 850
+  },
+  main: {
+    display: 'grid',
+    gap: 10,
+    alignContent: 'start',
+    minWidth: 0,
+    minHeight: 0,
+    padding: 16,
+    overflowY: 'auto',
+    overscrollBehavior: 'contain'
+  },
+  mainCollapsed: {
+    display: 'grid',
+    gap: 12,
+    alignContent: 'start',
+    minWidth: 0,
+    minHeight: 0,
+    padding: 16,
+    overflowY: 'auto',
+    overscrollBehavior: 'contain'
+  },
+  sectionStackItem: {
+    display: 'grid',
+    gap: 10,
+    minWidth: 0
+  },
+  section: {
+    borderRadius: 18,
+    border: 'var(--menu-border, 1px solid rgba(148, 163, 184, 0.24))',
+    background: 'var(--menu-item-hover, rgba(255, 255, 255, 0.035))',
+    padding: 14
+  },
+  sectionHeader: {
+    paddingBottom: 12,
+    marginBottom: 10,
+    borderBottom: 'var(--menu-border, 1px solid rgba(15, 23, 42, 0.34))'
+  },
+  eyebrow: {
+    marginBottom: 6,
+    color: 'var(--button-icon-hover, #99f6e4)',
+    fontSize: 10,
+    fontWeight: 900,
+    letterSpacing: '0.22em',
+    textTransform: 'uppercase'
+  },
+  sectionTitle: {
+    margin: 0,
+    color: 'var(--menu-text, #f8fafc)',
+    fontSize: 18,
+    lineHeight: 1.1,
+    fontWeight: 900
+  },
+  sectionBody: {
+    display: 'grid',
+    gap: 14
+  },
+  settingGroup: {
+    display: 'grid',
+    gap: 8
+  },
+  settingGroupTitle: {
+    color: 'var(--button-icon-hover, #99f6e4)',
+    fontSize: 10,
+    fontWeight: 820,
+    letterSpacing: '0.16em',
+    textTransform: 'uppercase'
+  },
+  settingGroupBody: {
+    display: 'grid',
+    gap: 10
+  },
+  settingPill: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(170px, 220px) minmax(180px, 1fr)',
+    alignItems: 'center',
+    gap: 12,
+    minHeight: 56,
+    borderRadius: 14,
+    background: 'var(--button-background, rgba(15, 23, 42, 0.32))',
+    boxShadow: 'inset 0 0 0 1px rgba(15, 23, 42, 0.08)',
+    padding: '10px 14px'
+  },
+  settingPillCollapsed: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
+    alignItems: 'center',
+    gap: 10,
+    minHeight: 56,
+    borderRadius: 14,
+    background: 'var(--button-background, rgba(15, 23, 42, 0.32))',
+    boxShadow: 'inset 0 0 0 1px rgba(15, 23, 42, 0.08)',
+    padding: '10px 14px'
+  },
+  settingMeta: {
+    minWidth: 0
+  },
+  settingControl: {
+    minWidth: 0
+  },
+  settingLabel: {
+    color: 'var(--menu-text, #dbeafe)',
+    fontSize: 13,
+    fontWeight: 760
+  },
+  settingHint: {
+    marginTop: 3,
+    color: 'var(--button-text, #94a3b8)',
+    fontSize: 11,
+    lineHeight: 1.3,
+    fontWeight: 620
+  },
+  numberGrid: {
+    display: 'grid',
+    width: '100%',
+    minWidth: 0,
+    gridTemplateColumns: 'minmax(0, 1fr) 70px',
+    gap: 12,
+    alignItems: 'center'
+  },
+  range: {
+    width: '100%',
+    minWidth: 0,
+    accentColor: 'var(--button-icon-hover, #60a5fa)'
+  },
+  numberInput: {
+    width: '100%',
+    minWidth: 0,
+    minHeight: 36,
+    boxSizing: 'border-box',
+    borderRadius: 13,
+    border: 'var(--menu-border, 1px solid rgba(148, 163, 184, 0.24))',
+    background: 'var(--menu-background, rgba(51, 65, 85, 0.78))',
+    color: 'var(--menu-text, #f8fafc)',
+    textAlign: 'center',
+    font: 'inherit',
+    fontSize: 13,
+    fontWeight: 760
+  },
+  textInput: {
+    width: '100%',
+    minHeight: 36,
+    borderRadius: 13,
+    border: 'var(--menu-border, 1px solid rgba(148, 163, 184, 0.24))',
+    background: 'var(--menu-background, rgba(51, 65, 85, 0.78))',
+    color: 'var(--menu-text, #f8fafc)',
+    padding: '0 16px',
+    font: 'inherit',
+    fontSize: 13,
+    fontWeight: 700
+  },
+  switchButton: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    width: '100%',
+    minHeight: 36,
+    border: 'none',
+    background: 'transparent',
+    color: 'var(--button-text, #94a3b8)',
+    font: 'inherit',
+    cursor: 'pointer'
+  },
+  switchButtonActive: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    width: '100%',
+    minHeight: 36,
+    border: 'none',
+    background: 'transparent',
+    color: 'var(--button-icon-hover, #cffafe)',
+    font: 'inherit',
+    cursor: 'pointer'
+  },
+  switchText: {
+    fontSize: 13,
+    fontWeight: 700
+  },
+  switchTrack: {
+    display: 'flex',
+    alignItems: 'center',
+    width: 44,
+    height: 24,
+    borderRadius: 999,
+    background: 'var(--menu-item-hover, rgba(15, 23, 42, 0.48))',
+    padding: 2
+  },
+  switchTrackActive: {
+    display: 'flex',
+    alignItems: 'center',
+    width: 44,
+    height: 24,
+    borderRadius: 999,
+    background: 'var(--button-icon-hover, #60a5fa)',
+    padding: 2
+  },
+  switchKnob: {
+    width: 20,
+    height: 20,
+    borderRadius: 999,
+    background: 'var(--button-text, #94a3b8)'
+  },
+  switchKnobActive: {
+    width: 20,
+    height: 20,
+    borderRadius: 999,
+    background: 'var(--menu-text, #ffffff)',
+    transform: 'translateX(20px)'
+  },
+  emptyState: {
+    color: 'var(--button-text, #94a3b8)',
+    fontSize: 12
+  },
+  shapeSection: {
+    borderRadius: 16,
+    border: 'var(--menu-border, 1px solid rgba(103, 232, 249, 0.24))',
+    background: 'var(--menu-item-hover, rgba(103, 232, 249, 0.045))',
+    padding: 14
+  },
+  shapeHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'start',
+    gap: 12,
+    marginBottom: 12
+  },
+  shapeTitle: {
+    margin: 0,
+    color: 'var(--menu-text, #f8fafc)',
+    fontSize: 14,
+    fontWeight: 800
+  },
+  shapeDescription: {
+    margin: '4px 0 0',
+    color: 'var(--button-text, #94a3b8)',
+    fontSize: 12,
+    fontWeight: 620
+  },
+  shapeIcon: {
+    color: 'var(--button-icon-hover, #99f6e4)'
+  },
+  shapeGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+    gap: 8
+  },
+  shapeCard: {
+    minHeight: 82,
+    display: 'grid',
+    alignContent: 'space-between',
+    borderRadius: 12,
+    border: 'var(--menu-border, 1px solid rgba(148, 163, 184, 0.18))',
+    background: 'var(--button-background, rgba(15, 23, 42, 0.32))',
+    color: 'var(--menu-text, #f8fafc)',
+    padding: 9,
+    textAlign: 'left',
+    cursor: 'pointer'
+  },
+  shapeCardSelected: {
+    minHeight: 82,
+    display: 'grid',
+    alignContent: 'space-between',
+    borderRadius: 12,
+    border: 'var(--menu-border, 1px solid rgba(103, 232, 249, 0.7))',
+    background: 'var(--button-background, rgba(103, 232, 249, 0.14))',
+    color: 'var(--menu-text, #f8fafc)',
+    padding: 9,
+    textAlign: 'left',
+    cursor: 'pointer'
+  },
+  shapePreview: {
+    width: '100%',
+    height: 30
+  },
+  endpointPill: {
+    fill: 'var(--menu-background, rgba(51, 65, 85, 0.88))'
+  },
+  dependencyPath: {
+    stroke: 'var(--button-icon-hover, #67e8f9)',
+    strokeWidth: 3,
+    strokeLinecap: 'round',
+    strokeLinejoin: 'round'
+  },
+  endpointDot: {
+    fill: 'var(--button-icon-hover, #a5f3fc)'
+  },
+  shapeCardFooter: {
+    display: 'flex',
+    alignItems: 'end',
+    justifyContent: 'space-between',
+    gap: 10
+  },
+  shapeCardTitle: {
+    color: 'var(--menu-text, #f8fafc)',
+    fontSize: 11,
+    fontWeight: 800
+  },
+  shapeCardSubtitle: {
+    marginTop: 2,
+    color: 'var(--button-text, #94a3b8)',
+    fontSize: 10,
+    fontWeight: 620
+  },
+  radio: {
+    display: 'grid',
+    placeItems: 'center',
+    width: 14,
+    height: 14,
+    borderRadius: 999,
+    border: 'var(--menu-border, 2px solid rgba(148, 163, 184, 0.65))'
+  },
+  radioSelected: {
+    display: 'grid',
+    placeItems: 'center',
+    width: 14,
+    height: 14,
+    borderRadius: 999,
+    border: 'var(--menu-border, 2px solid rgba(103, 232, 249, 0.9))',
+    background: 'var(--button-background, rgba(103, 232, 249, 0.16))'
+  },
+  radioDot: {
+    width: 5,
+    height: 5,
+    borderRadius: 999,
+    background: 'transparent'
+  },
+  radioDotSelected: {
+    width: 5,
+    height: 5,
+    borderRadius: 999,
+    background: 'var(--button-icon-hover, #a5f3fc)'
+  }
+} satisfies Record<string, JSX.CSSProperties>;

--- a/modules/widgets/src/index.ts
+++ b/modules/widgets/src/index.ts
@@ -33,6 +33,7 @@ export {
   type OmniBoxOption,
   type OmniBoxOptionProvider,
   type OmniBoxRenderOptionArgs,
+  type OmniBoxResultsSummaryArgs,
   type OmniBoxWidgetProps
 } from './widgets/omni-box-widget';
 export {ResetViewWidget, type ResetViewWidgetProps} from './widget-panels/reset-view-widget';
@@ -58,6 +59,11 @@ export {
   type ModalPanelWidgetProps,
   type ModalWidgetProps
 } from './widget-panels/modal-widget';
+export {
+  createStudioSettingsWidget,
+  updateStudioSettingsWidget,
+  type StudioSettingsWidgetProps
+} from './widget-panels/studio-settings-widget';
 export {IconButton, makeTextIcon} from './widget-components/icon-button';
 export {
   SidebarPanelWidget,

--- a/modules/widgets/src/widget-panels/studio-settings-widget.test.tsx
+++ b/modules/widgets/src/widget-panels/studio-settings-widget.test.tsx
@@ -1,0 +1,64 @@
+import {describe, expect, it} from 'vitest';
+
+import {createStudioSettingsWidget, updateStudioSettingsWidget} from './studio-settings-widget';
+
+import type {SettingsSchema, SettingsState} from '@deck.gl-community/panels';
+
+const TEST_SCHEMA: SettingsSchema = {
+  sections: [
+    {
+      id: 'display',
+      name: 'Display',
+      settings: [
+        {
+          name: 'showGrid',
+          label: 'Show grid',
+          type: 'boolean',
+          defaultValue: true
+        }
+      ]
+    }
+  ]
+};
+
+const TEST_SETTINGS: SettingsState = {
+  showGrid: true
+};
+
+describe('createStudioSettingsWidget', () => {
+  it('creates a non-blocking floating modal widget around StudioSettingsPanel', () => {
+    const widget = createStudioSettingsWidget({
+      schema: TEST_SCHEMA,
+      settings: TEST_SETTINGS
+    });
+
+    expect(widget.props.presentation).toBe('floating');
+    expect(widget.props.dialogPlacement).toBe('left');
+    expect(widget.props.title).toBe('Settings');
+    expect(widget.props.triggerLabel).toBe('Settings');
+    expect(widget.props.hideCloseButton).toBe(true);
+    expect(widget.props.draggable).toBe(true);
+    expect(widget.props.dragHandleSelector).toBe('[data-studio-settings-drag-handle="true"]');
+    expect(widget.props.dialogStyle).toMatchObject({maxWidth: 'calc(100vw - 48px)'});
+    expect(widget.props.contentStyle).toMatchObject({padding: 0, overflow: 'visible'});
+    expect(widget.props.panel?.id).toBe('studio-settings-panel');
+  });
+
+  it('updates an existing widget without replacing the instance', () => {
+    const widget = createStudioSettingsWidget({
+      schema: TEST_SCHEMA,
+      settings: TEST_SETTINGS
+    });
+
+    updateStudioSettingsWidget(widget, {
+      schema: TEST_SCHEMA,
+      settings: {...TEST_SETTINGS, showGrid: false},
+      title: 'Display settings',
+      triggerLabel: 'Display'
+    });
+
+    expect(widget.props.title).toBe('Display settings');
+    expect(widget.props.triggerLabel).toBe('Display');
+    expect(widget.props.panel?.content).toBeTruthy();
+  });
+});

--- a/modules/widgets/src/widget-panels/studio-settings-widget.tsx
+++ b/modules/widgets/src/widget-panels/studio-settings-widget.tsx
@@ -1,0 +1,79 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {createStudioSettingsPanel} from '@deck.gl-community/panels';
+
+import {ModalPanelWidget} from './modal-widget';
+
+import type {StudioSettingsPanelProps} from '@deck.gl-community/panels';
+import type {ModalPanelWidgetProps} from './modal-widget';
+import type {JSX} from 'preact';
+
+const STUDIO_SETTINGS_DRAG_HANDLE_SELECTOR = '[data-studio-settings-drag-handle="true"]';
+const STUDIO_SETTINGS_DIALOG_STYLE: JSX.CSSProperties = {
+  maxWidth: 'calc(100vw - 48px)'
+};
+const STUDIO_SETTINGS_CONTENT_STYLE: JSX.CSSProperties = {
+  padding: 0,
+  overflow: 'visible'
+};
+
+/** Props accepted by the floating Studio settings deck widget factory. */
+export type StudioSettingsWidgetProps = StudioSettingsPanelProps &
+  Omit<ModalPanelWidgetProps, 'panel'>;
+
+/** Creates a floating deck widget that hosts the Studio settings panel. */
+export function createStudioSettingsWidget(props: StudioSettingsWidgetProps): ModalPanelWidget {
+  return new ModalPanelWidget(buildStudioSettingsWidgetProps(props));
+}
+
+/** Updates an existing Studio settings widget without replacing the deck widget instance. */
+export function updateStudioSettingsWidget(
+  widget: ModalPanelWidget,
+  props: StudioSettingsWidgetProps
+): void {
+  widget.setProps(buildStudioSettingsWidgetProps(props));
+}
+
+function buildStudioSettingsWidgetProps(props: StudioSettingsWidgetProps): ModalPanelWidgetProps {
+  const {
+    schema,
+    applicationSchema,
+    fontFamily,
+    settings,
+    onSettingsChange,
+    presetLabel,
+    ...modalProps
+  } = props;
+  const title = modalProps.title ?? 'Settings';
+  return {
+    ...modalProps,
+    id: modalProps.id ?? 'studio-settings',
+    placement: modalProps.placement ?? 'top-left',
+    title,
+    dialogPlacement: modalProps.dialogPlacement ?? 'left',
+    triggerLabel: modalProps.triggerLabel ?? title,
+    dialogStyle: {
+      ...STUDIO_SETTINGS_DIALOG_STYLE,
+      ...modalProps.dialogStyle
+    },
+    contentStyle: {
+      ...STUDIO_SETTINGS_CONTENT_STYLE,
+      ...modalProps.contentStyle
+    },
+    showTitleBar: modalProps.showTitleBar ?? false,
+    hideCloseButton: modalProps.hideCloseButton ?? true,
+    presentation: modalProps.presentation ?? 'floating',
+    draggable: modalProps.draggable ?? true,
+    dragHandleSelector: modalProps.dragHandleSelector ?? STUDIO_SETTINGS_DRAG_HANDLE_SELECTOR,
+    panel: createStudioSettingsPanel({
+      schema,
+      applicationSchema,
+      fontFamily,
+      settings,
+      onSettingsChange,
+      presetLabel
+    })
+  };
+}

--- a/modules/widgets/src/widgets/omni-box-widget.test.tsx
+++ b/modules/widgets/src/widgets/omni-box-widget.test.tsx
@@ -162,6 +162,40 @@ describe('OmniBoxWidget', () => {
     cleanup();
   });
 
+  it('renders a caller-provided results summary above search options', async () => {
+    const {root, cleanup} = renderWidget({
+      minQueryLength: 0,
+      getOptions: () => [
+        {
+          id: 'alpha',
+          label: 'Alpha item'
+        },
+        {
+          id: 'beta',
+          label: 'Beta item'
+        }
+      ],
+      renderResultsSummary: ({mode, options, query}) =>
+        `${mode}:${query || '<empty>'}:${options.length}`
+    });
+
+    await act(async () => {});
+    const input = root.querySelector('input[aria-label="OmniBox"]') as HTMLInputElement;
+    await act(async () => {
+      input.focus();
+      input.dispatchEvent(new FocusEvent('focus', {bubbles: false}));
+      input.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
+    });
+    await act(async () => {
+      await new Promise(resolve => window.setTimeout(resolve, 0));
+    });
+
+    const summary = root.querySelector('[data-omni-box-results-summary="true"]');
+    expect(summary?.textContent).toBe('search:<empty>:2');
+
+    cleanup();
+  });
+
   it('closes an open result dropdown before hiding the widget on Escape', async () => {
     const {root, cleanup} = renderWidget({
       minQueryLength: 0,

--- a/modules/widgets/src/widgets/omni-box-widget.tsx
+++ b/modules/widgets/src/widgets/omni-box-widget.tsx
@@ -7,6 +7,7 @@ import type {Deck, Viewport, WidgetPlacement, WidgetProps} from '@deck.gl/core';
 import type {ComponentChildren, JSX} from 'preact';
 
 const OPTION_ROW_HEIGHT_PX = 32;
+const RESULTS_SUMMARY_HEIGHT_PX = 24;
 const MAX_VISIBLE_OPTION_COUNT = 4;
 const BLUR_CLOSE_DELAY_MS = 100;
 const OMNIBOX_MAX_WIDTH_PX = 520;
@@ -137,9 +138,22 @@ const DROPDOWN_STYLE: JSX.CSSProperties = {
   boxShadow: 'var(--menu-shadow, 0px 0px 8px 0px rgba(0, 0, 0, 0.25))',
   color: 'var(--menu-text, rgb(24, 24, 26))',
   overflowY: 'auto',
-  maxHeight: `${OPTION_ROW_HEIGHT_PX * MAX_VISIBLE_OPTION_COUNT}px`,
+  maxHeight: `${OPTION_ROW_HEIGHT_PX * MAX_VISIBLE_OPTION_COUNT + RESULTS_SUMMARY_HEIGHT_PX}px`,
   padding: '4px 0',
   pointerEvents: 'auto'
+};
+
+const RESULTS_SUMMARY_STYLE: JSX.CSSProperties = {
+  minHeight: `${RESULTS_SUMMARY_HEIGHT_PX}px`,
+  boxSizing: 'border-box',
+  display: 'flex',
+  alignItems: 'center',
+  padding: '4px 12px',
+  borderBottom: '1px solid var(--menu-border-color, rgba(148, 163, 184, 0.28))',
+  color: 'var(--menu-text, rgb(24, 24, 26))',
+  fontSize: '11px',
+  fontFamily: WIDGET_FONT_FAMILY,
+  opacity: 0.68
 };
 
 const DEFAULT_OPTION_CONTENT_STYLE: JSX.CSSProperties = {
@@ -264,6 +278,15 @@ export type OmniBoxRenderOptionArgs = {
   query: string;
 };
 
+export type OmniBoxResultsSummaryArgs = {
+  /** Current trimmed query used to produce the visible dropdown options. */
+  readonly query: string;
+  /** Options currently rendered in the dropdown. */
+  readonly options: ReadonlyArray<OmniBoxOption>;
+  /** Dropdown mode that produced the visible options. */
+  readonly mode: 'search' | 'command' | 'history';
+};
+
 export type OmniBoxWidgetProps = WidgetProps & {
   placement?: WidgetPlacement;
   placeholder?: string;
@@ -282,6 +305,8 @@ export type OmniBoxWidgetProps = WidgetProps & {
   topOffsetPx?: number;
   getOptions?: OmniBoxOptionProvider;
   renderOption?: (args: OmniBoxRenderOptionArgs) => ComponentChildren;
+  /** Optional renderer for a compact row above the current dropdown results. */
+  renderResultsSummary?: (args: OmniBoxResultsSummaryArgs) => ComponentChildren;
   onSelectOption?: (option: OmniBoxOption) => void;
   onActiveOptionChange?: (option: OmniBoxOption | null) => void;
   onNavigateOption?: (option: OmniBoxOption) => void;
@@ -309,6 +334,8 @@ type OmniBoxWidgetViewProps = {
   getOptions: OmniBoxOptionProvider;
   /** Custom renderer for a suggestion row. */
   renderOption?: (args: OmniBoxRenderOptionArgs) => ComponentChildren;
+  /** Optional renderer for a compact row above the current dropdown results. */
+  renderResultsSummary?: (args: OmniBoxResultsSummaryArgs) => ComponentChildren;
   /** Called when a suggestion is selected by click or Enter. */
   onSelectOption?: (option: OmniBoxOption) => void;
   /** Called when keyboard navigation changes the active suggestion. */
@@ -408,6 +435,7 @@ function OmniBoxWidgetView({
   showAnchorButton,
   getOptions,
   renderOption,
+  renderResultsSummary,
   onSelectOption,
   onActiveOptionChange,
   onNavigateOption,
@@ -697,6 +725,17 @@ function OmniBoxWidgetView({
   const hasMatches = options.length > 0;
   const hasQueryHistory = queryHistoryOptions.length > 0;
   const normalizedQuery = query.trim();
+  const dropdownMode: OmniBoxResultsSummaryArgs['mode'] = isShowingQueryHistory
+    ? 'history'
+    : 'search';
+  const resultsSummary =
+    !isLoading && renderResultsSummary
+      ? renderResultsSummary({
+          query: normalizedQuery,
+          options: visibleOptions,
+          mode: dropdownMode
+        })
+      : null;
   const shouldShowDropdown =
     !isHidden &&
     (isShowingQueryHistory ||
@@ -984,6 +1023,12 @@ function OmniBoxWidgetView({
             </div>
           )}
 
+          {!isLoading && resultsSummary != null && resultsSummary !== false && (
+            <div data-omni-box-results-summary="true" style={RESULTS_SUMMARY_STYLE}>
+              {resultsSummary}
+            </div>
+          )}
+
           {!isLoading &&
             visibleOptions.map((option, index) => {
               const isActive = index === activeOptionIndex;
@@ -1064,6 +1109,7 @@ export class OmniBoxWidget extends Widget<OmniBoxWidgetProps> {
     topOffsetPx: undefined,
     getOptions: (() => []) as OmniBoxOptionProvider,
     renderOption: undefined,
+    renderResultsSummary: undefined,
     onSelectOption: undefined,
     onActiveOptionChange: undefined,
     onNavigateOption: undefined,
@@ -1123,6 +1169,7 @@ export class OmniBoxWidget extends Widget<OmniBoxWidgetProps> {
         }
         getOptions={this.props.getOptions ?? OmniBoxWidget.defaultProps.getOptions}
         renderOption={this.props.renderOption}
+        renderResultsSummary={this.props.renderResultsSummary}
         onSelectOption={this.props.onSelectOption}
         onActiveOptionChange={this.props.onActiveOptionChange}
         onNavigateOption={this.props.onNavigateOption}


### PR DESCRIPTION
## Summary

- Add `StudioSettingsPanel` to `@deck.gl-community/panels` with schema-driven grouped settings, navigation, and dependency-shape controls.
- Add `SettingsManager` and `CommandManager` as public, documented helpers for settings persistence and shared command registration/execution.
- Add `createStudioSettingsWidget` / `updateStudioSettingsWidget` to `@deck.gl-community/widgets`.
- Extend `PanelModal` and modal widgets with floating, draggable, left-placement, custom style, and content-close support.
- Add `SettingsPanel` slider debounce support and `OmniBoxWidget` `renderResultsSummary`.
- Update API docs, sidebars, and `docs/whats-new.md`.