### PR TITLE
finish draw-polygon mode cartesian and add tests

### DIFF
--- a/modules/editable-layers/src/edit-modes/cartesian-utils.ts
+++ b/modules/editable-layers/src/edit-modes/cartesian-utils.ts
@@ -1,0 +1,95 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Feature, Polygon} from 'geojson';
+import {ModeProps} from './types';
+import {Position, FeatureCollection} from '../utils/geojson-types';
+import {CartesianCoordinateSystem} from './coordinate-system';
+
+/** Given 3 positions compute cross product of vectors (q-p) and (r-p)
+ * @param p start of directed line segment
+ * @param q end of directed line segment
+ * @param r position being tested
+ * @returns positive num if r is left, negative if right, 0 if collienar with p-q
+ */
+export function orientation(p: Position, q: Position, r: Position): number {
+  return (q[0] - p[0]) * (r[1] - p[1]) - (q[1] - p[1]) * (r[0] - p[0]);
+}
+
+/** Check if two line segments intersect given 4 points - segment1(p1,p2), segment2(p3,p4)
+ * Are p3→ p4 on opposite sides of line p1→ p2? And p1→ p2 on opposite sides of p3→ p4?
+ * If both yes then the segments cross, not just touch
+ * @param p1 start segment 1
+ * @param p2 end segment 1
+ * @param p3 start segment 2
+ * @param p4 end segment 2
+ * @returns true if segements intersect - false if non-intersecting
+ */
+export function segmentsIntersect(p1: Position, p2: Position, p3: Position, p4: Position): boolean {
+  const o1 = orientation(p1, p2, p3);
+  const o2 = orientation(p1, p2, p4);
+  const o3 = orientation(p3, p4, p1);
+  const o4 = orientation(p3, p4, p2);
+  return o1 * o2 < 0 && o3 * o4 < 0;
+}
+
+/** Check if two polygons have intersecting edges and returns true for intersection
+ * @param featureA polygon feature
+ * @param featureB polyfon feature
+ * @returns true if intersection
+ */
+export function polygonEdgesIntersect(
+  featureA: Feature<Polygon>,
+  featureB: Feature<Polygon>
+): boolean {
+  const ringA = featureA.geometry.coordinates[0];
+  const ringB = featureB.geometry.coordinates[0];
+  for (let i = 0; i < ringA.length - 1; i++) {
+    for (let j = 0; j < ringB.length - 1; j++) {
+      if (segmentsIntersect(ringA[i], ringA[i + 1], ringB[j], ringB[j + 1])) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** Check if point in polygon using standard ray casting algorithm
+ * @param point the position to test
+ * @param ring the polygon to test
+ * @returns true if point inside polygon
+ */
+export function pointInPolygon(point: Position, ring: Position[]): boolean {
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const xi = ring[i][0];
+    const yi = ring[i][1];
+    const xj = ring[j][0];
+    const yj = ring[j][1];
+    if (
+      yi > point[1] !== yj > point[1] &&
+      point[0] < ((xj - xi) * (point[1] - yi)) / (yj - yi) + xi
+    ) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+/** Uses pointInPolygon() to check if one polygon is inside another
+ * @param featureA inner polygon
+ * @param featureB outer polygon
+ * @returns true if featureA is inside of featureB
+ */
+export function polygonWithinPolygon(
+  featureA: Feature<Polygon>,
+  featureB: Feature<Polygon>
+): boolean {
+  const inner = featureA.geometry.coordinates[0];
+  const outer = featureB.geometry.coordinates[0];
+  for (const p of inner) {
+    if (!pointInPolygon(p, outer)) return false;
+  }
+  return true;
+}

--- a/modules/editable-layers/src/edit-modes/draw-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-polygon-mode.ts
@@ -305,14 +305,7 @@ export class DrawPolygonMode extends GeoJsonEditMode {
     }
 
     // Check outer polygon conflicts after iteration
-    // const intersectionWithOuter = cartesian
-    //   ? polygonEdgesIntersect(outer, newPolygon)
-    //   : lineIntersect(outer, newPolygon).features.length > 0;
-    const intersectionWithOuter = isIntersectionWithOuter(
-      outer,
-      newPolygon,
-      props.coordinateSystem
-    );
+    const intersectionWithOuter = isPolygonIntersecting(outer, newPolygon, props.coordinateSystem);
     if (intersectionWithOuter) {
       props.onEdit({
         updatedData: props.data,
@@ -322,9 +315,7 @@ export class DrawPolygonMode extends GeoJsonEditMode {
       return {handled: true};
     }
 
-    const outerWithin = cartesian
-      ? polygonWithinPolygon(outer, newPolygon)
-      : booleanWithin(outer, newPolygon);
+    const outerWithin = isPolygonWithin(outer, newPolygon, props.coordinateSystem);
     if (outerWithin) {
       props.onEdit({
         updatedData: props.data,
@@ -335,9 +326,7 @@ export class DrawPolygonMode extends GeoJsonEditMode {
     }
 
     // Check if new polygon is within outer polygon (valid hole)
-    const newWithinOuter = cartesian
-      ? polygonWithinPolygon(newPolygon, outer)
-      : booleanWithin(newPolygon, outer);
+    const newWithinOuter = isPolygonWithin(newPolygon, outer, props.coordinateSystem);
     if (newWithinOuter) {
       const updatedData = new ImmutableFeatureCollection(props.data)
         .replaceGeometry(featureIndex, {
@@ -386,63 +375,47 @@ function getPolygonFeature(
     : turfPolygon(polygonGeometry);
 }
 
+// Dispatch function to call function based on coord system, defaults to geo mode
+function forCoordSystem<T>(
+  coordSystem: EditModeCoordinateSystem,
+  geoFn: () => T,
+  cartFn: () => T
+): T {
+  return coordSystem === cartesianCoordinateSystem ? cartFn() : geoFn();
+}
+
 function isContainingOrContained(
-  polygon1: Feature<Polygon>,
-  polygon2: Feature<Polygon>,
-  coordinateSystem: EditModeCoordinateSystem
+  poly1: Feature<Polygon>,
+  poly2: Feature<Polygon>,
+  coordSystem: EditModeCoordinateSystem
 ): boolean {
-  let containsOrContained = false;
-  switch (coordinateSystem) {
-    case geoCoordinateSystem:
-    case undefined:
-      containsOrContained = booleanWithin(polygon1, polygon2) || booleanWithin(polygon2, polygon1);
-      break;
-    case cartesianCoordinateSystem:
-      containsOrContained =
-        polygonWithinPolygon(polygon1, polygon2) || polygonWithinPolygon(polygon2, polygon1);
-      break;
-    default:
-      break;
-  }
-  return containsOrContained;
+  return forCoordSystem(
+    coordSystem,
+    () => booleanWithin(poly1, poly2) || booleanWithin(poly2, poly1),
+    () => polygonWithinPolygon(poly1, poly2) || polygonWithinPolygon(poly2, poly1)
+  );
 }
 
 function isPolygonIntersecting(
-  polygon1: Feature<Polygon>,
-  polygon2: Feature<Polygon>,
-  coordinateSystem: EditModeCoordinateSystem
+  poly1: Feature<Polygon>,
+  poly2: Feature<Polygon>,
+  coordSystem: EditModeCoordinateSystem
 ): boolean {
-  let polygonIntersecting = false;
-  switch (coordinateSystem) {
-    case geoCoordinateSystem:
-    case undefined:
-      polygonIntersecting = lineIntersect(polygon1, polygon2).features.length > 0;
-      break;
-    case cartesianCoordinateSystem:
-      polygonIntersecting = polygonEdgesIntersect(polygon1, polygon2);
-      break;
-    default:
-      break;
-  }
-  return polygonIntersecting;
+  return forCoordSystem(
+    coordSystem,
+    () => lineIntersect(poly1, poly2).features.length > 0,
+    () => polygonEdgesIntersect(poly1, poly2)
+  );
 }
 
-function isIntersectionWithOuter(
-  polygon1: Feature<Polygon>,
-  polygon2: Feature<Polygon>,
-  coordinateSystem: EditModeCoordinateSystem
+function isPolygonWithin(
+  poly1: Feature<Polygon>,
+  poly2: Feature<Polygon>,
+  coordSystem: EditModeCoordinateSystem
 ): boolean {
-  let intersectionWithOuter = false;
-  switch (coordinateSystem) {
-    case geoCoordinateSystem:
-    case undefined:
-      intersectionWithOuter = lineIntersect(polygon1, polygon2).features.length > 0;
-      break;
-    case cartesianCoordinateSystem:
-      intersectionWithOuter = polygonEdgesIntersect(polygon1, polygon2);
-      break;
-    default:
-      break;
-  }
-  return intersectionWithOuter;
+  return forCoordSystem(
+    coordSystem,
+    () => booleanWithin(poly1, poly2),
+    () => polygonWithinPolygon(poly1, poly2)
+  );
 }

--- a/modules/editable-layers/src/edit-modes/draw-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-polygon-mode.ts
@@ -20,7 +20,13 @@ import {Position, FeatureCollection, SimpleFeatureCollection} from '../utils/geo
 import {getPickedEditHandle} from './utils';
 import {GeoJsonEditMode} from './geojson-edit-mode';
 import {ImmutableFeatureCollection} from './immutable-feature-collection';
-import {CartesianCoordinateSystem} from './coordinate-system';
+import {
+  cartesianCoordinateSystem,
+  CartesianCoordinateSystem,
+  EditModeCoordinateSystem,
+  geoCoordinateSystem,
+  GeoCoordinateSystem
+} from './coordinate-system';
 import {polygonEdgesIntersect, polygonWithinPolygon} from './cartesian-utils';
 
 export class DrawPolygonMode extends GeoJsonEditMode {
@@ -277,9 +283,7 @@ export class DrawPolygonMode extends GeoJsonEditMode {
     for (let i = 1; i < feature.geometry.coordinates.length; i++) {
       const hole = getPolygonFeature([feature.geometry.coordinates[i]], props);
 
-      const intersection = cartesian
-        ? polygonEdgesIntersect(hole, newPolygon)
-        : lineIntersect(hole, newPolygon).features.length > 0;
+      const intersection = isPolygonIntersecting(hole, newPolygon, props.coordinateSystem);
       if (intersection) {
         props.onEdit({
           updatedData: props.data,
@@ -289,9 +293,7 @@ export class DrawPolygonMode extends GeoJsonEditMode {
         return {handled: true};
       }
 
-      const containsOrContained = cartesian
-        ? polygonWithinPolygon(hole, newPolygon) || polygonWithinPolygon(newPolygon, hole)
-        : booleanWithin(hole, newPolygon) || booleanWithin(newPolygon, hole);
+      const containsOrContained = isContainingOrContained(hole, newPolygon, props.coordinateSystem);
       if (containsOrContained) {
         props.onEdit({
           updatedData: props.data,
@@ -303,9 +305,14 @@ export class DrawPolygonMode extends GeoJsonEditMode {
     }
 
     // Check outer polygon conflicts after iteration
-    const intersectionWithOuter = cartesian
-      ? polygonEdgesIntersect(outer, newPolygon)
-      : lineIntersect(outer, newPolygon).features.length > 0;
+    // const intersectionWithOuter = cartesian
+    //   ? polygonEdgesIntersect(outer, newPolygon)
+    //   : lineIntersect(outer, newPolygon).features.length > 0;
+    const intersectionWithOuter = isIntersectionWithOuter(
+      outer,
+      newPolygon,
+      props.coordinateSystem
+    );
     if (intersectionWithOuter) {
       props.onEdit({
         updatedData: props.data,
@@ -377,4 +384,65 @@ function getPolygonFeature(
   return props.coordinateSystem instanceof CartesianCoordinateSystem
     ? {type: 'Feature', properties: {}, geometry: {type: 'Polygon', coordinates: polygonGeometry}}
     : turfPolygon(polygonGeometry);
+}
+
+function isContainingOrContained(
+  polygon1: Feature<Polygon>,
+  polygon2: Feature<Polygon>,
+  coordinateSystem: EditModeCoordinateSystem
+): boolean {
+  let containsOrContained = false;
+  switch (coordinateSystem) {
+    case geoCoordinateSystem:
+    case undefined:
+      containsOrContained = booleanWithin(polygon1, polygon2) || booleanWithin(polygon2, polygon1);
+      break;
+    case cartesianCoordinateSystem:
+      containsOrContained =
+        polygonWithinPolygon(polygon1, polygon2) || polygonWithinPolygon(polygon2, polygon1);
+      break;
+    default:
+      break;
+  }
+  return containsOrContained;
+}
+
+function isPolygonIntersecting(
+  polygon1: Feature<Polygon>,
+  polygon2: Feature<Polygon>,
+  coordinateSystem: EditModeCoordinateSystem
+): boolean {
+  let polygonIntersecting = false;
+  switch (coordinateSystem) {
+    case geoCoordinateSystem:
+    case undefined:
+      polygonIntersecting = lineIntersect(polygon1, polygon2).features.length > 0;
+      break;
+    case cartesianCoordinateSystem:
+      polygonIntersecting = polygonEdgesIntersect(polygon1, polygon2);
+      break;
+    default:
+      break;
+  }
+  return polygonIntersecting;
+}
+
+function isIntersectionWithOuter(
+  polygon1: Feature<Polygon>,
+  polygon2: Feature<Polygon>,
+  coordinateSystem: EditModeCoordinateSystem
+): boolean {
+  let intersectionWithOuter = false;
+  switch (coordinateSystem) {
+    case geoCoordinateSystem:
+    case undefined:
+      intersectionWithOuter = lineIntersect(polygon1, polygon2).features.length > 0;
+      break;
+    case cartesianCoordinateSystem:
+      intersectionWithOuter = polygonEdgesIntersect(polygon1, polygon2);
+      break;
+    default:
+      break;
+  }
+  return intersectionWithOuter;
 }

--- a/modules/editable-layers/src/edit-modes/draw-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-polygon-mode.ts
@@ -7,7 +7,6 @@ import {polygon as turfPolygon} from '@turf/helpers';
 import booleanWithin from '@turf/boolean-within';
 import type {Feature, Geometry, Polygon} from 'geojson';
 import kinks from '@turf/kinks';
-
 import {
   ClickEvent,
   PointerMoveEvent,
@@ -21,12 +20,8 @@ import {Position, FeatureCollection, SimpleFeatureCollection} from '../utils/geo
 import {getPickedEditHandle} from './utils';
 import {GeoJsonEditMode} from './geojson-edit-mode';
 import {ImmutableFeatureCollection} from './immutable-feature-collection';
-// import {
-//   cartesianCoordinateSystem,
-//   GeoCoordinateSystem,
-//   getEditModeCoordinateSystem
-// } from './coordinate-system';
 import {CartesianCoordinateSystem} from './coordinate-system';
+import {polygonEdgesIntersect, polygonWithinPolygon} from './cartesian-utils';
 
 export class DrawPolygonMode extends GeoJsonEditMode {
   holeSequence: Position[] = [];
@@ -382,62 +377,4 @@ function getPolygonFeature(
   return props.coordinateSystem instanceof CartesianCoordinateSystem
     ? {type: 'Feature', properties: {}, geometry: {type: 'Polygon', coordinates: polygonGeometry}}
     : turfPolygon(polygonGeometry);
-}
-
-export function orientation(p: Position, q: Position, r: Position): number {
-  return (q[0] - p[0]) * (r[1] - p[1]) - (q[1] - p[1]) * (r[0] - p[0]);
-}
-
-export function segmentsIntersect(p1: Position, p2: Position, p3: Position, p4: Position): boolean {
-  const o1 = orientation(p1, p2, p3);
-  const o2 = orientation(p1, p2, p4);
-  const o3 = orientation(p3, p4, p1);
-  const o4 = orientation(p3, p4, p2);
-  return o1 * o2 < 0 && o3 * o4 < 0;
-}
-// Use segmentsIntersect to check polygon edge pairs:
-// Keeping consistency using Feature<Polygon> as param type to match turf
-export function polygonEdgesIntersect(
-  featureA: Feature<Polygon>,
-  featureB: Feature<Polygon>
-): boolean {
-  const ringA = featureA.geometry.coordinates[0];
-  const ringB = featureB.geometry.coordinates[0];
-  for (let i = 0; i < ringA.length - 1; i++) {
-    for (let j = 0; j < ringB.length - 1; j++) {
-      if (segmentsIntersect(ringA[i], ringA[i + 1], ringB[j], ringB[j + 1])) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-export function pointInPolygon(point: Position, ring: Position[]): boolean {
-  let inside = false;
-  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
-    const xi = ring[i][0];
-    const yi = ring[i][1];
-    const xj = ring[j][0];
-    const yj = ring[j][1];
-    if (
-      yi > point[1] !== yj > point[1] &&
-      point[0] < ((xj - xi) * (point[1] - yi)) / (yj - yi) + xi
-    ) {
-      inside = !inside;
-    }
-  }
-  return inside;
-}
-
-export function polygonWithinPolygon(
-  featureA: Feature<Polygon>,
-  featureB: Feature<Polygon>
-): boolean {
-  const inner = featureA.geometry.coordinates[0];
-  const outer = featureB.geometry.coordinates[0];
-  for (const p of inner) {
-    if (!pointInPolygon(p, outer)) return false;
-  }
-  return true;
 }

--- a/modules/editable-layers/src/edit-modes/draw-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-polygon-mode.ts
@@ -5,7 +5,7 @@
 import lineIntersect from '@turf/line-intersect';
 import {polygon as turfPolygon} from '@turf/helpers';
 import booleanWithin from '@turf/boolean-within';
-import type {Geometry} from 'geojson';
+import type {Feature, Geometry, Polygon} from 'geojson';
 import kinks from '@turf/kinks';
 
 import {
@@ -21,6 +21,12 @@ import {Position, FeatureCollection, SimpleFeatureCollection} from '../utils/geo
 import {getPickedEditHandle} from './utils';
 import {GeoJsonEditMode} from './geojson-edit-mode';
 import {ImmutableFeatureCollection} from './immutable-feature-collection';
+// import {
+//   cartesianCoordinateSystem,
+//   GeoCoordinateSystem,
+//   getEditModeCoordinateSystem
+// } from './coordinate-system';
+import {CartesianCoordinateSystem} from './coordinate-system';
 
 export class DrawPolygonMode extends GeoJsonEditMode {
   holeSequence: Position[] = [];
@@ -197,7 +203,7 @@ export class DrawPolygonMode extends GeoJsonEditMode {
     const clickSequence = this.getClickSequence();
     const polygon = [...clickSequence, clickSequence[0]];
 
-    const newPolygon = turfPolygon([polygon]);
+    const newPolygon = getPolygonFeature([polygon], props);
 
     const canAddHole = canAddHoleToPolygon(props);
     const canOverlap = canPolygonOverlap(props);
@@ -240,14 +246,14 @@ export class DrawPolygonMode extends GeoJsonEditMode {
   }
 
   private tryAddHoleToExistingPolygon(
-    newPolygon: any,
+    newPolygon: Feature<Polygon>,
     polygon: Position[],
     props: ModeProps<SimpleFeatureCollection>
   ): {handled: boolean} {
     for (const [featureIndex, feature] of props.data.features.entries()) {
       if (feature.geometry.type === 'Polygon') {
         const result = this.validateAndCreateHole(
-          feature,
+          feature as Feature<Polygon>,
           featureIndex,
           newPolygon,
           polygon,
@@ -262,21 +268,24 @@ export class DrawPolygonMode extends GeoJsonEditMode {
     return {handled: false};
   }
 
+  // eslint-disable-next-line max-statements, complexity
   private validateAndCreateHole(
-    feature: any,
+    feature: Feature<Polygon>,
     featureIndex: number,
-    newPolygon: any,
+    newPolygon: Feature<Polygon>,
     polygon: Position[],
     props: ModeProps<SimpleFeatureCollection>
   ): {handled: boolean} {
-    const outer = turfPolygon(feature.geometry.coordinates);
-
+    const outer = getPolygonFeature(feature.geometry.coordinates, props);
+    const cartesian = props.coordinateSystem instanceof CartesianCoordinateSystem;
     // Check existing holes for conflicts
     for (let i = 1; i < feature.geometry.coordinates.length; i++) {
-      const hole = turfPolygon([feature.geometry.coordinates[i]]);
-      const intersection = lineIntersect(hole, newPolygon);
+      const hole = getPolygonFeature([feature.geometry.coordinates[i]], props);
 
-      if (intersection.features.length > 0) {
+      const intersection = cartesian
+        ? polygonEdgesIntersect(hole, newPolygon)
+        : lineIntersect(hole, newPolygon).features.length > 0;
+      if (intersection) {
         props.onEdit({
           updatedData: props.data,
           editType: 'invalidHole',
@@ -285,7 +294,10 @@ export class DrawPolygonMode extends GeoJsonEditMode {
         return {handled: true};
       }
 
-      if (booleanWithin(hole, newPolygon) || booleanWithin(newPolygon, hole)) {
+      const containsOrContained = cartesian
+        ? polygonWithinPolygon(hole, newPolygon) || polygonWithinPolygon(newPolygon, hole)
+        : booleanWithin(hole, newPolygon) || booleanWithin(newPolygon, hole);
+      if (containsOrContained) {
         props.onEdit({
           updatedData: props.data,
           editType: 'invalidHole',
@@ -295,9 +307,11 @@ export class DrawPolygonMode extends GeoJsonEditMode {
       }
     }
 
-    // Check outer polygon conflicts
-    const intersectionWithOuter = lineIntersect(outer, newPolygon);
-    if (intersectionWithOuter.features.length > 0) {
+    // Check outer polygon conflicts after iteration
+    const intersectionWithOuter = cartesian
+      ? polygonEdgesIntersect(outer, newPolygon)
+      : lineIntersect(outer, newPolygon).features.length > 0;
+    if (intersectionWithOuter) {
       props.onEdit({
         updatedData: props.data,
         editType: 'invalidPolygon',
@@ -306,7 +320,10 @@ export class DrawPolygonMode extends GeoJsonEditMode {
       return {handled: true};
     }
 
-    if (booleanWithin(outer, newPolygon)) {
+    const outerWithin = cartesian
+      ? polygonWithinPolygon(outer, newPolygon)
+      : booleanWithin(outer, newPolygon);
+    if (outerWithin) {
       props.onEdit({
         updatedData: props.data,
         editType: 'invalidPolygon',
@@ -316,7 +333,10 @@ export class DrawPolygonMode extends GeoJsonEditMode {
     }
 
     // Check if new polygon is within outer polygon (valid hole)
-    if (booleanWithin(newPolygon, outer)) {
+    const newWithinOuter = cartesian
+      ? polygonWithinPolygon(newPolygon, outer)
+      : booleanWithin(newPolygon, outer);
+    if (newWithinOuter) {
       const updatedData = new ImmutableFeatureCollection(props.data)
         .replaceGeometry(featureIndex, {
           ...feature.geometry,
@@ -353,4 +373,71 @@ function canAddHoleToPolygon(props: ModeProps<FeatureCollection>): boolean {
 function canPolygonOverlap(props: ModeProps<FeatureCollection>): boolean {
   // Return the value of allowSelfIntersection (defaults to false for safety)
   return props.modeConfig?.allowSelfIntersection ?? false;
+}
+
+function getPolygonFeature(
+  polygonGeometry: Position[][],
+  props: ModeProps<FeatureCollection>
+): Feature<Polygon> {
+  return props.coordinateSystem instanceof CartesianCoordinateSystem
+    ? {type: 'Feature', properties: {}, geometry: {type: 'Polygon', coordinates: polygonGeometry}}
+    : turfPolygon(polygonGeometry);
+}
+
+export function orientation(p: Position, q: Position, r: Position): number {
+  return (q[0] - p[0]) * (r[1] - p[1]) - (q[1] - p[1]) * (r[0] - p[0]);
+}
+
+export function segmentsIntersect(p1: Position, p2: Position, p3: Position, p4: Position): boolean {
+  const o1 = orientation(p1, p2, p3);
+  const o2 = orientation(p1, p2, p4);
+  const o3 = orientation(p3, p4, p1);
+  const o4 = orientation(p3, p4, p2);
+  return o1 * o2 < 0 && o3 * o4 < 0;
+}
+// Use segmentsIntersect to check polygon edge pairs:
+// Keeping consistency using Feature<Polygon> as param type to match turf
+export function polygonEdgesIntersect(
+  featureA: Feature<Polygon>,
+  featureB: Feature<Polygon>
+): boolean {
+  const ringA = featureA.geometry.coordinates[0];
+  const ringB = featureB.geometry.coordinates[0];
+  for (let i = 0; i < ringA.length - 1; i++) {
+    for (let j = 0; j < ringB.length - 1; j++) {
+      if (segmentsIntersect(ringA[i], ringA[i + 1], ringB[j], ringB[j + 1])) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+export function pointInPolygon(point: Position, ring: Position[]): boolean {
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const xi = ring[i][0];
+    const yi = ring[i][1];
+    const xj = ring[j][0];
+    const yj = ring[j][1];
+    if (
+      yi > point[1] !== yj > point[1] &&
+      point[0] < ((xj - xi) * (point[1] - yi)) / (yj - yi) + xi
+    ) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+export function polygonWithinPolygon(
+  featureA: Feature<Polygon>,
+  featureB: Feature<Polygon>
+): boolean {
+  const inner = featureA.geometry.coordinates[0];
+  const outer = featureB.geometry.coordinates[0];
+  for (const p of inner) {
+    if (!pointInPolygon(p, outer)) return false;
+  }
+  return true;
 }

--- a/modules/editable-layers/test/edit-modes/lib/draw-polygon-mode.spec.ts
+++ b/modules/editable-layers/test/edit-modes/lib/draw-polygon-mode.spec.ts
@@ -3,13 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {beforeEach, describe, it, expect} from 'vitest';
-import {
-  DrawPolygonMode,
-  pointInPolygon,
-  polygonEdgesIntersect,
-  polygonWithinPolygon,
-  segmentsIntersect
-} from '../../../src/edit-modes/draw-polygon-mode';
+import {DrawPolygonMode} from '../../../src/edit-modes/draw-polygon-mode';
 import {
   createFeatureCollectionProps,
   createClickEvent,
@@ -17,6 +11,12 @@ import {
   createPolygonFeature
 } from '../test-utils';
 import {Feature, Polygon, Position} from 'geojson';
+import {
+  pointInPolygon,
+  polygonEdgesIntersect,
+  polygonWithinPolygon,
+  segmentsIntersect
+} from '../../../src/edit-modes/cartesian-utils';
 
 let props;
 let mode;

--- a/modules/editable-layers/test/edit-modes/lib/draw-polygon-mode.spec.ts
+++ b/modules/editable-layers/test/edit-modes/lib/draw-polygon-mode.spec.ts
@@ -3,13 +3,20 @@
 // Copyright (c) vis.gl contributors
 
 import {beforeEach, describe, it, expect} from 'vitest';
-import {DrawPolygonMode} from '../../../src/edit-modes/draw-polygon-mode';
+import {
+  DrawPolygonMode,
+  pointInPolygon,
+  polygonEdgesIntersect,
+  polygonWithinPolygon,
+  segmentsIntersect
+} from '../../../src/edit-modes/draw-polygon-mode';
 import {
   createFeatureCollectionProps,
   createClickEvent,
   createKeyboardEvent,
   createPolygonFeature
 } from '../test-utils';
+import {Feature, Polygon, Position} from 'geojson';
 
 let props;
 let mode;
@@ -308,6 +315,114 @@ describe('allowSelfIntersection configuration', () => {
         [0, 2],
         [0, 0]
       ]);
+    });
+  });
+});
+
+describe('non-turfjs cartesian geometry functions', () => {
+  const poly = (ring: Position[]): Feature<Polygon> => {
+    return {
+      type: 'Feature',
+      properties: {},
+      geometry: {type: 'Polygon', coordinates: [ring]}
+    };
+  };
+  describe('cartesian polygon contains functions', () => {
+    const pointIn = [10, 10];
+    const pointOut = [14, 14];
+    const outerRing = [
+      [8, 8],
+      [12, 8],
+      [12, 12],
+      [8, 12],
+      [8, 8]
+    ];
+    const innerRing = [
+      [9, 9],
+      [11, 9],
+      [11, 11],
+      [9, 11],
+      [9, 9]
+    ];
+    const intersectingRing = [
+      [7, 7],
+      [13, 13],
+      [12, 12],
+      [7, 12],
+      [7, 7]
+    ];
+    it('returns true for pointInPolygon - point inside', async () => {
+      const result = pointInPolygon(pointIn, outerRing);
+      expect(result).toEqual(true);
+    });
+    it('returns false for pointInPolygon - point outside', async () => {
+      const result = pointInPolygon(pointOut, innerRing);
+      expect(result).toEqual(false);
+    });
+    it('returns true for polygonWithinPolygon - polygon inside', async () => {
+      const result = polygonWithinPolygon(poly(innerRing), poly(outerRing));
+      expect(result).toEqual(true);
+    });
+    it('returns false for polygonWithinPolygon - polygon outside', async () => {
+      const result = polygonWithinPolygon(poly(outerRing), poly(innerRing));
+      expect(result).toEqual(false);
+    });
+    it('returns false for polygonWithinPolygon - intersecting polygon', async () => {
+      const result = polygonWithinPolygon(poly(intersectingRing), poly(outerRing));
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('cartesian intersection functions', () => {
+    const line1 = [
+      [10, 10],
+      [10, 14]
+    ];
+    const line2 = [
+      [8, 12],
+      [12, 12]
+    ];
+    const line3 = [
+      [12, 12],
+      [12, 14]
+    ];
+    const outerRing = [
+      [8, 8],
+      [12, 8],
+      [12, 12],
+      [8, 12],
+      [8, 8]
+    ];
+    const intersectingRing = [
+      [8, 7],
+      [13, 13],
+      [11, 11],
+      [7, 12],
+      [7, 7]
+    ];
+    const nonIntersectingRing = [
+      [6, 6],
+      [8, 6],
+      [7, 8],
+      [6, 8],
+      [6, 6]
+    ];
+    it('check for intersecting segments - returns true for intersection', async () => {
+      const result = segmentsIntersect(line1[0], line1[1], line2[0], line2[1]);
+      expect(result).toEqual(true);
+    });
+    it('check for intersecting segments - returns false for no intersection', async () => {
+      const result = segmentsIntersect(line1[0], line1[1], line3[0], line3[1]);
+      expect(result).toEqual(false);
+    });
+    // export function polygonEdgesIntersect(ringA: Position[], ringB: Position[]): boolean {
+    it('check for polygon intersection - true for intersection', async () => {
+      const result = polygonEdgesIntersect(poly(intersectingRing), poly(outerRing));
+      expect(result).toEqual(true);
+    });
+    it('check for polygon intersection - false for intersection', async () => {
+      const result = polygonEdgesIntersect(poly(nonIntersectingRing), poly(outerRing));
+      expect(result).toEqual(false);
     });
   });
 });


### PR DESCRIPTION
Finished updating `draw-polygon-mode.ts` to use turf(geo modes), and simple geometric functions(cartesian modes).  Did not attempt turfJS kinks function which involves another order of complexity.  Created simple geometry functions and tests, needed to bypass linter checks for complexity on `validateAndCreateHole()`.  