### PR TITLE
feat(panels) Add shared trace viewer controls

### DIFF
--- a/modules/panels/src/index.ts
+++ b/modules/panels/src/index.ts
@@ -122,6 +122,10 @@ export {
   type ArrowRecordBatchLike
 } from './leaf-panels/arrow/arrow-batches-panel';
 export {
+  CommandDocumentationPanel,
+  type CommandDocumentationPanelProps
+} from './leaf-panels/commands/command-documentation-panel';
+export {
   KeyboardShortcutsPanel,
   KeyboardShortcutsPanelContent,
   type KeyboardShortcutsPanelProps
@@ -173,6 +177,7 @@ export {
   type SettingDescriptorByName,
   type SettingOption,
   type SettingPersistenceTarget,
+  type SettingScalarValue,
   type SettingType,
   type SettingValue,
   type SettingsOption,
@@ -211,7 +216,8 @@ export {
   isShortcutMatchingKeyEvent,
   findShortcutMatchingKeyEvent,
   DEFAULT_SHORTCUTS,
-  formatKey
+  formatKey,
+  formatShortcutKeyHTML
 } from './lib/keyboard-shortcuts/keyboard-shortcuts';
 export {
   KeyboardShortcutsManager,
@@ -233,3 +239,18 @@ export {
   URLManager,
   type URLManagerCreateSearchParamsOptions
 } from './lib/url-parameters/url-manager';
+export {IconButton, makeTextIcon} from './preact/icon-button';
+export {
+  PanelMultiSelect,
+  PanelSelect,
+  type PanelMultiSelectOption,
+  type PanelMultiSelectProps,
+  type PanelSelectOption,
+  type PanelSelectProps,
+  type PanelSelectValue
+} from './preact/panel-select';
+export {
+  WidgetTooltip,
+  type WidgetTooltipPlacement,
+  type WidgetTooltipProps
+} from './preact/widget-tooltip';

--- a/modules/panels/src/leaf-panels/commands/command-documentation-panel.tsx
+++ b/modules/panels/src/leaf-panels/commands/command-documentation-panel.tsx
@@ -1,0 +1,351 @@
+/** @jsxImportSource preact */
+
+import {Panel} from '../../panels/panel';
+
+import type {CommandDescriptor, CommandManager} from '../../lib/commands/command-manager';
+import type {PanelTheme} from '../../panels/panel';
+import type {JSX} from 'preact';
+
+/** Props used to construct a command documentation panel. */
+export type CommandDocumentationPanelProps = {
+  /** Command manager whose registered command metadata is rendered. */
+  manager: CommandManager;
+  /** Optional panel theme override. */
+  theme?: PanelTheme;
+};
+
+/**
+ * A panel definition that renders command metadata from a command manager.
+ */
+export class CommandDocumentationPanel extends Panel {
+  /**
+   * Creates a command documentation panel.
+   */
+  constructor({manager, theme = 'inherit'}: CommandDocumentationPanelProps) {
+    super({
+      id: 'command-documentation',
+      title: 'Commands',
+      theme,
+      content: <CommandDocumentationPanelContent manager={manager} />
+    });
+  }
+}
+
+/** Renders command metadata or an empty state. */
+function CommandDocumentationPanelContent({
+  manager
+}: {
+  /** Command manager whose command metadata is rendered. */
+  manager: CommandManager;
+}) {
+  const commandRows = buildCommandDocumentationRows(manager.listCommands());
+  const automationSupport = manager.listAutomationSupport();
+  const exampleAutomationCommand = manager.listCommands({exposure: 'automation'})[0];
+  if (commandRows.length === 0) {
+    return (
+      <div style={EMPTY_STATE_STYLE}>
+        <strong>No commands registered.</strong>
+        <span>Commands registered with the command manager will appear here.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div style={COMMAND_LIST_STYLE}>
+      <div style={INTRO_STYLE}>
+        <ul style={INTRO_LIST_STYLE}>
+          <li>User commands can be executed via the Search box (Omnibox).</li>
+          <li>Automation commands can be executed programmatically, see bottom of page.</li>
+        </ul>
+      </div>
+      <div style={COMMAND_TABLE_WRAPPER_STYLE}>
+        <table style={COMMAND_TABLE_STYLE}>
+          <thead>
+            <tr>
+              <th style={COMMAND_HEADER_CELL_STYLE}>Command</th>
+              <th style={COMMAND_CENTER_HEADER_CELL_STYLE}>User</th>
+              <th style={COMMAND_CENTER_HEADER_CELL_STYLE}>Automation</th>
+            </tr>
+          </thead>
+          <tbody>
+            {commandRows.map(command => (
+              <tr key={command.ids.join('\n')}>
+                <td style={COMMAND_CELL_STYLE}>
+                  {command.label ? (
+                    <div style={COMMAND_LABEL_STYLE}>{command.label}</div>
+                  ) : (
+                    <code style={COMMAND_LABEL_ID_STYLE}>{command.ids[0]}</code>
+                  )}
+                  {command.description ? (
+                    <div style={COMMAND_DESCRIPTION_STYLE}>{command.description}</div>
+                  ) : null}
+                  {command.label
+                    ? command.ids.map(id => (
+                        <code key={id} style={COMMAND_ID_STYLE}>
+                          {id}
+                        </code>
+                      ))
+                    : null}
+                </td>
+                <td style={COMMAND_CENTER_CELL_STYLE}>
+                  {renderAvailabilityIndicator(command.userAvailable)}
+                </td>
+                <td style={COMMAND_CENTER_CELL_STYLE}>
+                  {renderAvailabilityIndicator(command.automationAvailable)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {automationSupport.length ? (
+        <div style={POSTMESSAGE_SECTION_STYLE}>
+          <strong>Installed automation</strong>
+          {automationSupport.map(support => (
+            <div key={support.id} style={AUTOMATION_SUPPORT_STYLE}>
+              <span>
+                <strong>{support.label}</strong>
+                {support.globalName ? (
+                  <>
+                    {' '}
+                    via <code style={INLINE_CODE_STYLE}>globalThis.{support.globalName}</code>
+                  </>
+                ) : null}
+              </span>
+              {support.description ? <span>{support.description}</span> : null}
+              {support.requestType && support.responseType ? (
+                <span>
+                  postMessage requests use{' '}
+                  <code style={INLINE_CODE_STYLE}>{support.requestType}</code> and responses use{' '}
+                  <code style={INLINE_CODE_STYLE}>{support.responseType}</code>.
+                </span>
+              ) : null}
+              {support.globalName && exampleAutomationCommand ? (
+                <code style={COMMAND_EXAMPLE_STYLE}>
+                  await globalThis.{support.globalName}.commands.execute('
+                  {exampleAutomationCommand.id}');
+                </code>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/** Render-ready command documentation row, with duplicate command ids merged. */
+type CommandDocumentationRow = {
+  /** Command ids represented by this row. */
+  ids: string[];
+  /** Human-readable command label. */
+  label?: string;
+  /** Optional command description. */
+  description?: string;
+  /** Whether any represented command is user-facing. */
+  userAvailable: boolean;
+  /** Whether any represented command is automation-facing. */
+  automationAvailable: boolean;
+};
+
+/** Builds command docs rows with user-available commands before automation-only commands. */
+function buildCommandDocumentationRows(commands: CommandDescriptor[]): CommandDocumentationRow[] {
+  const rows = mergeEquivalentCommands(commands);
+  const userRows = rows.filter(row => row.userAvailable);
+  const automationOnlyRows = rows.filter(row => !row.userAvailable);
+  return [...userRows, ...automationOnlyRows];
+}
+
+/** Merges command ids that describe the same user-visible action. */
+function mergeEquivalentCommands(commands: CommandDescriptor[]): CommandDocumentationRow[] {
+  const rows: CommandDocumentationRow[] = [];
+  const rowsByKey = new Map<string, CommandDocumentationRow>();
+
+  for (const command of commands) {
+    const key = getCommandDocumentationMergeKey(command);
+    const existingRow = key ? rowsByKey.get(key) : undefined;
+    if (existingRow) {
+      existingRow.ids.push(command.id);
+      existingRow.userAvailable ||= isUserCommand(command);
+      existingRow.automationAvailable ||= isAutomationCommand(command);
+      continue;
+    }
+
+    const row = {
+      ids: [command.id],
+      label: command.label,
+      description: command.description,
+      userAvailable: isUserCommand(command),
+      automationAvailable: isAutomationCommand(command)
+    };
+    rows.push(row);
+    if (key) {
+      rowsByKey.set(key, row);
+    }
+  }
+
+  return rows;
+}
+
+/** Returns a merge key only when a command has enough display metadata to identify an action. */
+function getCommandDocumentationMergeKey(command: CommandDescriptor): string | null {
+  if (!command.label) {
+    return null;
+  }
+  return `${command.label}\n${command.description ?? ''}`;
+}
+
+/** Returns whether a command is available to user-facing surfaces. */
+function isUserCommand(command: CommandDescriptor): boolean {
+  return command.exposure === 'user' || command.exposure === 'all';
+}
+
+/** Returns whether a command is available to external automation surfaces. */
+function isAutomationCommand(command: CommandDescriptor): boolean {
+  return command.exposure === 'automation' || command.exposure === 'all';
+}
+
+/** Renders a compact boolean indicator for command metadata tables. */
+function renderAvailabilityIndicator(value: boolean): string {
+  return value ? '✅' : '❌';
+}
+
+const COMMAND_LIST_STYLE: JSX.CSSProperties = {
+  display: 'grid',
+  gap: '10px'
+};
+
+const INTRO_STYLE: JSX.CSSProperties = {
+  display: 'grid',
+  gap: '4px',
+  padding: '4px 2px 6px',
+  color: 'var(--menu-text, rgb(24, 24, 26))',
+  fontSize: '12px',
+  lineHeight: '16px'
+};
+
+const INTRO_LIST_STYLE: JSX.CSSProperties = {
+  margin: 0,
+  paddingLeft: '18px'
+};
+
+const COMMAND_TABLE_WRAPPER_STYLE: JSX.CSSProperties = {
+  overflowX: 'auto',
+  borderRadius: 'var(--button-corner-radius, 14px)',
+  border: 'var(--menu-border, 1px solid rgba(148, 163, 184, 0.42))',
+  background: 'var(--menu-background, #fff)',
+  boxShadow: '0 8px 18px rgba(15, 23, 42, 0.055)'
+};
+
+const COMMAND_TABLE_STYLE: JSX.CSSProperties = {
+  width: '100%',
+  borderCollapse: 'collapse',
+  color: 'var(--menu-text, rgb(24, 24, 26))',
+  fontSize: '12px',
+  lineHeight: '16px'
+};
+
+const COMMAND_HEADER_CELL_STYLE: JSX.CSSProperties = {
+  padding: '9px 10px',
+  borderBottom: '1px solid rgba(148, 163, 184, 0.24)',
+  color: 'var(--button-icon-idle, rgb(71, 85, 105))',
+  backgroundColor: 'rgba(248, 250, 252, 0.72)',
+  fontSize: '10px',
+  lineHeight: '13px',
+  fontWeight: 800,
+  letterSpacing: '0.04em',
+  textAlign: 'left',
+  textTransform: 'uppercase'
+};
+
+const COMMAND_CENTER_HEADER_CELL_STYLE: JSX.CSSProperties = {
+  ...COMMAND_HEADER_CELL_STYLE,
+  textAlign: 'center',
+  whiteSpace: 'nowrap'
+};
+
+const COMMAND_CELL_STYLE: JSX.CSSProperties = {
+  padding: '10px',
+  borderBottom: '1px solid rgba(148, 163, 184, 0.16)',
+  verticalAlign: 'top'
+};
+
+const COMMAND_CENTER_CELL_STYLE: JSX.CSSProperties = {
+  ...COMMAND_CELL_STYLE,
+  width: '1%',
+  textAlign: 'center',
+  whiteSpace: 'nowrap'
+};
+
+const COMMAND_ID_STYLE: JSX.CSSProperties = {
+  display: 'block',
+  minWidth: 0,
+  overflowWrap: 'anywhere',
+  color: 'var(--button-icon-idle, rgb(71, 85, 105))',
+  fontSize: '11px',
+  lineHeight: '15px',
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace'
+};
+
+const COMMAND_LABEL_ID_STYLE: JSX.CSSProperties = {
+  ...COMMAND_ID_STYLE,
+  color: 'var(--menu-text, rgb(24, 24, 26))',
+  fontSize: '13px',
+  lineHeight: '17px'
+};
+
+const COMMAND_LABEL_STYLE: JSX.CSSProperties = {
+  fontSize: '14px',
+  lineHeight: '18px',
+  fontWeight: 700
+};
+
+const COMMAND_DESCRIPTION_STYLE: JSX.CSSProperties = {
+  color: 'var(--button-icon-idle, rgb(71, 85, 105))',
+  fontSize: '12px',
+  lineHeight: '16px'
+};
+
+const POSTMESSAGE_SECTION_STYLE: JSX.CSSProperties = {
+  display: 'grid',
+  gap: '8px',
+  padding: '10px 12px',
+  borderRadius: 'var(--button-corner-radius, 14px)',
+  border: '1px solid rgba(100, 116, 139, 0.18)',
+  color: 'var(--button-icon-idle, rgb(71, 85, 105))',
+  backgroundColor: 'rgba(248, 250, 252, 0.56)',
+  fontSize: '12px',
+  lineHeight: '16px'
+};
+
+const AUTOMATION_SUPPORT_STYLE: JSX.CSSProperties = {
+  display: 'grid',
+  gap: '4px'
+};
+
+const INLINE_CODE_STYLE: JSX.CSSProperties = {
+  fontSize: '11px',
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace'
+};
+
+const COMMAND_EXAMPLE_STYLE: JSX.CSSProperties = {
+  display: 'block',
+  overflowX: 'auto',
+  padding: '7px 8px',
+  borderRadius: '8px',
+  border: '1px solid rgba(100, 116, 139, 0.18)',
+  color: 'var(--menu-text, rgb(24, 24, 26))',
+  backgroundColor: 'rgba(255, 255, 255, 0.72)',
+  fontSize: '11px',
+  lineHeight: '15px',
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace'
+};
+
+const EMPTY_STATE_STYLE: JSX.CSSProperties = {
+  display: 'grid',
+  gap: '4px',
+  padding: '12px',
+  color: 'var(--button-icon-idle, rgb(71, 85, 105))',
+  fontSize: '12px',
+  lineHeight: '16px'
+};

--- a/modules/panels/src/leaf-panels/settings/studio-settings-panel.tsx
+++ b/modules/panels/src/leaf-panels/settings/studio-settings-panel.tsx
@@ -19,6 +19,7 @@ import type {
 } from '../../lib/settings/settings-manager';
 import type {
   SettingDescriptor,
+  SettingScalarValue,
   SettingsSchema,
   SettingsSectionDescriptor,
   SettingsState,
@@ -545,7 +546,11 @@ function SelectControl({
   settingRowLayout: StudioSettingsRowLayout;
   onChange: (value: SettingValue) => void;
 }) {
-  const options = (setting.options ?? [getDefaultValue(setting)]).map(normalizeOption);
+  const defaultValue = getDefaultValue(setting);
+  const fallbackOptions: SettingScalarValue[] = isSettingScalarValue(defaultValue)
+    ? [defaultValue]
+    : [];
+  const options = (setting.options ?? fallbackOptions).map(normalizeOption);
   return (
     <SettingRow setting={setting} compact={compact} settingRowLayout={settingRowLayout}>
       <SelectComponent
@@ -557,6 +562,11 @@ function SelectControl({
       />
     </SettingRow>
   );
+}
+
+/** Returns whether one setting value can populate a single-value control. */
+function isSettingScalarValue(value: SettingValue): value is SettingScalarValue {
+  return typeof value === 'boolean' || typeof value === 'number' || typeof value === 'string';
 }
 
 /** Renders a boolean setting row. */

--- a/modules/panels/src/lib/keyboard-shortcuts/keyboard-shortcuts-manager.ts
+++ b/modules/panels/src/lib/keyboard-shortcuts/keyboard-shortcuts-manager.ts
@@ -1,4 +1,5 @@
-import {findShortcutMatchingKeyEvent} from './keyboard-shortcuts';
+import {commandManager} from '../commands/command-manager';
+import {findShortcutMatchingKeyEvent, formatShortcutKeyHTML} from './keyboard-shortcuts';
 
 import type {KeyboardShortcut} from './keyboard-shortcuts';
 
@@ -22,6 +23,7 @@ export type KeyboardShortcutEventManager = {
  * Installs keyboard shortcuts on an event manager that forwards `keydown` events.
  */
 export class KeyboardShortcutsManager {
+  static readonly #keyHTMLByCommandId = new Map<string, string>();
   private shortcuts: KeyboardShortcut[] = [];
   eventManager: KeyboardShortcutEventManager;
 
@@ -31,6 +33,20 @@ export class KeyboardShortcutsManager {
   constructor(eventManager: KeyboardShortcutEventManager, shortcuts: KeyboardShortcut[]) {
     this.eventManager = eventManager;
     this.shortcuts = shortcuts;
+    KeyboardShortcutsManager.registerShortcutKeyHTML(shortcuts);
+  }
+
+  /** Returns compact key display text for one command id when known. */
+  static getKeyHTML(commandId: string): string | undefined {
+    return KeyboardShortcutsManager.#keyHTMLByCommandId.get(commandId);
+  }
+
+  /** Returns compact key display text for one command id from this manager. */
+  getKeyHTML(commandId: string): string | undefined {
+    return (
+      getKeyHTMLForShortcuts(this.shortcuts, commandId) ??
+      KeyboardShortcutsManager.getKeyHTML(commandId)
+    );
   }
 
   /**
@@ -50,12 +66,28 @@ export class KeyboardShortcutsManager {
   private _handleKeyDown = (event: KeyboardShortcutManagerEvent) => {
     const shortcut = findShortcutMatchingKeyEvent(event.srcEvent, this.shortcuts);
     if (shortcut) {
+      if (shortcut.shouldHandle && !shortcut.shouldHandle(event.srcEvent)) {
+        return;
+      }
       if (shortcut.preventDefault) {
         event.srcEvent.preventDefault?.();
       }
-      shortcut.onKeyPress?.();
+      runShortcutCommand(shortcut);
     }
   };
+
+  /** Records command key labels from shortcut definitions for external tooltip rendering. */
+  static registerShortcutKeyHTML(shortcuts: readonly KeyboardShortcut[]): void {
+    for (const shortcut of shortcuts) {
+      if (!shortcut.commandId) {
+        continue;
+      }
+      KeyboardShortcutsManager.#keyHTMLByCommandId.set(
+        shortcut.commandId,
+        formatShortcutKeyHTML(shortcut)
+      );
+    }
+  }
 }
 
 /**
@@ -69,6 +101,15 @@ export class KeyboardShortcutsManagerDocument {
    */
   constructor(shortcuts: KeyboardShortcut[]) {
     this.shortcuts = shortcuts;
+    KeyboardShortcutsManager.registerShortcutKeyHTML(shortcuts);
+  }
+
+  /** Returns compact key display text for one command id when known. */
+  getKeyHTML(commandId: string): string | undefined {
+    return (
+      getKeyHTMLForShortcuts(this.shortcuts, commandId) ??
+      KeyboardShortcutsManager.getKeyHTML(commandId)
+    );
   }
 
   /**
@@ -88,10 +129,29 @@ export class KeyboardShortcutsManagerDocument {
   private _handleKeyDown = (event: KeyboardEvent) => {
     const shortcut = findShortcutMatchingKeyEvent(event, this.shortcuts);
     if (shortcut) {
+      if (shortcut.shouldHandle && !shortcut.shouldHandle(event)) {
+        return;
+      }
       if (shortcut.preventDefault) {
         event.preventDefault();
       }
-      shortcut.onKeyPress?.();
+      runShortcutCommand(shortcut);
     }
   };
+}
+
+function runShortcutCommand(shortcut: KeyboardShortcut): void {
+  if (shortcut.commandId) {
+    commandManager.executeCommand(shortcut.commandId);
+    return;
+  }
+  shortcut.onKeyPress?.();
+}
+
+function getKeyHTMLForShortcuts(
+  shortcuts: readonly KeyboardShortcut[],
+  commandId: string
+): string | undefined {
+  const shortcut = shortcuts.find(candidate => candidate.commandId === commandId);
+  return shortcut ? formatShortcutKeyHTML(shortcut) : undefined;
 }

--- a/modules/panels/src/lib/keyboard-shortcuts/keyboard-shortcuts.ts
+++ b/modules/panels/src/lib/keyboard-shortcuts/keyboard-shortcuts.ts
@@ -55,6 +55,10 @@ export type KeyboardShortcut = {
   displaySection?: KeyboardShortcutDisplaySection;
   /** Prevents the browser default behavior when this shortcut matches. */
   preventDefault?: boolean;
+  /** Optional runtime guard that can reject a matching keyboard event. */
+  shouldHandle?: (event: KeyboardEvent) => boolean;
+  /** Optional command id executed through the shared command manager. */
+  commandId?: string;
   /** Optional visual badges displayed next to the shortcut. */
   badges?: string[];
   /** Optional paired display metadata used for grouped shortcut rows. */
@@ -207,4 +211,23 @@ export function formatKey(key: string): string {
 
   // Fallback for less common named keys
   return key.toUpperCase();
+}
+
+/** Formats one keyboard shortcut as compact text for shortcut chips. */
+export function formatShortcutKeyHTML(shortcut: KeyboardShortcut): string {
+  const parts: string[] = [];
+  if (shortcut.commandKey) {
+    parts.push(isMac ? '⌘' : 'Ctrl');
+  }
+  if (shortcut.ctrlKey) {
+    parts.push(isMac ? '⌃' : 'Ctrl');
+  }
+  if (shortcut.shiftKey) {
+    parts.push('Shift');
+  }
+  if (shortcut.key) {
+    parts.push(formatKey(shortcut.key));
+  }
+
+  return isMac ? parts.join('') : parts.join('+');
 }

--- a/modules/panels/src/lib/settings/settings-manager.ts
+++ b/modules/panels/src/lib/settings/settings-manager.ts
@@ -173,7 +173,7 @@ export class SettingsManager<Change extends SettingsChangeDescriptor = SettingsC
       ? resolveSettingValue(descriptor, candidateSettings)
       : nextValue;
     const previousValue = getValueAtPath(this.#currentSettings, name);
-    if (Object.is(previousValue, resolvedNextValue)) {
+    if (areSettingValuesEqual(previousValue, resolvedNextValue)) {
       return;
     }
 
@@ -209,7 +209,7 @@ export class SettingsManager<Change extends SettingsChangeDescriptor = SettingsC
       const previousValue = getValueAtPath(this.#currentSettings, name);
       const nextValue = getValueAtPath(nextSettings, name);
 
-      if (!Object.is(previousValue, nextValue)) {
+      if (!areSettingValuesEqual(previousValue, nextValue)) {
         changedSettings.push({
           type: 'setting',
           name,
@@ -317,7 +317,38 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isSettingValue(value: unknown): value is SettingValue {
-  return typeof value === 'boolean' || typeof value === 'number' || typeof value === 'string';
+  return (
+    typeof value === 'boolean' ||
+    typeof value === 'number' ||
+    typeof value === 'string' ||
+    isStringArray(value)
+  );
+}
+
+/** Returns whether two setting values should be treated as unchanged. */
+function areSettingValuesEqual(left: unknown, right: unknown): boolean {
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return areStringArraysEqual(left, right);
+  }
+
+  return Object.is(left, right);
+}
+
+/** Compares string-array settings with order-sensitive value equality. */
+function areStringArraysEqual(left: unknown, right: unknown): boolean {
+  if (!isStringArray(left) || !isStringArray(right)) {
+    return false;
+  }
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((value, index) => value === right[index]);
+}
+
+/** Returns whether the value is a string-array setting candidate. */
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(entry => typeof entry === 'string');
 }
 
 function shouldPersistSetting(descriptor: SettingDescriptor | undefined): boolean {

--- a/modules/panels/src/lib/settings/settings.ts
+++ b/modules/panels/src/lib/settings/settings.ts
@@ -1,14 +1,17 @@
-/** Primitive value supported by schema-driven settings controls. */
-export type SettingValue = boolean | number | string;
+/** Scalar value supported by single-value settings controls. */
+export type SettingScalarValue = boolean | number | string;
+
+/** Persistable value supported by settings controls. */
+export type SettingValue = SettingScalarValue | readonly string[];
 
 /** Built-in control kinds supported by settings panels. */
-export type SettingType = 'boolean' | 'number' | 'string' | 'select';
+export type SettingType = 'boolean' | 'number' | 'string' | 'select' | 'multi-select';
 
 /** Persistence bucket used by settings managers and URL integrations. */
 export type SettingPersistenceTarget = 'local-storage' | 'url' | 'none';
 
 /** One selectable setting option, either as a raw value or label/value pair. */
-export type SettingOption<Value extends SettingValue = SettingValue> =
+export type SettingOption<Value extends SettingScalarValue = SettingScalarValue> =
   | Value
   | {
       /** Human-friendly label shown in the select control. */
@@ -20,7 +23,8 @@ export type SettingOption<Value extends SettingValue = SettingValue> =
     };
 
 /** Backwards-compatible alias for selectable setting options. */
-export type SettingsOption<Value extends SettingValue = SettingValue> = SettingOption<Value>;
+export type SettingsOption<Value extends SettingScalarValue = SettingScalarValue> =
+  SettingOption<Value>;
 
 /** Describes one schema-driven setting control. */
 export type SettingDescriptor<
@@ -42,7 +46,7 @@ export type SettingDescriptor<
   step?: number;
   /** Optional trailing debounce, in milliseconds, for numeric range-slider input events. */
   sliderDebounceMs?: number;
-  options?: readonly SettingOption<Value>[];
+  options?: readonly SettingOption[];
   defaultValue?: Value;
 };
 
@@ -181,20 +185,20 @@ export function buildInitialCollapsedState(
 /** Normalizes a setting option into a label/value pair. */
 export function normalizeOption(option: SettingsOption): {
   label: string;
-  value: SettingValue;
+  value: SettingScalarValue;
   description?: string;
 } {
   if (isRecord(option) && 'label' in option && 'value' in option) {
     return {
       label: String(option.label),
-      value: option.value as SettingValue,
+      value: option.value as SettingScalarValue,
       description: typeof option.description === 'string' ? option.description : undefined
     };
   }
 
   return {
     label: String(option),
-    value: option as SettingValue
+    value: option as SettingScalarValue
   };
 }
 
@@ -268,6 +272,10 @@ export function getDefaultValue(setting: SettingDescriptor): SettingValue {
     return '';
   }
 
+  if (setting.type === 'multi-select') {
+    return [];
+  }
+
   return '';
 }
 
@@ -309,6 +317,16 @@ export function resolveSettingValue(
 
     const match = normalizedOptions.find(option => option.value === candidateValue);
     return match ? match.value : normalizedOptions[0].value;
+  }
+
+  if (setting.type === 'multi-select') {
+    if (Array.isArray(currentValue)) {
+      return currentValue.filter(
+        (value): value is string => typeof value === 'string' && value.length > 0
+      );
+    }
+    const defaultValue = getDefaultValue(setting);
+    return Array.isArray(defaultValue) ? defaultValue : [];
   }
 
   if (typeof currentValue === 'string') {

--- a/modules/panels/src/preact/icon-button.tsx
+++ b/modules/panels/src/preact/icon-button.tsx
@@ -1,0 +1,82 @@
+/** @jsxImportSource preact */
+// Ported from deck.gl-community/modules/widgets/src/widget-components/icon-button.tsx.
+
+import type {JSX} from 'preact';
+
+/**
+ * Stops widget button events from leaking into the deck canvas interaction layer.
+ */
+function stopPropagation(event: Event): void {
+  event.stopPropagation();
+}
+
+/**
+ * Creates a data URI SVG icon from a text glyph.
+ */
+export function makeTextIcon(content: string, fontSize = 16, viewBoxSize = 24): string {
+  const halfViewBoxSize = viewBoxSize / 2;
+
+  return `data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-${halfViewBoxSize} -${halfViewBoxSize} ${viewBoxSize} ${viewBoxSize}" ><text text-anchor="middle" alignment-baseline="middle" font-family="sans-serif" font-size="${fontSize}">${content}</text></svg>`;
+}
+
+/**
+ * Renders a deck widget icon button using deck.gl widget chrome classes.
+ */
+export function IconButton({
+  icon,
+  color,
+  style,
+  buttonStyle,
+  iconStyle,
+  className = '',
+  ariaLabel,
+  title,
+  onClick
+}: {
+  /** Mask-image icon data URI. */
+  icon: string;
+  /** Optional mask fill color. */
+  color?: string;
+  /** Optional class name applied to the button wrapper. */
+  className?: string;
+  /** Optional inline style applied to the button wrapper. */
+  style?: JSX.CSSProperties;
+  /** Optional inline style applied to the native button. */
+  buttonStyle?: JSX.CSSProperties;
+  /** Optional inline style applied to the masked icon. */
+  iconStyle?: JSX.CSSProperties;
+  /** Optional accessible label for buttons without native title text. */
+  ariaLabel?: string;
+  /** Optional button title and tooltip text. */
+  title?: string;
+  /** Optional click handler invoked when the button is pressed. */
+  onClick?: () => void;
+}) {
+  return (
+    <div className={`deck-widget-button ${className}`} style={style}>
+      <button
+        aria-label={ariaLabel ?? title}
+        className="deck-widget-icon-button"
+        type="button"
+        title={title}
+        style={buttonStyle}
+        onPointerDown={stopPropagation}
+        onPointerUp={stopPropagation}
+        onClick={event => {
+          event.stopPropagation();
+          onClick?.();
+        }}
+        onDblClick={stopPropagation}
+      >
+        <div
+          className="deck-widget-icon"
+          style={{
+            backgroundColor: color,
+            maskImage: `url('${icon}')`,
+            ...iconStyle
+          }}
+        />
+      </button>
+    </div>
+  );
+}

--- a/modules/panels/src/preact/panel-select.test.tsx
+++ b/modules/panels/src/preact/panel-select.test.tsx
@@ -1,0 +1,77 @@
+/** @jsxImportSource preact */
+
+import {render} from 'preact';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {PanelSelect} from './panel-select';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('PanelSelect', () => {
+  it('renders a rounded themed menu with lighter option text', async () => {
+    const onChange = vi.fn();
+    const root = document.createElement('div');
+    document.body.append(root);
+
+    render(
+      <PanelSelect
+        ariaLabel="Color"
+        value="processes"
+        options={[
+          {label: 'Process Id', value: 'processes'},
+          {label: 'Span Status', value: 'span-status'}
+        ]}
+        onChange={onChange}
+      />,
+      root
+    );
+
+    (root.querySelector('button[aria-label="Color"]') as HTMLButtonElement).click();
+    await Promise.resolve();
+
+    const menu = document.body.querySelector('[role="listbox"]') as HTMLElement;
+    const option = Array.from(document.body.querySelectorAll('[role="option"]')).find(
+      candidate => candidate.textContent === 'Span Status'
+    ) as HTMLButtonElement;
+
+    expect(menu.style.borderRadius).toBe('13px');
+    expect(option.style.fontWeight).toBe('430');
+
+    option.click();
+    await Promise.resolve();
+
+    expect(onChange).toHaveBeenCalledWith('span-status');
+  });
+
+  it('supports arrow-key navigation and Enter selection in the body-portaled menu', async () => {
+    const onChange = vi.fn();
+    const root = document.createElement('div');
+    document.body.append(root);
+
+    render(
+      <PanelSelect
+        ariaLabel="Color"
+        value="processes"
+        options={[
+          {label: 'Process Id', value: 'processes'},
+          {label: 'Span Status', value: 'span-status'},
+          {label: 'Latency', value: 'latency'}
+        ]}
+        onChange={onChange}
+      />,
+      root
+    );
+
+    const button = root.querySelector('button[aria-label="Color"]') as HTMLButtonElement;
+    button.click();
+    await Promise.resolve();
+    button.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true, key: 'ArrowDown'}));
+    await Promise.resolve();
+    button.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true, key: 'Enter'}));
+    await Promise.resolve();
+
+    expect(onChange).toHaveBeenCalledWith('span-status');
+  });
+});

--- a/modules/panels/src/preact/panel-select.tsx
+++ b/modules/panels/src/preact/panel-select.tsx
@@ -1,0 +1,677 @@
+/** @jsxImportSource preact */
+
+import {createPortal} from 'preact/compat';
+import {useEffect, useLayoutEffect, useMemo, useRef, useState} from 'preact/hooks';
+
+import type {ComponentChildren, JSX} from 'preact';
+
+/** Scalar values supported by the reusable panel select. */
+export type PanelSelectValue = string | number | boolean;
+
+/** Option rendered by the reusable panel select. */
+export type PanelSelectOption = {
+  /** User-visible option label. */
+  label: string;
+  /** Stable value emitted when the option is selected. */
+  value: PanelSelectValue;
+};
+
+/** Props accepted by the reusable themed panel select. */
+export type PanelSelectProps = {
+  /** Accessible control label. */
+  ariaLabel: string;
+  /** Current selected value. */
+  value: PanelSelectValue;
+  /** Options available in the dropdown menu. */
+  options: ReadonlyArray<PanelSelectOption>;
+  /** Called when the selected value changes. */
+  onChange: (value: PanelSelectValue) => void;
+  /** Optional icon rendered at the end of the button. */
+  trailingIcon?: ComponentChildren;
+  /** Optional inline style applied to the outer shell. */
+  style?: JSX.CSSProperties;
+};
+
+/** Option rendered by the reusable panel multi-select. */
+export type PanelMultiSelectOption = {
+  /** User-visible option label. */
+  label: string;
+  /** Stable string value toggled by the option. */
+  value: string;
+};
+
+/** Props accepted by the reusable themed panel multi-select. */
+export type PanelMultiSelectProps = {
+  /** Accessible control label. */
+  ariaLabel: string;
+  /** Current selected values. */
+  value: readonly string[];
+  /** Options available in the dropdown menu. */
+  options: ReadonlyArray<PanelMultiSelectOption>;
+  /** Called when selected values change. */
+  onChange: (value: string[]) => void;
+  /** Text shown when no values are selected. */
+  placeholder?: string;
+  /** Optional icon rendered at the end of the button. */
+  trailingIcon?: ComponentChildren;
+  /** Optional inline style applied to the outer shell. */
+  style?: JSX.CSSProperties;
+};
+
+/** Renders a deck-themed select control with a rounded custom dropdown menu. */
+export function PanelSelect({
+  ariaLabel,
+  value,
+  options,
+  onChange,
+  trailingIcon,
+  style
+}: PanelSelectProps) {
+  const shellRef = useRef<HTMLDivElement | null>(null);
+  const listboxRef = useRef<HTMLDivElement | null>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const [open, setOpen] = useState(false);
+  const [activeOptionIndex, setActiveOptionIndex] = useState(() =>
+    findSelectedOptionIndex(options, value)
+  );
+  const [menuStyle, setMenuStyle] = useState<JSX.CSSProperties>(PANEL_SELECT_STYLES.menu);
+  const selectedOptionIndex = useMemo(
+    () => findSelectedOptionIndex(options, value),
+    [options, value]
+  );
+  const selectedOption = selectedOptionIndex >= 0 ? options[selectedOptionIndex] : undefined;
+  const listboxId = `${ariaLabel.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-options`;
+
+  useEffect(() => {
+    optionRefs.current = optionRefs.current.slice(0, options.length);
+  }, [options.length]);
+
+  useEffect(() => {
+    if (!open) {
+      setActiveOptionIndex(selectedOptionIndex);
+    }
+  }, [open, selectedOptionIndex]);
+
+  useEffect(() => {
+    const ownerDocument = shellRef.current?.ownerDocument;
+    if (!open || !ownerDocument) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const shell = shellRef.current;
+      const listbox = listboxRef.current;
+      if (
+        !shell ||
+        !event.target ||
+        shell.contains(event.target as Node) ||
+        listbox?.contains(event.target as Node)
+      ) {
+        return;
+      }
+      setOpen(false);
+    };
+
+    ownerDocument.addEventListener('pointerdown', handlePointerDown);
+    return () => ownerDocument.removeEventListener('pointerdown', handlePointerDown);
+  }, [open]);
+
+  useLayoutEffect(() => {
+    const ownerDocument = shellRef.current?.ownerDocument;
+    const ownerWindow = ownerDocument?.defaultView;
+    if (!open || !shellRef.current || !ownerWindow) {
+      return;
+    }
+
+    const updateMenuStyle = () => {
+      const shell = shellRef.current;
+      if (!shell) {
+        return;
+      }
+      const rect = shell.getBoundingClientRect();
+      setMenuStyle({
+        ...PANEL_SELECT_STYLES.menu,
+        top: `${rect.bottom + 4}px`,
+        left: `${rect.left}px`,
+        width: `${rect.width}px`
+      });
+    };
+
+    updateMenuStyle();
+    ownerWindow.addEventListener('resize', updateMenuStyle);
+    ownerWindow.addEventListener('scroll', updateMenuStyle, true);
+    return () => {
+      ownerWindow.removeEventListener('resize', updateMenuStyle);
+      ownerWindow.removeEventListener('scroll', updateMenuStyle, true);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || activeOptionIndex < 0) {
+      return;
+    }
+    optionRefs.current[activeOptionIndex]?.scrollIntoView?.({block: 'nearest'});
+  }, [activeOptionIndex, open]);
+
+  const selectOption = (option: PanelSelectOption) => {
+    onChange(option.value);
+    setOpen(false);
+  };
+
+  const handleTriggerKeyDown: JSX.KeyboardEventHandler<HTMLButtonElement> = event => {
+    stopEventPropagation(event as unknown as Event);
+
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      setOpen(true);
+      setActiveOptionIndex(previous =>
+        getNextOptionIndex(previous, event.key === 'ArrowDown' ? 1 : -1, options.length)
+      );
+      return;
+    }
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      if (open && activeOptionIndex >= 0) {
+        const option = options[activeOptionIndex];
+        if (option) {
+          selectOption(option);
+        }
+        return;
+      }
+      setOpen(true);
+      setActiveOptionIndex(selectedOptionIndex);
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div
+      ref={shellRef}
+      style={{...PANEL_SELECT_STYLES.shell, ...style}}
+      onPointerDown={event => stopEventPropagation(event as unknown as Event)}
+      onMouseDown={event => stopEventPropagation(event as unknown as Event)}
+      onWheel={event => stopEventPropagation(event as unknown as Event)}
+      onClick={event => stopEventPropagation(event as unknown as Event)}
+    >
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        style={{
+          ...PANEL_SELECT_STYLES.button,
+          ...(open ? PANEL_SELECT_STYLES.buttonOpen : {}),
+          opacity: options.length ? 1 : 0.58,
+          cursor: options.length ? 'pointer' : 'default'
+        }}
+        disabled={!options.length}
+        onClick={() => setOpen(current => !current)}
+        onKeyDown={handleTriggerKeyDown}
+        onKeyUp={event => stopEventPropagation(event as unknown as Event)}
+      >
+        <span>{selectedOption?.label ?? String(value)}</span>
+        {trailingIcon ?? <PanelSelectChevron />}
+      </button>
+      {open && shellRef.current?.ownerDocument.body
+        ? createPortal(
+            <div
+              ref={listboxRef}
+              id={listboxId}
+              role="listbox"
+              aria-label={`${ariaLabel} options`}
+              style={menuStyle}
+              onPointerDown={event => stopEventPropagation(event as unknown as Event)}
+              onMouseDown={event => stopEventPropagation(event as unknown as Event)}
+              onWheel={event => stopEventPropagation(event as unknown as Event)}
+              onClick={event => stopEventPropagation(event as unknown as Event)}
+            >
+              {options.map((option, index) => {
+                const selected = String(option.value) === String(value);
+                const active = index === activeOptionIndex;
+                return (
+                  <button
+                    key={String(option.value)}
+                    ref={element => {
+                      optionRefs.current[index] = element;
+                    }}
+                    type="button"
+                    role="option"
+                    aria-selected={selected}
+                    style={{
+                      ...PANEL_SELECT_STYLES.option,
+                      ...(active ? PANEL_SELECT_STYLES.optionActive : {}),
+                      ...(selected ? PANEL_SELECT_STYLES.optionSelected : {})
+                    }}
+                    onPointerEnter={() => setActiveOptionIndex(index)}
+                    onMouseDown={event => {
+                      event.preventDefault();
+                      stopEventPropagation(event as unknown as Event);
+                    }}
+                    onClick={() => selectOption(option)}
+                  >
+                    <span>{option.label}</span>
+                    {selected ? <span aria-hidden>✓</span> : null}
+                  </button>
+                );
+              })}
+            </div>,
+            shellRef.current.ownerDocument.body
+          )
+        : null}
+    </div>
+  );
+}
+
+/** Renders a deck-themed searchable string multi-select. */
+export function PanelMultiSelect({
+  ariaLabel,
+  value,
+  options,
+  onChange,
+  placeholder = 'All',
+  trailingIcon,
+  style
+}: PanelMultiSelectProps) {
+  const shellRef = useRef<HTMLDivElement | null>(null);
+  const listboxRef = useRef<HTMLDivElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [menuStyle, setMenuStyle] = useState<JSX.CSSProperties>(PANEL_SELECT_STYLES.menu);
+  const selectedValues = useMemo(
+    () => value.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0),
+    [value]
+  );
+  const mergedOptions = useMemo(
+    () => mergeSelectedMultiSelectOptions(options, selectedValues),
+    [options, selectedValues]
+  );
+  const selectedValueSet = useMemo(() => new Set(selectedValues), [selectedValues]);
+  const filteredOptions = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return mergedOptions;
+    }
+    return mergedOptions.filter(
+      option =>
+        option.label.toLowerCase().includes(normalizedQuery) ||
+        option.value.toLowerCase().includes(normalizedQuery)
+    );
+  }, [mergedOptions, query]);
+  const listboxId = `${ariaLabel.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-options`;
+  const summaryLabel = getMultiSelectSummaryLabel(selectedValues, mergedOptions, placeholder);
+
+  useEffect(() => {
+    const ownerDocument = shellRef.current?.ownerDocument;
+    if (!open || !ownerDocument) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const shell = shellRef.current;
+      const listbox = listboxRef.current;
+      if (
+        !shell ||
+        !event.target ||
+        shell.contains(event.target as Node) ||
+        listbox?.contains(event.target as Node)
+      ) {
+        return;
+      }
+      setOpen(false);
+    };
+
+    ownerDocument.addEventListener('pointerdown', handlePointerDown);
+    return () => ownerDocument.removeEventListener('pointerdown', handlePointerDown);
+  }, [open]);
+
+  useLayoutEffect(() => {
+    const ownerDocument = shellRef.current?.ownerDocument;
+    const ownerWindow = ownerDocument?.defaultView;
+    if (!open || !shellRef.current || !ownerWindow) {
+      return;
+    }
+
+    const updateMenuStyle = () => {
+      const shell = shellRef.current;
+      if (!shell) {
+        return;
+      }
+      const rect = shell.getBoundingClientRect();
+      setMenuStyle({
+        ...PANEL_SELECT_STYLES.menu,
+        top: `${rect.bottom + 4}px`,
+        left: `${rect.left}px`,
+        width: `${rect.width}px`
+      });
+    };
+
+    updateMenuStyle();
+    ownerWindow.addEventListener('resize', updateMenuStyle);
+    ownerWindow.addEventListener('scroll', updateMenuStyle, true);
+    return () => {
+      ownerWindow.removeEventListener('resize', updateMenuStyle);
+      ownerWindow.removeEventListener('scroll', updateMenuStyle, true);
+    };
+  }, [open]);
+
+  const toggleOption = (option: PanelMultiSelectOption) => {
+    const nextValues = selectedValueSet.has(option.value)
+      ? selectedValues.filter(entry => entry !== option.value)
+      : [...selectedValues, option.value];
+    onChange(nextValues);
+  };
+
+  return (
+    <div
+      ref={shellRef}
+      style={{...PANEL_SELECT_STYLES.shell, ...style}}
+      onPointerDown={event => stopEventPropagation(event as unknown as Event)}
+      onMouseDown={event => stopEventPropagation(event as unknown as Event)}
+      onWheel={event => stopEventPropagation(event as unknown as Event)}
+      onClick={event => stopEventPropagation(event as unknown as Event)}
+    >
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        style={{
+          ...PANEL_SELECT_STYLES.button,
+          ...(open ? PANEL_SELECT_STYLES.buttonOpen : {}),
+          opacity: mergedOptions.length ? 1 : 0.58,
+          cursor: mergedOptions.length ? 'pointer' : 'default'
+        }}
+        disabled={!mergedOptions.length}
+        onClick={() => setOpen(current => !current)}
+        onKeyDown={event => {
+          stopEventPropagation(event as unknown as Event);
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            setOpen(current => !current);
+          }
+          if (event.key === 'Escape') {
+            event.preventDefault();
+            setOpen(false);
+          }
+        }}
+        onKeyUp={event => stopEventPropagation(event as unknown as Event)}
+      >
+        <span style={PANEL_SELECT_STYLES.summaryText}>{summaryLabel}</span>
+        {trailingIcon ?? <PanelSelectChevron />}
+      </button>
+      {open && shellRef.current?.ownerDocument.body
+        ? createPortal(
+            <div
+              ref={listboxRef}
+              id={listboxId}
+              role="listbox"
+              aria-label={`${ariaLabel} options`}
+              aria-multiselectable="true"
+              style={menuStyle}
+              onPointerDown={event => stopEventPropagation(event as unknown as Event)}
+              onMouseDown={event => stopEventPropagation(event as unknown as Event)}
+              onWheel={event => stopEventPropagation(event as unknown as Event)}
+              onClick={event => stopEventPropagation(event as unknown as Event)}
+            >
+              <input
+                aria-label={`${ariaLabel} search`}
+                type="search"
+                value={query}
+                placeholder="Search..."
+                style={PANEL_SELECT_STYLES.searchInput}
+                onInput={event => setQuery(event.currentTarget.value)}
+                onKeyDown={event => stopEventPropagation(event as unknown as Event)}
+                onKeyUp={event => stopEventPropagation(event as unknown as Event)}
+              />
+              {filteredOptions.map(option => {
+                const selected = selectedValueSet.has(option.value);
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    role="option"
+                    aria-selected={selected}
+                    style={{
+                      ...PANEL_SELECT_STYLES.option,
+                      ...(selected ? PANEL_SELECT_STYLES.optionSelected : {})
+                    }}
+                    onMouseDown={event => {
+                      event.preventDefault();
+                      stopEventPropagation(event as unknown as Event);
+                    }}
+                    onClick={() => toggleOption(option)}
+                  >
+                    <span>{option.label}</span>
+                    {selected ? <span aria-hidden>✓</span> : null}
+                  </button>
+                );
+              })}
+              {filteredOptions.length === 0 ? (
+                <div style={PANEL_SELECT_STYLES.emptyState}>No matching options</div>
+              ) : null}
+              {selectedValues.length > 0 ? (
+                <button
+                  type="button"
+                  style={PANEL_SELECT_STYLES.clearButton}
+                  onMouseDown={event => {
+                    event.preventDefault();
+                    stopEventPropagation(event as unknown as Event);
+                  }}
+                  onClick={() => onChange([])}
+                >
+                  Clear selection
+                </button>
+              ) : null}
+            </div>,
+            shellRef.current.ownerDocument.body
+          )
+        : null}
+    </div>
+  );
+}
+
+/**
+ * Renders the default chevron glyph for the panel select trigger.
+ */
+function PanelSelectChevron() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      style={PANEL_SELECT_STYLES.chevron}
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+
+/** Preserves selected values that are not in the current option list so they can be cleared. */
+function mergeSelectedMultiSelectOptions(
+  options: ReadonlyArray<PanelMultiSelectOption>,
+  selectedValues: readonly string[]
+): PanelMultiSelectOption[] {
+  const values = new Set(options.map(option => option.value));
+  return [
+    ...options,
+    ...selectedValues
+      .filter(value => !values.has(value))
+      .map(value => ({
+        label: value,
+        value
+      }))
+  ];
+}
+
+/** Returns the compact button text for a multi-select value. */
+function getMultiSelectSummaryLabel(
+  selectedValues: readonly string[],
+  options: ReadonlyArray<PanelMultiSelectOption>,
+  placeholder: string
+): string {
+  if (selectedValues.length === 0) {
+    return placeholder;
+  }
+  const labelsByValue = new Map(options.map(option => [option.value, option.label] as const));
+  const labels = selectedValues.map(value => labelsByValue.get(value) ?? value);
+  if (labels.length <= 2) {
+    return labels.join(', ');
+  }
+  return `${labels.length} selected`;
+}
+
+/**
+ * Stops panel select interactions from reaching deck gestures underneath the overlay.
+ */
+function stopEventPropagation(event: Event): void {
+  event.stopPropagation();
+  if (
+    typeof (event as {stopImmediatePropagation?: () => void}).stopImmediatePropagation ===
+    'function'
+  ) {
+    (event as {stopImmediatePropagation: () => void}).stopImmediatePropagation();
+  }
+}
+
+/**
+ * Returns the selected option index for the current serialized scalar value.
+ */
+function findSelectedOptionIndex(
+  options: ReadonlyArray<PanelSelectOption>,
+  value: PanelSelectValue
+): number {
+  return options.findIndex(option => String(option.value) === String(value));
+}
+
+/**
+ * Advances an active option index cyclically for arrow-key navigation.
+ */
+function getNextOptionIndex(currentIndex: number, delta: -1 | 1, optionCount: number): number {
+  if (optionCount === 0) {
+    return -1;
+  }
+  const resolvedIndex = currentIndex >= 0 ? currentIndex : delta > 0 ? -1 : 0;
+  return (resolvedIndex + delta + optionCount) % optionCount;
+}
+
+const PANEL_SELECT_STYLES = {
+  shell: {
+    position: 'relative',
+    width: '100%',
+    minWidth: 0
+  },
+  button: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    width: '100%',
+    minHeight: 36,
+    borderRadius: 13,
+    border: 'var(--menu-border, 1px solid rgba(148, 163, 184, 0.24))',
+    background: 'var(--menu-background, rgba(51, 65, 85, 0.78))',
+    color: 'var(--menu-text, #f8fafc)',
+    padding: '0 14px',
+    font: 'inherit',
+    fontSize: 12,
+    fontWeight: 650,
+    textAlign: 'left',
+    cursor: 'pointer'
+  },
+  buttonOpen: {
+    borderColor: 'var(--button-icon-hover, rgba(96, 165, 250, 0.78))',
+    boxShadow: '0 0 0 2px rgba(96, 165, 250, 0.16)'
+  },
+  menu: {
+    position: 'fixed',
+    zIndex: 10000,
+    display: 'grid',
+    gap: 2,
+    maxHeight: 260,
+    overflow: 'auto',
+    borderRadius: 13,
+    border: 'var(--menu-border, 1px solid rgba(148, 163, 184, 0.28))',
+    background: 'var(--menu-background, #334155)',
+    boxShadow: 'var(--menu-shadow, 0 16px 34px rgba(0, 0, 0, 0.32))',
+    padding: 4
+  },
+  option: {
+    minHeight: 30,
+    border: 'none',
+    borderRadius: 9,
+    background: 'transparent',
+    color: 'var(--menu-text, #f8fafc)',
+    font: 'inherit',
+    fontSize: 12,
+    fontWeight: 430,
+    textAlign: 'left',
+    cursor: 'pointer',
+    padding: '0 10px',
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0, 1fr) auto',
+    alignItems: 'center',
+    gap: 8
+  },
+  optionActive: {
+    background: 'var(--menu-item-hover, rgba(148, 163, 184, 0.16))'
+  },
+  optionSelected: {
+    background: 'var(--button-background, rgba(96, 165, 250, 0.36))',
+    color: 'var(--menu-text, #f8fafc)',
+    fontWeight: 520
+  },
+  summaryText: {
+    minWidth: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap'
+  },
+  searchInput: {
+    minHeight: 30,
+    border: 'var(--menu-border, 1px solid rgba(148, 163, 184, 0.28))',
+    borderRadius: 9,
+    background: 'var(--button-background, rgba(15, 23, 42, 0.22))',
+    color: 'var(--menu-text, #f8fafc)',
+    font: 'inherit',
+    fontSize: 12,
+    padding: '0 10px',
+    outline: 'none'
+  },
+  emptyState: {
+    color: 'var(--button-text, #94a3b8)',
+    fontSize: 12,
+    padding: '8px 10px'
+  },
+  clearButton: {
+    minHeight: 30,
+    border: 'none',
+    borderRadius: 9,
+    background: 'transparent',
+    color: 'var(--button-text, #94a3b8)',
+    font: 'inherit',
+    fontSize: 12,
+    fontWeight: 520,
+    textAlign: 'left',
+    cursor: 'pointer',
+    padding: '0 10px'
+  },
+  chevron: {
+    width: 18,
+    height: 18,
+    flex: '0 0 auto',
+    color: 'var(--button-text, #94a3b8)',
+    pointerEvents: 'none'
+  }
+} satisfies Record<string, JSX.CSSProperties>;

--- a/modules/panels/src/preact/widget-tooltip.test.tsx
+++ b/modules/panels/src/preact/widget-tooltip.test.tsx
@@ -1,0 +1,37 @@
+/** @jsxImportSource preact */
+
+import {render} from 'preact';
+import {afterEach, describe, expect, it} from 'vitest';
+
+import {WidgetTooltip} from './widget-tooltip';
+
+/**
+ * Renders one tooltip into a disposable DOM root.
+ */
+function renderTooltip() {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+
+  render(
+    <WidgetTooltip label="Example tooltip">
+      <button type="button">Trigger</button>
+    </WidgetTooltip>,
+    root
+  );
+
+  return root;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('WidgetTooltip', () => {
+  it('uses keyboard-visible focus instead of persistent focus-within', () => {
+    const root = renderTooltip();
+    const css = root.querySelector('style')?.textContent ?? '';
+
+    expect(css).toContain(':has(:focus-visible)');
+    expect(css).not.toContain(':focus-within');
+  });
+});

--- a/modules/panels/src/preact/widget-tooltip.tsx
+++ b/modules/panels/src/preact/widget-tooltip.tsx
@@ -1,0 +1,194 @@
+/** @jsxImportSource preact */
+
+import type {ComponentChildren} from 'preact';
+
+/** Preferred placement for a deck widget tooltip. */
+export type WidgetTooltipPlacement =
+  | 'top'
+  | 'top-start'
+  | 'top-end'
+  | 'right'
+  | 'bottom'
+  | 'bottom-start'
+  | 'bottom-end'
+  | 'left';
+
+/** Props for the shared deck widget tooltip wrapper. */
+export type WidgetTooltipProps = {
+  /** Visible tooltip label. */
+  label: string;
+  /** Optional caller-provided tooltip HTML. */
+  html?: HTMLElement | string;
+  /** Optional keyboard shortcut text rendered as a trailing key chip. */
+  shortcutKeyHTML?: string;
+  /** Tooltip placement relative to the wrapped control. */
+  placement?: WidgetTooltipPlacement;
+  /** Control that owns the tooltip. */
+  children: ComponentChildren;
+};
+
+/** Wraps a deck widget control with an immediate, styled hover/focus tooltip. */
+export function WidgetTooltip({
+  label,
+  html,
+  shortcutKeyHTML,
+  placement = 'right',
+  children
+}: WidgetTooltipProps) {
+  const tooltipContent =
+    html === undefined ? (
+      <>
+        <span>{label}</span>
+        {shortcutKeyHTML ? <kbd>{shortcutKeyHTML}</kbd> : null}
+      </>
+    ) : typeof html === 'string' ? (
+      <span dangerouslySetInnerHTML={{__html: html}} />
+    ) : (
+      <span ref={element => element?.replaceChildren(html)} />
+    );
+
+  return (
+    <span className="deck-widget-tooltip-anchor" data-tooltip-placement={placement}>
+      <WidgetTooltipStyle />
+      {children}
+      <span className="deck-widget-tooltip" role="tooltip">
+        {tooltipContent}
+      </span>
+    </span>
+  );
+}
+
+function WidgetTooltipStyle() {
+  return <style>{WIDGET_TOOLTIP_CSS}</style>;
+}
+
+const WIDGET_TOOLTIP_CSS = `
+.deck-widget-tooltip-anchor {
+  position: relative;
+  display: inline-flex;
+}
+
+.deck-widget-tooltip {
+  position: absolute;
+  z-index: 2147483647;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 280px;
+  padding: 5px 7px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 6px;
+  background: rgba(15, 23, 42, 0.94);
+  color: white;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.18);
+  font: 500 11px/1.3 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 80ms ease, transform 80ms ease;
+  white-space: nowrap;
+}
+
+.deck-widget-tooltip kbd {
+  display: inline-flex;
+  align-items: center;
+  min-height: 16px;
+  padding: 0 4px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.94);
+  font: 600 10px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.deck-widget-tooltip-anchor:hover .deck-widget-tooltip,
+.deck-widget-tooltip-anchor:has(:focus-visible) .deck-widget-tooltip {
+  opacity: 1;
+}
+
+.deck-widget-tooltip-anchor[data-tooltip-placement="right"] .deck-widget-tooltip {
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translate(-2px, -50%);
+}
+
+.deck-widget-tooltip-anchor[data-tooltip-placement="right"]:hover .deck-widget-tooltip,
+.deck-widget-tooltip-anchor[data-tooltip-placement="right"]:has(:focus-visible) .deck-widget-tooltip {
+  transform: translate(0, -50%);
+}
+
+.deck-widget-tooltip-anchor[data-tooltip-placement="left"] .deck-widget-tooltip {
+  right: calc(100% + 8px);
+  top: 50%;
+  transform: translate(2px, -50%);
+}
+
+.deck-widget-tooltip-anchor[data-tooltip-placement="left"]:hover .deck-widget-tooltip,
+.deck-widget-tooltip-anchor[data-tooltip-placement="left"]:has(:focus-visible) .deck-widget-tooltip {
+  transform: translate(0, -50%);
+}
+
+.deck-widget-tooltip-anchor[data-tooltip-placement="top"] .deck-widget-tooltip {
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translate(-50%, 2px);
+}
+
+.deck-widget-tooltip-anchor[data-tooltip-placement="top"]:hover .deck-widget-tooltip,
+.deck-widget-tooltip-anchor[data-tooltip-placement="top"]:has(:focus-visible) .deck-widget-tooltip {
+  transform: translate(-50%, 0);
+}
+
+.deck-widget-tooltip-anchor[data-tooltip-placement="top-start"] .deck-widget-tooltip {
+  bottom: calc(100% + 8px);
+  left: 0;
+  transform: translate(0, 2px);
+}
+
+.deck-widget-tooltip-anchor[data-tooltip-placement="top-start"]:hover .deck-widget-tooltip,
+.deck-widget-tooltip-anchor[data-tooltip-placement="top-start"]:has(:focus-visible) .deck-widget-tooltip {
+  transform: translate(0, 0);
+}
+
+.deck-widget-tooltip-anchor[data-tooltip-placement="top-end"] .deck-widget-tooltip {
+  bottom: calc(100% + 8px);
+  right: 0;
+  transform: translate(0, 2px);
+}
+
+.deck-widget-tooltip-anchor[data-tooltip-placement="top-end"]:hover .deck-widget-tooltip,
+.deck-widget-tooltip-anchor[data-tooltip-placement="top-end"]:has(:focus-visible) .deck-widget-tooltip {
+  transform: translate(0, 0);
+}
+
+.deck-widget-tooltip-anchor[data-tooltip-placement="bottom"] .deck-widget-tooltip {
+  left: 50%;
+  top: calc(100% + 8px);
+  transform: translate(-50%, -2px);
+}
+
+.deck-widget-tooltip-anchor[data-tooltip-placement="bottom"]:hover .deck-widget-tooltip,
+.deck-widget-tooltip-anchor[data-tooltip-placement="bottom"]:has(:focus-visible) .deck-widget-tooltip {
+  transform: translate(-50%, 0);
+}
+
+.deck-widget-tooltip-anchor[data-tooltip-placement="bottom-start"] .deck-widget-tooltip {
+  left: 0;
+  top: calc(100% + 8px);
+  transform: translate(0, -2px);
+}
+
+.deck-widget-tooltip-anchor[data-tooltip-placement="bottom-start"]:hover .deck-widget-tooltip,
+.deck-widget-tooltip-anchor[data-tooltip-placement="bottom-start"]:has(:focus-visible) .deck-widget-tooltip {
+  transform: translate(0, 0);
+}
+
+.deck-widget-tooltip-anchor[data-tooltip-placement="bottom-end"] .deck-widget-tooltip {
+  right: 0;
+  top: calc(100% + 8px);
+  transform: translate(0, -2px);
+}
+
+.deck-widget-tooltip-anchor[data-tooltip-placement="bottom-end"]:hover .deck-widget-tooltip,
+.deck-widget-tooltip-anchor[data-tooltip-placement="bottom-end"]:has(:focus-visible) .deck-widget-tooltip {
+  transform: translate(0, 0);
+}
+`;

--- a/modules/widgets/src/index.ts
+++ b/modules/widgets/src/index.ts
@@ -36,10 +36,24 @@ export {
   type OmniBoxResultsSummaryArgs,
   type OmniBoxWidgetProps
 } from './widgets/omni-box-widget';
+export {
+  CommandResetViewWidget,
+  type CommandResetViewWidgetProps
+} from './widgets/command-reset-view-widget';
+export {
+  CommandToggleWidget,
+  type CommandToggleWidgetProps
+} from './widgets/command-toggle-widget';
+export {
+  KeyboardShortcutsWidget,
+  type KeyboardShortcutsWidgetProps
+} from './widgets/keyboard-shortcuts-widget';
 export {ResetViewWidget, type ResetViewWidgetProps} from './widgets/reset-view-widget';
+export {SettingsWidget, type SettingsWidgetProps} from './widgets/settings-widget';
 export {
   TimeMeasureWidget,
   type TimeMeasureRange,
+  type TimeMeasureWidgetProps,
   type TimeMeasureSelectionState
 } from './widgets/time-measure-widget';
 export {YZoomWidget, type YZoomWidgetProps} from './widgets/y-zoom-widget';
@@ -59,4 +73,3 @@ export {
   type ToastWidgetProps,
   type ToolbarWidgetProps
 } from './panel-widgets/panel-widget';
-export {IconButton, makeTextIcon} from './preact/icon-button';

--- a/modules/widgets/src/widgets/command-reset-view-widget.tsx
+++ b/modules/widgets/src/widgets/command-reset-view-widget.tsx
@@ -1,0 +1,115 @@
+/** @jsxImportSource preact */
+import {ResetViewWidget} from '@deck.gl/widgets';
+import {render} from 'preact';
+
+import {WidgetTooltip} from '@deck.gl-community/panels';
+
+import type {WidgetTooltipPlacement} from '@deck.gl-community/panels';
+import type {ResetViewWidgetProps} from '@deck.gl/widgets';
+import type {JSX} from 'preact';
+
+type CommandResetViewWidgetExtraProps = {
+  /** Optional command id metadata used by external command wiring. */
+  commandId?: string;
+  /** CSS mask data URL used as the reset button icon. */
+  icon?: string;
+  /** Optional command implementation used instead of the built-in reset behavior. */
+  onCommand?: () => void;
+  /** Optional caller-owned HTML renderer for the trigger tooltip. */
+  renderTooltipHTML?: ({widget}: {widget: CommandResetViewWidget}) => HTMLElement | string;
+  /** Optional keyboard shortcut text rendered in the tooltip. */
+  shortcutKeyHTML?: string;
+  /** Tooltip placement relative to the reset button. */
+  tooltipPlacement?: WidgetTooltipPlacement;
+};
+
+/** Props for a reset-view widget with optional external command metadata and a styled tooltip. */
+export type CommandResetViewWidgetProps = ResetViewWidgetProps & CommandResetViewWidgetExtraProps;
+
+/** ResetViewWidget subclass that exposes a stable action method and styled tooltips. */
+export class CommandResetViewWidget extends ResetViewWidget {
+  /** Resolved props after deck.gl widget defaulting. */
+  declare props: Required<ResetViewWidgetProps> & CommandResetViewWidgetExtraProps;
+  /** Command id currently registered for this widget instance. */
+  commandId?: string;
+
+  /** Creates a reset-view widget. */
+  constructor(props: CommandResetViewWidgetProps = {}) {
+    super(props);
+    this.commandId = props.commandId;
+  }
+
+  /** Performs the reset action for external command wiring. */
+  static performAction({widget}: {widget: CommandResetViewWidget}): void {
+    widget.runCommand();
+  }
+
+  override setProps(props: Partial<CommandResetViewWidgetProps>): void {
+    this.commandId = props.commandId ?? this.commandId;
+    super.setProps(props);
+  }
+
+  override onRenderHTML(rootElement: HTMLElement): void {
+    const {
+      className,
+      style,
+      icon = '',
+      label = 'Reset View',
+      shortcutKeyHTML,
+      renderTooltipHTML
+    } = this.props;
+    const tooltipHTML = renderTooltipHTML?.({widget: this});
+
+    rootElement.className = ['deck-widget', this.className, this.props.className]
+      .filter(Boolean)
+      .join(' ');
+
+    render(
+      <WidgetTooltip
+        label={label}
+        html={tooltipHTML}
+        shortcutKeyHTML={shortcutKeyHTML}
+        placement={this.props.tooltipPlacement}
+      >
+        <div
+          className={`deck-widget-button ${className ?? ''}`}
+          style={style as unknown as JSX.CSSProperties}
+        >
+          <button
+            aria-label={label}
+            className="deck-widget-icon-button deck-widget-reset-focus"
+            type="button"
+            onClick={this.handleWidgetClick}
+          >
+            <div
+              className="deck-widget-icon"
+              style={
+                icon
+                  ? {
+                      maskImage: `url('${icon}')`,
+                      WebkitMaskImage: `url('${icon}')`
+                    }
+                  : undefined
+              }
+            />
+          </button>
+        </div>
+      </WidgetTooltip>,
+      rootElement
+    );
+  }
+
+  private handleWidgetClick = (event: MouseEvent): void => {
+    event.preventDefault();
+    event.stopPropagation();
+    CommandResetViewWidget.performAction({widget: this});
+  };
+
+  private runCommand(): void {
+    if (this.props.onCommand) {
+      this.props.onCommand();
+      return;
+    }
+    super.handleClick();
+  }
+}

--- a/modules/widgets/src/widgets/command-toggle-widget.tsx
+++ b/modules/widgets/src/widgets/command-toggle-widget.tsx
@@ -1,0 +1,110 @@
+/** @jsxImportSource preact */
+import {ToggleWidget} from '@deck.gl/widgets';
+import {render} from 'preact';
+
+import {WidgetTooltip} from '@deck.gl-community/panels';
+
+import type {WidgetTooltipPlacement} from '@deck.gl-community/panels';
+import type {ToggleWidgetProps} from '@deck.gl/widgets';
+import type {JSX} from 'preact';
+
+type CommandToggleWidgetExtraProps = {
+  /** Optional command id metadata used by external command wiring. */
+  commandId?: string;
+  /** Optional caller-owned HTML renderer for the trigger tooltip. */
+  renderTooltipHTML?: ({widget}: {widget: CommandToggleWidget}) => HTMLElement | string;
+  /** Optional keyboard shortcut text rendered in the tooltip. */
+  shortcutKeyHTML?: string;
+  /** Tooltip placement relative to the toggle button. */
+  tooltipPlacement?: WidgetTooltipPlacement;
+};
+
+/** Props for a toggle widget with optional external command metadata and a styled tooltip. */
+export type CommandToggleWidgetProps = ToggleWidgetProps & CommandToggleWidgetExtraProps;
+
+/** ToggleWidget subclass that exposes a stable action method and styled tooltips. */
+export class CommandToggleWidget extends ToggleWidget {
+  /** Resolved props after deck.gl widget defaulting. */
+  declare props: Required<ToggleWidgetProps> & CommandToggleWidgetExtraProps;
+  /** Command id currently registered for this widget instance. */
+  commandId?: string;
+
+  /** Creates a toggle widget. */
+  constructor(props: CommandToggleWidgetProps) {
+    super(props);
+    this.commandId = props.commandId;
+  }
+
+  /** Performs the toggle action for external command wiring. */
+  static performAction({widget}: {widget: CommandToggleWidget}): void {
+    widget.toggleCommand();
+  }
+
+  override setProps(props: Partial<CommandToggleWidgetProps>): void {
+    this.commandId = props.commandId ?? this.commandId;
+    super.setProps(props);
+  }
+
+  override onRenderHTML(rootElement: HTMLElement): void {
+    const {
+      className,
+      style,
+      icon,
+      label,
+      color,
+      onIcon = icon,
+      onLabel = label,
+      onColor = color,
+      shortcutKeyHTML,
+      tooltipPlacement,
+      renderTooltipHTML
+    } = this.props;
+    const isChecked = this.checked;
+    const tooltipLabel = isChecked ? onLabel : label;
+    const tooltipHTML = renderTooltipHTML?.({widget: this});
+
+    rootElement.dataset.checked = String(isChecked);
+
+    render(
+      <WidgetTooltip
+        label={tooltipLabel ?? ''}
+        html={tooltipHTML}
+        shortcutKeyHTML={shortcutKeyHTML}
+        placement={tooltipPlacement}
+      >
+        <div
+          className={`deck-widget-button ${className ?? ''}`}
+          style={style as unknown as JSX.CSSProperties}
+        >
+          <button
+            aria-label={tooltipLabel}
+            aria-pressed={isChecked}
+            className="deck-widget-icon-button"
+            type="button"
+            onClick={this.handleClick}
+          >
+            <div
+              className="deck-widget-icon"
+              style={{
+                backgroundColor: isChecked ? onColor : color,
+                maskImage: `url('${isChecked ? onIcon : icon}')`,
+                WebkitMaskImage: `url('${isChecked ? onIcon : icon}')`
+              }}
+            />
+          </button>
+        </div>
+      </WidgetTooltip>,
+      rootElement
+    );
+  }
+
+  private handleClick = (): void => {
+    CommandToggleWidget.performAction({widget: this});
+  };
+
+  private toggleCommand(): void {
+    this.checked = !this.checked;
+    this.props.onChange?.(this.checked);
+    this.updateHTML();
+  }
+}

--- a/modules/widgets/src/widgets/command-widget-boundary.test.tsx
+++ b/modules/widgets/src/widgets/command-widget-boundary.test.tsx
@@ -1,0 +1,77 @@
+import {describe, expect, it, vi} from 'vitest';
+
+import {commandManager} from '@deck.gl-community/panels';
+import {CommandResetViewWidget} from './command-reset-view-widget';
+import {CommandToggleWidget} from './command-toggle-widget';
+
+/** Renders a widget into a document-attached root for DOM assertions. */
+function renderWidget(widget: {onRenderHTML: (rootElement: HTMLElement) => void}) {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  widget.onRenderHTML(root);
+  return {
+    root,
+    cleanup() {
+      root.remove();
+    }
+  };
+}
+
+describe('command action widgets', () => {
+  it('runs toggle actions directly from clicks and caller-owned commands', () => {
+    const onChange = vi.fn();
+    const widget = new CommandToggleWidget({
+      id: 'test-toggle',
+      icon: 'test-icon',
+      label: 'Enable test mode',
+      onChange,
+      renderTooltipHTML: () => '<span>Enable test mode <kbd>T</kbd></span>'
+    });
+    const {root, cleanup} = renderWidget(widget);
+
+    expect(root.querySelector('[role="tooltip"]')?.innerHTML).toContain('<kbd>T</kbd>');
+
+    root.querySelector('button')?.click();
+    expect(onChange).toHaveBeenLastCalledWith(true);
+
+    commandManager.registerCommand({
+      id: 'test-toggle.external',
+      do: () => CommandToggleWidget.performAction({widget})
+    });
+    commandManager.executeCommand('test-toggle.external');
+    expect(onChange).toHaveBeenLastCalledWith(false);
+
+    cleanup();
+  });
+
+  it('runs reset actions directly from clicks and caller-owned commands', () => {
+    const onCommand = vi.fn();
+    const widget = new CommandResetViewWidget({
+      id: 'test-reset',
+      label: 'Reset test view',
+      onCommand,
+      renderTooltipHTML: () => {
+        const element = document.createElement('span');
+        element.textContent = 'Reset from caller tooltip';
+        return element;
+      }
+    });
+    const {root, cleanup} = renderWidget(widget);
+
+    expect(root.querySelector('[role="tooltip"]')?.textContent).toContain(
+      'Reset from caller tooltip'
+    );
+
+    root.querySelector('button')?.click();
+    expect(onCommand).toHaveBeenCalledTimes(1);
+
+    commandManager.registerCommand({
+      id: 'test-reset.external',
+      do: () => CommandResetViewWidget.performAction({widget})
+    });
+    commandManager.executeCommand('test-reset.external');
+    expect(onCommand).toHaveBeenCalledTimes(2);
+
+    cleanup();
+  });
+});

--- a/modules/widgets/src/widgets/heap-memory-widget.tsx
+++ b/modules/widgets/src/widgets/heap-memory-widget.tsx
@@ -118,7 +118,7 @@ function HeapMemoryWidgetView({pollIntervalMs}: HeapMemoryWidgetViewProps) {
     borderRadius: 'var(--button-corner-radius)',
     backgroundImage: gradient,
     backgroundColor: 'var(--button-background)',
-    color: 'var(--deck-widget-text-color, #111827)',
+    color: 'var(--button-text, currentColor)',
     border: '1px solid var(--button-stroke)',
     boxShadow: 'var(--button-shadow)',
     overflow: 'hidden',
@@ -148,8 +148,7 @@ function HeapMemoryWidgetView({pollIntervalMs}: HeapMemoryWidgetViewProps) {
         <span
           style={{
             lineHeight: 1.05,
-            fontSize: '10px',
-            textShadow: '0 1px 1px rgba(255, 255, 255, 0.35)'
+            fontSize: '10px'
           }}
         >
           {valueText}
@@ -157,8 +156,7 @@ function HeapMemoryWidgetView({pollIntervalMs}: HeapMemoryWidgetViewProps) {
         <span
           style={{
             lineHeight: 1,
-            fontSize: '9px',
-            textShadow: '0 1px 1px rgba(255, 255, 255, 0.35)'
+            fontSize: '9px'
           }}
         >
           GB

--- a/modules/widgets/src/widgets/keyboard-shortcuts-widget.test.tsx
+++ b/modules/widgets/src/widgets/keyboard-shortcuts-widget.test.tsx
@@ -1,0 +1,372 @@
+import {afterEach, describe, expect, it} from 'vitest';
+
+import {commandManager} from '@deck.gl-community/panels';
+import {KeyboardShortcutsWidget} from './keyboard-shortcuts-widget';
+
+import type {KeyboardShortcut} from '@deck.gl-community/panels';
+
+type Handler = (event: {srcEvent: KeyboardEvent}) => void;
+
+const isMac =
+  typeof window !== 'undefined' && globalThis.navigator.platform.toUpperCase().includes('MAC');
+
+class FakeEventManager {
+  handlers = new Map<string, Handler>();
+
+  on(event: string, handler: Handler) {
+    this.handlers.set(event, handler);
+  }
+
+  off(event: string, handler: Handler) {
+    const existing = this.handlers.get(event);
+    if (existing === handler) {
+      this.handlers.delete(event);
+    }
+  }
+
+  emit(event: string, srcEvent: KeyboardEvent) {
+    const handler = this.handlers.get(event);
+    handler?.({srcEvent});
+  }
+}
+
+function commandKeyEvent(key: string): KeyboardEvent {
+  return new KeyboardEvent('keydown', {
+    key,
+    ctrlKey: !isMac,
+    metaKey: isMac
+  });
+}
+
+/**
+ * Renders a keyboard shortcuts widget into a detached DOM node for interaction tests.
+ */
+function renderWidget(options?: {
+  commandId?: string;
+  eventManager?: FakeEventManager;
+  installShortcuts?: boolean;
+  keyboardShortcuts?: KeyboardShortcut[];
+}) {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+
+  const widget = new KeyboardShortcutsWidget({
+    commandId: options?.commandId,
+    installShortcuts: options?.installShortcuts,
+    keyboardShortcuts: options?.keyboardShortcuts ?? []
+  });
+
+  if (options?.eventManager) {
+    (widget as unknown as {deck?: {eventManager: FakeEventManager}}).deck = {
+      eventManager: options.eventManager
+    };
+  }
+
+  widget.onRenderHTML(root);
+  widget.onAdd();
+
+  return {
+    root,
+    widget,
+    cleanup() {
+      widget.onRemove();
+      root.remove();
+    }
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('KeyboardShortcutsWidget', () => {
+  it('renders paired and single shortcut rows with shared descriptions', async () => {
+    const {root, cleanup} = renderWidget({
+      keyboardShortcuts: [
+        {
+          key: 'a',
+          name: 'Pan Left',
+          description: 'Pan left',
+          badges: ['perfetto'],
+          displayPair: {
+            id: 'pan-horizontal',
+            position: 'primary',
+            description: 'Pan horizontally.'
+          }
+        },
+        {
+          key: 'd',
+          name: 'Pan Right',
+          description: 'Pan right',
+          badges: ['perfetto'],
+          displayPair: {
+            id: 'pan-horizontal',
+            position: 'secondary',
+            description: 'Pan horizontally.'
+          }
+        },
+        {
+          key: 'g',
+          name: 'Jump',
+          description: 'Move to the selected span.'
+        },
+        {
+          key: 'c',
+          name: 'Next color scheme',
+          description: 'Cycle to the next color scheme.',
+          displayPair: {
+            id: 'color',
+            position: 'primary',
+            description: 'Cycle to next/prev color scheme.'
+          }
+        },
+        {
+          key: 'c',
+          shiftKey: true,
+          name: 'Previous color scheme',
+          description: 'Cycle to the previous color scheme.',
+          displayPair: {
+            id: 'color',
+            position: 'secondary',
+            description: 'Cycle to next/prev color scheme.'
+          }
+        }
+      ]
+    });
+
+    (root.querySelector('button[title="Keyboard shortcuts"]') as HTMLButtonElement).click();
+    await Promise.resolve();
+
+    const descriptions = Array.from(
+      root.querySelectorAll('[data-shortcut-description="true"]')
+    ).map(element => element.textContent);
+
+    expect(descriptions).toContain('Show keyboard shortcuts');
+    expect(descriptions).toContain('Pan horizontally.');
+    expect(descriptions).toContain('Move to the selected span.');
+    expect(descriptions).not.toContain('Jump');
+    const sections = Array.from(root.querySelectorAll('[data-shortcut-section]'));
+    expect(sections.map(section => section.getAttribute('data-shortcut-section'))).toEqual([
+      'Navigation',
+      'Commands',
+      'Settings'
+    ]);
+    expect(sections[0]?.textContent).toContain('Pan horizontally.');
+    expect(sections[0]?.textContent).not.toContain('Move to the selected span.');
+    expect(sections[1]?.textContent).toContain('Show keyboard shortcuts');
+    expect(sections[1]?.textContent).toContain('Move to the selected span.');
+    expect(sections[2]?.textContent).toContain('Cycle to next/prev color scheme.');
+    expect(root.querySelectorAll('[data-shortcut-row-kind="pair"]')).toHaveLength(2);
+    expect(root.querySelectorAll('[data-shortcut-row-kind="single"]')).toHaveLength(2);
+    const pairedRow = root.querySelector(
+      '[data-shortcut-row-kind="pair"]'
+    ) as HTMLDivElement | null;
+    expect(pairedRow?.style.gap).toBe('11px');
+    const keyTexts = Array.from(
+      root.querySelectorAll('[data-shortcut-input-kind="keyboard"] kbd')
+    ).map(element => element.textContent);
+    expect(keyTexts).toContain('/');
+    expect(keyTexts).toContain('A');
+    expect(keyTexts).toContain('D');
+    expect(root.textContent).toContain('perfetto');
+    expect(root.textContent?.match(/perfetto/g)).toHaveLength(1);
+
+    cleanup();
+  });
+
+  it('falls back to separate rows when pair metadata is not adjacent', async () => {
+    const {root, cleanup} = renderWidget({
+      keyboardShortcuts: [
+        {
+          key: 'a',
+          name: 'Pan Left',
+          description: 'Pan left',
+          displayPair: {
+            id: 'pan-horizontal',
+            position: 'primary',
+            description: 'Pan horizontally.'
+          }
+        },
+        {
+          key: 'g',
+          name: 'Jump',
+          description: 'Move to the selected span.'
+        },
+        {
+          key: 'd',
+          name: 'Pan Right',
+          description: 'Pan right',
+          displayPair: {
+            id: 'pan-horizontal',
+            position: 'secondary',
+            description: 'Pan horizontally.'
+          }
+        }
+      ]
+    });
+
+    (root.querySelector('button[title="Keyboard shortcuts"]') as HTMLButtonElement).click();
+    await Promise.resolve();
+
+    expect(root.querySelectorAll('[data-shortcut-row-kind="pair"]')).toHaveLength(0);
+    expect(root.querySelectorAll('[data-shortcut-row-kind="single"]')).toHaveLength(4);
+    expect(root.textContent).not.toContain('Pan horizontally.');
+
+    cleanup();
+  });
+
+  it('opens the shortcuts dialog from the default keyboard binding', async () => {
+    const eventManager = new FakeEventManager();
+    const {root, cleanup} = renderWidget({
+      commandId: 'test.shortcuts.open',
+      eventManager,
+      installShortcuts: true
+    });
+
+    expect(root.querySelector('button')?.getAttribute('title')).toBe(
+      isMac ? 'Keyboard shortcuts (⌘/)' : 'Keyboard shortcuts (Ctrl+/)'
+    );
+
+    eventManager.emit('keydown', commandKeyEvent('/'));
+    await Promise.resolve();
+    expect(root.querySelector('[role="dialog"]')).toBeTruthy();
+
+    cleanup();
+  });
+
+  it('opens the shortcuts dialog from its configured command id', async () => {
+    const {root, cleanup} = renderWidget({
+      commandId: 'test.shortcuts.command-open'
+    });
+
+    commandManager.executeCommand('test.shortcuts.command-open');
+    await Promise.resolve();
+
+    expect(root.querySelector('[role="dialog"]')).toBeTruthy();
+
+    cleanup();
+  });
+
+  it('renders display-only mouse and trackpad interactions', async () => {
+    const {root, cleanup} = renderWidget({
+      keyboardShortcuts: [
+        {
+          key: '',
+          name: 'Trackpad pan',
+          description: 'Pan with the trackpad.',
+          displayInputs: [
+            {
+              kind: 'trackpad',
+              label: 'two-finger swipe',
+              icon: 'trackpad-pan'
+            }
+          ]
+        },
+        {
+          key: '',
+          name: 'Mouse drag',
+          description: 'Measure time with the mouse.',
+          displayInputs: [
+            {
+              kind: 'mouse',
+              label: 'drag',
+              modifiers: ['shift'],
+              icon: 'mouse-drag'
+            }
+          ]
+        }
+      ]
+    });
+
+    (root.querySelector('button[title="Keyboard shortcuts"]') as HTMLButtonElement).click();
+    await Promise.resolve();
+
+    expect(root.querySelector('[data-shortcut-input-kind="trackpad"]')).toBeTruthy();
+    expect(root.querySelector('[data-shortcut-input-kind="mouse"]')).toBeTruthy();
+    expect(root.querySelector('svg[aria-label="Keyboard"]')).toBeNull();
+    expect(root.querySelector('svg[aria-label="Trackpad pan"]')).toBeTruthy();
+    expect(root.querySelector('svg[aria-label="Mouse drag"]')).toBeNull();
+    expect(root.textContent).toContain('two-finger swipe');
+    expect(root.textContent).toContain('drag');
+    expect(root.textContent).toContain('Shift');
+
+    cleanup();
+  });
+
+  it('honors explicit section overrides for display-only interactions', async () => {
+    const {root, cleanup} = renderWidget({
+      keyboardShortcuts: [
+        {
+          key: '',
+          name: 'Press and drag',
+          description: 'Pan with the trackpad.',
+          displaySection: 'navigation',
+          displayInputs: [
+            {
+              kind: 'trackpad',
+              label: 'press + drag',
+              icon: 'trackpad-pan'
+            }
+          ]
+        },
+        {
+          key: '',
+          name: 'Select Block',
+          description: 'Select a span and open the span inspector.',
+          displaySection: 'interaction',
+          displayInputs: [
+            {
+              kind: 'trackpad',
+              label: 'click',
+              icon: 'trackpad-click'
+            }
+          ]
+        },
+        {
+          key: '',
+          shiftKey: true,
+          name: 'Select Dependent Blocks',
+          description: 'Select a span and hide non-dependent spans.',
+          displaySection: 'interaction',
+          displayInputs: [
+            {
+              kind: 'trackpad',
+              label: 'click',
+              modifiers: ['shift'],
+              icon: 'trackpad-click'
+            }
+          ]
+        }
+      ]
+    });
+
+    (root.querySelector('button[title="Keyboard shortcuts"]') as HTMLButtonElement).click();
+    await Promise.resolve();
+
+    const sections = Array.from(root.querySelectorAll('[data-shortcut-section]'));
+    expect(sections.map(section => section.getAttribute('data-shortcut-section'))).toEqual([
+      'Navigation',
+      'Interaction',
+      'Commands'
+    ]);
+    const navigationSection = sections[0];
+    const interactionSection = sections[1];
+    const commandSection = sections[2];
+    expect(navigationSection?.textContent).toContain('Pan with the trackpad.');
+    expect(interactionSection?.textContent).toContain('Select a span and open the span inspector.');
+    expect(interactionSection?.textContent).toContain(
+      'Select a span and hide non-dependent spans.'
+    );
+    expect(commandSection?.textContent).toContain('Show keyboard shortcuts');
+    expect(root.querySelectorAll('svg[aria-label="Trackpad click"]')).toHaveLength(2);
+    const descriptions = Array.from(
+      interactionSection?.querySelectorAll('[data-shortcut-description="true"]') ?? []
+    ).map(element => element.textContent);
+    expect(descriptions).toEqual([
+      'Select a span and open the span inspector.',
+      'Select a span and hide non-dependent spans.'
+    ]);
+
+    cleanup();
+  });
+});

--- a/modules/widgets/src/widgets/keyboard-shortcuts-widget.tsx
+++ b/modules/widgets/src/widgets/keyboard-shortcuts-widget.tsx
@@ -1,0 +1,285 @@
+/** @jsxImportSource preact */
+
+import {Widget} from '@deck.gl/core';
+import {render} from 'preact';
+import {
+  commandManager,
+  DEFAULT_SHORTCUTS,
+  KeyboardShortcutsManager,
+  KeyboardShortcutsPanelContent
+} from '@deck.gl-community/panels';
+
+import type {WidgetPlacement, WidgetProps} from '@deck.gl/core';
+import type {KeyboardShortcut} from '@deck.gl-community/panels';
+import type {JSX} from 'preact';
+
+/** Props for the standalone keyboard shortcuts widget. */
+export type KeyboardShortcutsWidgetProps = WidgetProps & {
+  /** Widget positioning within the view. */
+  placement?: WidgetPlacement;
+  /** Keyboard shortcuts and display-only interactions rendered in the panel. */
+  keyboardShortcuts: KeyboardShortcut[];
+  /** Whether to install shortcut handlers on deck's event manager. */
+  installShortcuts?: boolean;
+  /** Command id used by the trigger and default keyboard shortcut. */
+  commandId?: string;
+};
+
+/** Standalone shortcuts widget that renders a help trigger and shortcut reference modal. */
+export class KeyboardShortcutsWidget extends Widget<KeyboardShortcutsWidgetProps> {
+  static override defaultProps = {
+    ...Widget.defaultProps,
+    id: 'keyboard-bindings',
+    placement: 'top-left',
+    keyboardShortcuts: [],
+    commandId: 'keyboard-shortcuts.open'
+  } satisfies Required<WidgetProps> &
+    Required<Pick<KeyboardShortcutsWidgetProps, 'placement' | 'keyboardShortcuts' | 'commandId'>> &
+    KeyboardShortcutsWidgetProps;
+
+  className = 'deck-widget-keyboard-bindings';
+  placement: WidgetPlacement = KeyboardShortcutsWidget.defaultProps.placement;
+
+  #isOpen = false;
+  #rootElement: HTMLElement | null = null;
+  #keyboardShortcuts: KeyboardShortcut[] = KeyboardShortcutsWidget.defaultProps.keyboardShortcuts;
+  #keyboardShortcutsManager: KeyboardShortcutsManager | null = null;
+  /** Command id registered for opening the shortcuts panel. */
+  commandId = KeyboardShortcutsWidget.defaultProps.commandId;
+
+  /** Creates a standalone shortcuts widget. */
+  constructor(props: KeyboardShortcutsWidgetProps) {
+    super({...KeyboardShortcutsWidget.defaultProps, ...props});
+    this.#keyboardShortcuts = props.keyboardShortcuts;
+    this.commandId = props.commandId ?? this.commandId;
+    commandManager.registerCommand({
+      id: this.commandId,
+      do: this.#handleOpen
+    });
+    if (props.placement !== undefined) {
+      this.placement = props.placement;
+    }
+  }
+
+  /** Updates widget placement, shortcut list, and installed shortcut handlers. */
+  override setProps(props: Partial<KeyboardShortcutsWidgetProps>): void {
+    this.commandId = props.commandId ?? this.commandId;
+    commandManager.registerCommand({
+      id: this.commandId,
+      do: this.#handleOpen
+    });
+    if (props.keyboardShortcuts !== undefined) {
+      this.#keyboardShortcuts = props.keyboardShortcuts;
+      this.#restartKeyboardShortcutsManager();
+      this.#renderRootElement();
+    }
+    if (props.installShortcuts !== undefined) {
+      this.#restartKeyboardShortcutsManager();
+      this.#renderRootElement();
+    }
+    if (props.placement !== undefined) {
+      this.placement = props.placement;
+    }
+    super.setProps(props);
+  }
+
+  /** Installs optional deck keyboard handling when the widget is added. */
+  override onAdd(): void {
+    this.#restartKeyboardShortcutsManager();
+    this.#renderRootElement();
+  }
+
+  /** Renders the shortcut trigger and modal into the deck widget root. */
+  override onRenderHTML(rootElement: HTMLElement): void {
+    this.#rootElement = rootElement;
+    rootElement.className = ['deck-widget', this.className, this.props.className]
+      .filter(Boolean)
+      .join(' ');
+    this.#renderRootElement();
+  }
+
+  /** Removes rendered UI and installed keyboard handlers. */
+  override onRemove(): void {
+    if (this.#rootElement) {
+      render(null, this.#rootElement);
+    }
+    if (this.#keyboardShortcutsManager) {
+      this.#keyboardShortcutsManager.stop();
+      this.#keyboardShortcutsManager = null;
+    }
+  }
+
+  #restartKeyboardShortcutsManager(): void {
+    if (this.#keyboardShortcutsManager) {
+      this.#keyboardShortcutsManager.stop();
+      this.#keyboardShortcutsManager = null;
+    }
+    // @ts-expect-error Accessing protected member 'eventManager'.
+    const eventManager = this.deck?.eventManager;
+    if (eventManager && this.props.installShortcuts) {
+      this.#keyboardShortcutsManager = new KeyboardShortcutsManager(
+        eventManager,
+        this.#getEffectiveKeyboardShortcuts()
+      );
+      this.#keyboardShortcutsManager.start();
+    }
+  }
+
+  #renderRootElement(): void {
+    if (!this.#rootElement) {
+      return;
+    }
+
+    render(
+      <KeyboardShortcutsWidgetView
+        isOpen={this.#isOpen}
+        keyboardShortcuts={this.#getEffectiveKeyboardShortcuts()}
+        shortcutKeyHTML={
+          this.#keyboardShortcutsManager?.getKeyHTML(this.commandId) ??
+          KeyboardShortcutsManager.getKeyHTML(this.commandId)
+        }
+        onClose={this.#handleClose}
+        onOpen={this.#handleTrigger}
+      />,
+      this.#rootElement
+    );
+  }
+
+  #getEffectiveKeyboardShortcuts(): KeyboardShortcut[] {
+    return [
+      ...DEFAULT_SHORTCUTS.map(shortcut => ({
+        ...shortcut,
+        commandId: this.commandId,
+        onKeyPress: this.#handleOpen
+      })),
+      ...this.#keyboardShortcuts
+    ];
+  }
+
+  #handleOpen = (): void => {
+    if (this.#isOpen) {
+      return;
+    }
+    this.#isOpen = true;
+    this.#renderRootElement();
+  };
+
+  #handleClose = (): void => {
+    if (!this.#isOpen) {
+      return;
+    }
+    this.#isOpen = false;
+    this.#renderRootElement();
+  };
+
+  #handleTrigger = (): void => {
+    commandManager.executeCommand(this.commandId);
+  };
+}
+
+function KeyboardShortcutsWidgetView({
+  isOpen,
+  keyboardShortcuts,
+  shortcutKeyHTML,
+  onClose,
+  onOpen
+}: {
+  isOpen: boolean;
+  keyboardShortcuts: KeyboardShortcut[];
+  shortcutKeyHTML?: string;
+  onClose: () => void;
+  onOpen: () => void;
+}) {
+  return (
+    <>
+      <div className="deck-widget-button">
+        <button
+          className="deck-widget-icon-button"
+          style={{color: 'var(--button-text, currentColor)'}}
+          type="button"
+          title={getWidgetTooltipTitle('Keyboard shortcuts', shortcutKeyHTML)}
+          aria-label="Keyboard shortcuts"
+          onClick={onOpen}
+        >
+          <span style={{fontSize: '12px', fontWeight: 700, color: ICON_COLOR}}>
+            <kbd style={{color: ICON_COLOR}}>?</kbd>
+          </span>
+        </button>
+      </div>
+
+      {isOpen && (
+        <div style={MODAL_BACKDROP_STYLE} onClick={onClose}>
+          <div
+            style={MODAL_STYLE}
+            role="dialog"
+            aria-label="Keyboard Shortcuts"
+            onClick={event => event.stopPropagation()}
+          >
+            <div style={MODAL_HEADER_STYLE}>
+              <div style={MODAL_TITLE_STYLE}>Keyboard Shortcuts</div>
+              <button
+                type="button"
+                onClick={onClose}
+                style={MODAL_CLOSE_BUTTON_STYLE}
+                aria-label="Close keyboard shortcuts"
+                title="Close"
+              >
+                ×
+              </button>
+            </div>
+            <KeyboardShortcutsPanelContent keyboardShortcuts={keyboardShortcuts} />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function getWidgetTooltipTitle(label: string, shortcutKeyHTML?: string): string {
+  return shortcutKeyHTML ? `${label} (${shortcutKeyHTML})` : label;
+}
+
+const MODAL_BACKDROP_STYLE: JSX.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  display: 'grid',
+  placeItems: 'center',
+  background: 'rgba(15, 23, 42, 0.28)',
+  zIndex: 50
+};
+
+const MODAL_STYLE: JSX.CSSProperties = {
+  width: 'min(720px, calc(100vw - 24px))',
+  maxHeight: 'min(720px, calc(100vh - 24px))',
+  borderRadius: '12px',
+  background: 'rgba(255, 255, 255, 0.96)',
+  boxShadow: '0 14px 40px rgba(15, 23, 42, 0.28)',
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'hidden'
+};
+
+const MODAL_HEADER_STYLE: JSX.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  borderBottom: '1px solid rgba(226, 232, 240, 1)',
+  padding: '10px 12px'
+};
+
+const MODAL_TITLE_STYLE: JSX.CSSProperties = {
+  fontSize: '14px',
+  fontWeight: 700,
+  color: 'rgb(30, 41, 59)'
+};
+
+const MODAL_CLOSE_BUTTON_STYLE: JSX.CSSProperties = {
+  border: 0,
+  background: 'transparent',
+  color: 'rgb(71, 85, 105)',
+  cursor: 'pointer',
+  fontSize: '18px',
+  lineHeight: '18px'
+};
+
+const ICON_COLOR = 'var(--button-icon-idle, var(--button-text, currentColor))';

--- a/modules/widgets/src/widgets/settings-widget.test.tsx
+++ b/modules/widgets/src/widgets/settings-widget.test.tsx
@@ -1,0 +1,261 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {SettingsWidget} from './settings-widget';
+
+import type {SettingsSchema, SettingsState} from '@deck.gl-community/panels';
+
+const TEST_SCHEMA: SettingsSchema = {
+  title: 'Test settings',
+  sections: [
+    {
+      id: 'visibility',
+      name: 'Visibility',
+      settings: [
+        {
+          name: 'flags.enabled',
+          label: 'Enabled',
+          type: 'boolean',
+          description: 'Enable rendering for this layer.'
+        },
+        {
+          name: 'render.opacity',
+          label: 'Opacity',
+          type: 'number',
+          min: 0,
+          max: 1,
+          step: 0.1,
+          description: 'Adjust alpha for rendered paths.'
+        }
+      ]
+    },
+    {
+      id: 'mode',
+      name: 'Mode',
+      settings: [
+        {
+          name: 'mode',
+          label: 'Mode',
+          type: 'select',
+          options: ['all', 'critical-path', 'selected-only'],
+          description: 'Control which traces remain visible.'
+        },
+        {
+          name: 'streams',
+          label: 'Streams',
+          type: 'multi-select',
+          options: ['worker-1', 'worker-2'],
+          description: 'Choose visible streams.'
+        }
+      ]
+    }
+  ]
+};
+
+const INITIAL_SETTINGS: SettingsState = {
+  flags: {enabled: true},
+  render: {opacity: 0.4},
+  mode: 'all',
+  streams: []
+};
+
+function renderWidget(options?: {
+  settings?: SettingsState;
+  onSettingsChange?: (settings: SettingsState) => void;
+}) {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+
+  const widget = new SettingsWidget({
+    label: 'Visualization settings',
+    schema: TEST_SCHEMA,
+    settings: options?.settings ?? INITIAL_SETTINGS,
+    onSettingsChange: options?.onSettingsChange
+  });
+
+  widget.onRenderHTML(root);
+
+  return {
+    root,
+    widget,
+    cleanup() {
+      widget.onRemove();
+      root.remove();
+    }
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('SettingsWidget', () => {
+  it('opens and closes the settings pane and toggles section collapse state', async () => {
+    const {root, cleanup} = renderWidget();
+
+    const openButton = root.querySelector('button[title="Visualization settings"]');
+    expect(openButton).toBeTruthy();
+
+    (openButton as HTMLButtonElement).click();
+    await Promise.resolve();
+
+    const dialog = root.querySelector('[role="dialog"]');
+    expect(dialog).toBeTruthy();
+
+    expect(root.textContent).not.toContain('Enable rendering for this layer.');
+    expect(root.querySelector('[data-setting-info-for]')).toBeNull();
+
+    const sectionToggles = root.querySelectorAll('button[aria-expanded]');
+    expect(sectionToggles.length).toBe(2);
+
+    const visibilityToggle = sectionToggles[0] as HTMLButtonElement;
+    const modeToggle = sectionToggles[1] as HTMLButtonElement;
+
+    expect(visibilityToggle.getAttribute('aria-expanded')).toBe('false');
+    expect(modeToggle.getAttribute('aria-expanded')).toBe('false');
+
+    visibilityToggle.click();
+    await Promise.resolve();
+    expect(visibilityToggle.getAttribute('aria-expanded')).toBe('true');
+
+    const enabledSettingRow = root.querySelector('[data-setting-row-for="flags.enabled"]') as
+      | HTMLElement
+      | undefined;
+    expect(enabledSettingRow).toBeTruthy();
+    expect(enabledSettingRow?.getAttribute('title')).toBe('Enable rendering for this layer.');
+
+    modeToggle.click();
+    await Promise.resolve();
+    expect(modeToggle.getAttribute('aria-expanded')).toBe('true');
+
+    const modeSettingRow = root.querySelector('[data-setting-row-for="mode"]') as
+      | HTMLElement
+      | undefined;
+    expect(modeSettingRow?.getAttribute('title')).toBe('Control which traces remain visible.');
+
+    document.body.dispatchEvent(new Event('pointerdown', {bubbles: true}));
+    await Promise.resolve();
+    expect(root.querySelector('[role="dialog"]')).toBeNull();
+
+    cleanup();
+  });
+
+  it('emits updated settings for nested boolean, clamped numeric, and select values', async () => {
+    const handleSettingsChange = vi.fn<(settings: SettingsState) => void>();
+    const {root, cleanup} = renderWidget({onSettingsChange: handleSettingsChange});
+
+    (root.querySelector('button[title="Visualization settings"]') as HTMLButtonElement).click();
+    await Promise.resolve();
+
+    const sectionToggles = root.querySelectorAll('button[aria-expanded]');
+    const visibilityToggle = sectionToggles[0] as HTMLButtonElement;
+    const modeToggle = sectionToggles[1] as HTMLButtonElement;
+
+    visibilityToggle.click();
+    await Promise.resolve();
+
+    const checkbox = root.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event('input', {bubbles: true}));
+    await Promise.resolve();
+
+    expect(handleSettingsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flags: expect.objectContaining({enabled: false})
+      })
+    );
+
+    const numberInput = root.querySelector('input[type="number"]') as HTMLInputElement;
+    numberInput.value = '2';
+    numberInput.dispatchEvent(new Event('input', {bubbles: true}));
+    await Promise.resolve();
+
+    expect(handleSettingsChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        render: expect.objectContaining({opacity: 1})
+      })
+    );
+
+    modeToggle.click();
+    await Promise.resolve();
+
+    const select = root.querySelector('select') as HTMLSelectElement;
+    select.value = 'critical-path';
+    select.dispatchEvent(new Event('change', {bubbles: true}));
+    await Promise.resolve();
+
+    expect(handleSettingsChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        mode: 'critical-path'
+      })
+    );
+
+    const streamCheckbox = Array.from(
+      root.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')
+    ).find(candidate => candidate.getAttribute('aria-label') === 'worker-2');
+    expect(streamCheckbox).toBeTruthy();
+    (streamCheckbox as HTMLInputElement).checked = true;
+    streamCheckbox?.dispatchEvent(new Event('change', {bubbles: true}));
+    await Promise.resolve();
+
+    expect(handleSettingsChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        streams: ['worker-2']
+      })
+    );
+
+    cleanup();
+  });
+
+  it('emits one multi-select update when checkbox input and change both fire', async () => {
+    const handleSettingsChange = vi.fn<(settings: SettingsState) => void>();
+    const {root, cleanup} = renderWidget({onSettingsChange: handleSettingsChange});
+
+    (root.querySelector('button[title="Visualization settings"]') as HTMLButtonElement).click();
+    await Promise.resolve();
+
+    const modeToggle = root.querySelectorAll('button[aria-expanded]')[1] as HTMLButtonElement;
+    modeToggle.click();
+    await Promise.resolve();
+
+    const streamCheckbox = Array.from(
+      root.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')
+    ).find(candidate => candidate.getAttribute('aria-label') === 'worker-2');
+    expect(streamCheckbox).toBeTruthy();
+    (streamCheckbox as HTMLInputElement).checked = true;
+    streamCheckbox?.dispatchEvent(new Event('input', {bubbles: true}));
+    streamCheckbox?.dispatchEvent(new Event('change', {bubbles: true}));
+    await Promise.resolve();
+
+    expect(handleSettingsChange).toHaveBeenCalledTimes(1);
+    expect(handleSettingsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        streams: ['worker-2']
+      })
+    );
+
+    cleanup();
+  });
+
+  it('uses deck widget theme CSS variables for the settings panel and controls', async () => {
+    const {root, cleanup} = renderWidget();
+
+    (root.querySelector('button[title="Visualization settings"]') as HTMLButtonElement).click();
+    await Promise.resolve();
+
+    const dialog = root.querySelector('[role="dialog"]') as HTMLDivElement;
+    expect(dialog.getAttribute('style')).toContain('var(--menu-backdrop-filter');
+    expect(dialog.getAttribute('style')).toContain('var(--menu-shadow');
+
+    const sectionToggle = root.querySelector('button[aria-expanded]') as HTMLButtonElement;
+    sectionToggle.click();
+    await Promise.resolve();
+
+    const numberInput = root.querySelector('input[type="number"]') as HTMLInputElement;
+    expect(numberInput.getAttribute('style')).toContain('var(--button-backdrop-filter');
+    expect(numberInput.getAttribute('style')).toContain('height: 28px');
+    expect(numberInput.getAttribute('style')).toContain('padding: 2px 6px');
+
+    cleanup();
+  });
+});

--- a/modules/widgets/src/widgets/settings-widget.tsx
+++ b/modules/widgets/src/widgets/settings-widget.tsx
@@ -1,0 +1,784 @@
+/** @jsxImportSource preact */
+import {Widget} from '@deck.gl/core';
+import {render} from 'preact';
+import {useEffect, useMemo, useRef, useState} from 'preact/hooks';
+
+import {
+  buildInitialCollapsedState,
+  clamp,
+  getSectionKey,
+  mergeCollapsedState,
+  normalizeOption,
+  resolveSettingValue,
+  setValueAtPath
+} from '@deck.gl-community/panels';
+import {IconButton, makeTextIcon} from '@deck.gl-community/panels';
+
+import type {
+  SettingDescriptor,
+  SettingsSchema,
+  SettingsState,
+  SettingValue
+} from '@deck.gl-community/panels';
+import type {SettingsChangeDescriptor} from '@deck.gl-community/panels';
+import type {WidgetPlacement, WidgetProps} from '@deck.gl/core';
+import type {JSX} from 'preact';
+
+export type SettingsWidgetProps = WidgetProps & {
+  placement?: WidgetPlacement;
+  label?: string;
+  schema?: SettingsSchema;
+  settings?: SettingsState;
+  onSettingsChange?: (
+    settings: SettingsState,
+    changedSettings?: SettingsChangeDescriptor[]
+  ) => void;
+};
+
+const PANE_STYLE: JSX.CSSProperties = {
+  position: 'absolute',
+  top: 'calc(100% + var(--menu-gap, 4px))',
+  left: 0,
+  width: '380px',
+  maxHeight: 'min(460px, calc(100vh - 60px))',
+  borderRadius: 'var(--button-corner-radius, 8px)',
+  border: 'var(--menu-border, 1px solid rgba(128, 128, 128, 0.3))',
+  background: 'var(--menu-background, #fff)',
+  backdropFilter: 'var(--menu-backdrop-filter, unset)',
+  color: 'var(--menu-text, rgb(24, 24, 26))',
+  boxShadow: 'var(--menu-shadow, 0px 0px 8px 0px rgba(0, 0, 0, 0.25))',
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'hidden',
+  pointerEvents: 'auto',
+  zIndex: 20
+};
+
+const HEADER_STYLE: JSX.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  borderBottom: '1px solid var(--menu-item-hover, rgba(128, 128, 128, 0.22))',
+  padding: '10px 12px'
+};
+
+const SECTION_TOGGLE_STYLE: JSX.CSSProperties = {
+  width: '100%',
+  border: 0,
+  margin: 0,
+  padding: '8px 12px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '8px',
+  background: 'transparent',
+  color: 'inherit',
+  cursor: 'pointer',
+  fontSize: '12px'
+};
+
+const SECTION_CONTENT_STYLE: JSX.CSSProperties = {
+  display: 'grid',
+  gap: '8px',
+  padding: '8px 12px 12px 18px'
+};
+
+const SETTING_ROW_STYLE: JSX.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'minmax(120px, 1fr) minmax(200px, 1.4fr)',
+  alignItems: 'center',
+  gap: '8px'
+};
+
+const SETTING_LABEL_STYLE: JSX.CSSProperties = {
+  fontSize: '12px',
+  fontWeight: 600,
+  color: 'var(--button-text, currentColor)',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis'
+};
+
+const SETTING_CONTROL_STYLE: JSX.CSSProperties = {
+  minWidth: 0,
+  display: 'flex',
+  alignItems: 'center'
+};
+
+const INPUT_STYLE: JSX.CSSProperties = {
+  width: '100%',
+  border: 'var(--button-inner-stroke, 1px solid rgba(128, 128, 128, 0.35))',
+  borderRadius: 'calc(var(--button-corner-radius, 8px) - 2px)',
+  backgroundColor: 'var(--button-background, #fff)',
+  backdropFilter: 'var(--button-backdrop-filter, unset)',
+  color: 'var(--button-text, currentColor)',
+  fontSize: '12px',
+  padding: '4px 6px',
+  boxSizing: 'border-box'
+};
+
+const STRING_CONTROL_STYLE: JSX.CSSProperties = {
+  ...INPUT_STYLE,
+  flex: 1
+};
+
+const STRING_APPLY_BUTTON_STYLE: JSX.CSSProperties = {
+  border: 'var(--button-inner-stroke, 1px solid rgba(128, 128, 128, 0.35))',
+  borderRadius: 'calc(var(--button-corner-radius, 8px) - 2px)',
+  backgroundColor: 'var(--button-background, #fff)',
+  color: 'var(--button-text, currentColor)',
+  fontSize: '11px',
+  padding: '4px 8px',
+  cursor: 'pointer',
+  whiteSpace: 'nowrap'
+};
+
+const RANGE_INPUT_STYLE: JSX.CSSProperties = {
+  width: '100%',
+  minWidth: '120px',
+  margin: 0
+};
+
+const NUMBER_INPUT_STYLE: JSX.CSSProperties = {
+  ...INPUT_STYLE,
+  width: '84px',
+  flexShrink: 0,
+  height: '28px',
+  lineHeight: '16px',
+  padding: '2px 6px'
+};
+
+const CHECKBOX_STYLE: JSX.CSSProperties = {
+  width: '14px',
+  height: '14px',
+  margin: 0,
+  accentColor: 'var(--button-icon-hover, currentColor)'
+};
+
+const MULTI_SELECT_LIST_STYLE: JSX.CSSProperties = {
+  width: '100%',
+  maxHeight: '120px',
+  overflow: 'auto',
+  display: 'grid',
+  gap: '4px',
+  border: 'var(--button-inner-stroke, 1px solid rgba(128, 128, 128, 0.35))',
+  borderRadius: 'calc(var(--button-corner-radius, 8px) - 2px)',
+  backgroundColor: 'var(--button-background, #fff)',
+  padding: '4px',
+  boxSizing: 'border-box'
+};
+
+const MULTI_SELECT_OPTION_STYLE: JSX.CSSProperties = {
+  minWidth: 0,
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+  color: 'var(--button-text, currentColor)',
+  fontSize: '12px'
+};
+
+const MULTI_SELECT_OPTION_LABEL_STYLE: JSX.CSSProperties = {
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap'
+};
+
+const MULTI_SELECT_EMPTY_STYLE: JSX.CSSProperties = {
+  color: 'var(--button-text, currentColor)',
+  fontSize: '12px',
+  opacity: 0.68,
+  padding: '2px'
+};
+
+const SETTINGS_BUTTON_ICON = makeTextIcon('⚙', 24, 36);
+
+function stopPropagation(event: Event) {
+  event.stopPropagation();
+}
+
+function stopPropagationForInput(event: Event) {
+  event.stopPropagation();
+  if (
+    typeof (event as {stopImmediatePropagation?: () => void}).stopImmediatePropagation ===
+    'function'
+  ) {
+    (event as {stopImmediatePropagation?: () => void}).stopImmediatePropagation?.();
+  }
+}
+
+type SettingsControlProps = {
+  setting: SettingDescriptor;
+  value: SettingValue;
+  onValueChange: (nextValue: SettingValue) => void;
+};
+
+type StringSettingControlProps = {
+  inputId: string;
+  label: string;
+  value: string;
+  onApply: (nextValue: string) => void;
+};
+
+function StringSettingControl({inputId, label, value, onApply}: StringSettingControlProps) {
+  const [pendingValue, setPendingValue] = useState(value);
+  const [recentValues, setRecentValues] = useState<string[]>(() => (value ? [value] : []));
+
+  const isDirty = pendingValue !== value;
+
+  useEffect(() => {
+    setPendingValue(value);
+  }, [value]);
+
+  useEffect(() => {
+    if (!value) {
+      return;
+    }
+    setRecentValues(previous =>
+      previous.includes(value) ? previous : [value, ...previous].slice(0, 8)
+    );
+  }, [value]);
+
+  const handlePendingTextChange: JSX.GenericEventHandler<HTMLInputElement> = event => {
+    setPendingValue((event.currentTarget as HTMLInputElement).value);
+  };
+
+  const applyPendingText = () => {
+    if (pendingValue === value) {
+      return;
+    }
+    onApply(pendingValue);
+    setRecentValues(previous =>
+      [pendingValue, ...previous.filter(entry => entry !== pendingValue)].slice(0, 8)
+    );
+  };
+
+  const handleTextCommit = (event: KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      applyPendingText();
+    }
+    stopPropagationForInput(event);
+  };
+
+  return (
+    <div style={SETTING_CONTROL_STYLE}>
+      <input
+        id={inputId}
+        type="text"
+        value={pendingValue}
+        onInput={handlePendingTextChange}
+        list={`${inputId}-recent-values`}
+        onKeyDown={handleTextCommit}
+        onKeyUp={stopPropagationForInput}
+        onPointerDown={stopPropagationForInput}
+        aria-label={label}
+        style={STRING_CONTROL_STYLE}
+      />
+      {recentValues.length > 0 && (
+        <datalist id={`${inputId}-recent-values`}>
+          {recentValues.map(recentValue => (
+            <option key={`${inputId}-${recentValue}`} value={recentValue} />
+          ))}
+        </datalist>
+      )}
+      <button
+        type="button"
+        disabled={!isDirty}
+        style={{
+          ...STRING_APPLY_BUTTON_STYLE,
+          opacity: isDirty ? 1 : 0.55,
+          cursor: isDirty ? 'pointer' : 'default',
+          marginLeft: '6px'
+        }}
+        onClick={applyPendingText}
+        onPointerDown={stopPropagationForInput}
+        onKeyDown={stopPropagationForInput}
+        onKeyUp={stopPropagationForInput}
+      >
+        {isDirty ? '✓' : '✅'}
+      </button>
+    </div>
+  );
+}
+
+function SettingsControl({setting, value, onValueChange}: SettingsControlProps) {
+  const label = setting.label ?? setting.name;
+  const tooltip = setting.description?.trim();
+  const inputId = `settings-widget-input-${setting.name.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
+
+  const handleBooleanChange: JSX.GenericEventHandler<HTMLInputElement> = event => {
+    onValueChange((event.currentTarget as HTMLInputElement).checked);
+  };
+
+  const handleNumberChange = (nextValue: number) => {
+    if (!Number.isFinite(nextValue)) {
+      return;
+    }
+    onValueChange(clamp(nextValue, setting.min, setting.max));
+  };
+
+  const handleSelectChange: JSX.GenericEventHandler<HTMLSelectElement> = event => {
+    const selectedRaw = (event.currentTarget as HTMLSelectElement).value;
+    const selectedValue = (setting.options ?? []).map(normalizeOption).find(option => {
+      return String(option.value) === selectedRaw;
+    });
+    onValueChange(selectedValue ? selectedValue.value : selectedRaw);
+  };
+
+  let control: JSX.Element;
+
+  if (setting.type === 'boolean') {
+    control = (
+      <input
+        id={inputId}
+        type="checkbox"
+        checked={Boolean(value)}
+        onInput={handleBooleanChange}
+        onChange={handleBooleanChange}
+        aria-label={label}
+        style={CHECKBOX_STYLE}
+      />
+    );
+  } else if (setting.type === 'number') {
+    const numericValue = Number(value);
+    const showRange = Number.isFinite(setting.min) && Number.isFinite(setting.max);
+
+    control = showRange ? (
+      <div style={{display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0, width: '100%'}}>
+        <input
+          id={inputId}
+          type="range"
+          min={String(setting.min)}
+          max={String(setting.max)}
+          step={String(setting.step ?? 1)}
+          value={String(numericValue)}
+          onInput={event =>
+            handleNumberChange(Number((event.currentTarget as HTMLInputElement).value))
+          }
+          onChange={event =>
+            handleNumberChange(Number((event.currentTarget as HTMLInputElement).value))
+          }
+          aria-label={label}
+          style={RANGE_INPUT_STYLE}
+        />
+        <input
+          type="number"
+          min={Number.isFinite(setting.min) ? String(setting.min) : undefined}
+          max={Number.isFinite(setting.max) ? String(setting.max) : undefined}
+          step={String(setting.step ?? 1)}
+          value={String(numericValue)}
+          onInput={event =>
+            handleNumberChange(Number((event.currentTarget as HTMLInputElement).value))
+          }
+          onChange={event =>
+            handleNumberChange(Number((event.currentTarget as HTMLInputElement).value))
+          }
+          aria-label={`${label} numeric value`}
+          style={NUMBER_INPUT_STYLE}
+        />
+      </div>
+    ) : (
+      <input
+        id={inputId}
+        type="number"
+        step={String(setting.step ?? 1)}
+        value={String(numericValue)}
+        onInput={event =>
+          handleNumberChange(Number((event.currentTarget as HTMLInputElement).value))
+        }
+        onChange={event =>
+          handleNumberChange(Number((event.currentTarget as HTMLInputElement).value))
+        }
+        aria-label={label}
+        style={INPUT_STYLE}
+      />
+    );
+  } else if (setting.type === 'select') {
+    const normalizedOptions = (setting.options ?? []).map(normalizeOption);
+
+    control = (
+      <select
+        id={inputId}
+        value={String(value)}
+        onInput={handleSelectChange}
+        onChange={handleSelectChange}
+        onPointerDown={stopPropagationForInput}
+        onKeyDown={stopPropagationForInput}
+        onKeyUp={stopPropagationForInput}
+        aria-label={label}
+        style={INPUT_STYLE}
+      >
+        {normalizedOptions.map((option, index) => (
+          <option
+            key={`${setting.name}-${index}-${String(option.value)}`}
+            value={String(option.value)}
+          >
+            {option.label}
+          </option>
+        ))}
+      </select>
+    );
+  } else if (setting.type === 'multi-select') {
+    const selectedValues = Array.isArray(value)
+      ? value.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0)
+      : [];
+    const selectedValueSet = new Set(selectedValues);
+    const optionValues = new Set<string>();
+    const normalizedOptions = [
+      ...(setting.options ?? []).map(option => {
+        const normalized = normalizeOption(option);
+        const optionValue = String(normalized.value);
+        optionValues.add(optionValue);
+        return {
+          label: normalized.label,
+          value: optionValue
+        };
+      }),
+      ...selectedValues
+        .filter(selectedValue => !optionValues.has(selectedValue))
+        .map(selectedValue => ({
+          label: selectedValue,
+          value: selectedValue
+        }))
+    ];
+
+    control = (
+      <div style={MULTI_SELECT_LIST_STYLE}>
+        {normalizedOptions.map(option => {
+          const checked = selectedValueSet.has(option.value);
+          return (
+            <label
+              key={`${setting.name}-${option.value}`}
+              style={MULTI_SELECT_OPTION_STYLE}
+              title={option.label}
+            >
+              <input
+                type="checkbox"
+                checked={checked}
+                onChange={event => {
+                  const nextChecked = (event.currentTarget as HTMLInputElement).checked;
+                  onValueChange(
+                    nextChecked
+                      ? [...selectedValues, option.value]
+                      : selectedValues.filter(selectedValue => selectedValue !== option.value)
+                  );
+                }}
+                onPointerDown={stopPropagationForInput}
+                onKeyDown={stopPropagationForInput}
+                onKeyUp={stopPropagationForInput}
+                aria-label={option.label}
+                style={CHECKBOX_STYLE}
+              />
+              <span style={MULTI_SELECT_OPTION_LABEL_STYLE}>{option.label}</span>
+            </label>
+          );
+        })}
+        {normalizedOptions.length === 0 ? (
+          <div style={MULTI_SELECT_EMPTY_STYLE}>No options</div>
+        ) : null}
+      </div>
+    );
+  } else {
+    control = (
+      <StringSettingControl
+        inputId={inputId}
+        label={label}
+        value={String(value)}
+        onApply={onValueChange}
+      />
+    );
+  }
+
+  return (
+    <div data-setting-row-for={setting.name} style={SETTING_ROW_STYLE} title={tooltip}>
+      <label htmlFor={inputId} style={SETTING_LABEL_STYLE}>
+        {label}
+      </label>
+      <div style={SETTING_CONTROL_STYLE}>{control}</div>
+    </div>
+  );
+}
+
+type SettingsWidgetViewProps = {
+  label: string;
+  schema: SettingsSchema;
+  settings: SettingsState;
+  onSettingsChange?: (
+    settings: SettingsState,
+    changedSettings?: SettingsChangeDescriptor[]
+  ) => void;
+};
+
+const DEFAULT_SETTINGS_WIDGET_SCHEMA: SettingsSchema = {sections: []};
+const DEFAULT_SETTINGS_WIDGET_STATE: SettingsState = {};
+
+function SettingsWidgetView({label, schema, settings, onSettingsChange}: SettingsWidgetViewProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [isPaneOpen, setIsPaneOpen] = useState(false);
+  const [localSettings, setLocalSettings] = useState<SettingsState>(settings);
+  const [collapsedState, setCollapsedState] = useState<Record<string, boolean>>(() =>
+    buildInitialCollapsedState(schema.sections)
+  );
+
+  useEffect(() => {
+    setLocalSettings(settings);
+  }, [settings]);
+
+  useEffect(() => {
+    setCollapsedState(previous => mergeCollapsedState(previous, schema.sections));
+  }, [schema.sections]);
+
+  useEffect(() => {
+    if (!isPaneOpen || typeof document === 'undefined') {
+      return;
+    }
+
+    const handleDocumentPointerDown = (event: PointerEvent) => {
+      const container = containerRef.current;
+      const target = event.target;
+
+      if (!container || !target) {
+        return;
+      }
+
+      if (container.contains(target as Node)) {
+        return;
+      }
+
+      const activeElement = document.activeElement;
+      const activeElementInPanel =
+        activeElement instanceof Element ? container.contains(activeElement) : false;
+      const targetIsSelectOption =
+        target instanceof Element && target.tagName.toUpperCase() === 'OPTION';
+
+      if (activeElementInPanel && targetIsSelectOption) {
+        return;
+      }
+
+      if (!container.contains(target as Node)) {
+        setIsPaneOpen(false);
+      }
+    };
+
+    document.addEventListener('pointerdown', handleDocumentPointerDown);
+    return () => {
+      document.removeEventListener('pointerdown', handleDocumentPointerDown);
+    };
+  }, [isPaneOpen]);
+
+  const sectionEntries = useMemo(
+    () =>
+      schema.sections.map((section, index) => ({
+        key: getSectionKey(section, index),
+        section
+      })),
+    [schema.sections]
+  );
+
+  const updateSetting = (path: string, nextValue: SettingValue) => {
+    setLocalSettings(previous => {
+      const nextSettings = setValueAtPath(previous, path, nextValue);
+      onSettingsChange?.(nextSettings);
+      return nextSettings;
+    });
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      style={{position: 'relative', pointerEvents: 'auto'}}
+      onPointerDown={event => stopPropagation(event as unknown as Event)}
+      onMouseDown={event => stopPropagation(event as unknown as Event)}
+      onPointerMove={event => stopPropagation(event as unknown as Event)}
+      onMouseMove={event => stopPropagation(event as unknown as Event)}
+      onWheel={event => stopPropagation(event as unknown as Event)}
+    >
+      <IconButton
+        icon={SETTINGS_BUTTON_ICON}
+        title={label}
+        className={isPaneOpen ? 'deck-widget-button-active' : ''}
+        onClick={() => setIsPaneOpen(previous => !previous)}
+      />
+
+      {isPaneOpen && (
+        <div
+          role="dialog"
+          aria-label={schema.title ?? label}
+          style={PANE_STYLE}
+          onPointerMove={event => stopPropagation(event as unknown as Event)}
+          onMouseMove={event => stopPropagation(event as unknown as Event)}
+          onPointerDown={event => stopPropagation(event as unknown as Event)}
+          onMouseDown={event => stopPropagation(event as unknown as Event)}
+          onWheel={event => stopPropagation(event as unknown as Event)}
+          onClick={event => stopPropagation(event as unknown as Event)}
+        >
+          <div style={HEADER_STYLE}>
+            <div style={{fontSize: '13px', fontWeight: 700}}>{schema.title ?? label}</div>
+            <button
+              type="button"
+              onClick={() => setIsPaneOpen(false)}
+              style={{
+                border: 'var(--button-inner-stroke, 1px solid rgba(128, 128, 128, 0.35))',
+                borderRadius: 'calc(var(--button-corner-radius, 8px) - 2px)',
+                padding: '2px 6px',
+                background: 'var(--button-background, transparent)',
+                color: 'var(--button-icon-idle, currentColor)',
+                cursor: 'pointer',
+                fontSize: '14px',
+                lineHeight: 1
+              }}
+              title="Close settings"
+              aria-label="Close settings"
+            >
+              ×
+            </button>
+          </div>
+
+          <div style={{overflowY: 'auto', paddingBottom: '8px'}}>
+            {sectionEntries.map(({key, section}) => {
+              const isCollapsed = collapsedState[key] ?? false;
+              return (
+                <div
+                  key={key}
+                  style={{
+                    borderBottom: '1px solid var(--menu-item-hover, rgba(128, 128, 128, 0.22))'
+                  }}
+                >
+                  <button
+                    type="button"
+                    style={SECTION_TOGGLE_STYLE}
+                    onClick={() =>
+                      setCollapsedState(previous => ({
+                        ...previous,
+                        [key]: !isCollapsed
+                      }))
+                    }
+                    aria-expanded={!isCollapsed}
+                  >
+                    <span style={{display: 'grid', gap: '2px', textAlign: 'left'}}>
+                      <span style={{fontWeight: 700, fontSize: '12px'}}>{section.name}</span>
+                      {section.description && (
+                        <span
+                          style={{
+                            fontSize: '11px',
+                            color: 'var(--button-icon-idle, currentColor)'
+                          }}
+                        >
+                          {section.description}
+                        </span>
+                      )}
+                    </span>
+                    <span aria-hidden>{isCollapsed ? '▸' : '▾'}</span>
+                  </button>
+
+                  {!isCollapsed && (
+                    <div style={SECTION_CONTENT_STYLE}>
+                      {section.settings.map(setting => (
+                        <SettingsControl
+                          key={setting.name}
+                          setting={setting}
+                          value={resolveSettingValue(setting, localSettings)}
+                          onValueChange={nextValue => updateSetting(setting.name, nextValue)}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export class SettingsWidget extends Widget<SettingsWidgetProps> {
+  static override defaultProps = {
+    ...Widget.defaultProps,
+    id: 'settings',
+    placement: 'top-left',
+    label: 'Settings',
+    schema: DEFAULT_SETTINGS_WIDGET_SCHEMA,
+    settings: DEFAULT_SETTINGS_WIDGET_STATE,
+    onSettingsChange: undefined
+  } satisfies Required<WidgetProps> &
+    Required<Pick<SettingsWidgetProps, 'placement' | 'label' | 'schema' | 'settings'>> &
+    SettingsWidgetProps;
+
+  className = 'deck-widget-settings';
+  placement: WidgetPlacement = SettingsWidget.defaultProps.placement;
+
+  #label = SettingsWidget.defaultProps.label;
+  #schema = SettingsWidget.defaultProps.schema;
+  #settings = SettingsWidget.defaultProps.settings;
+  #onSettingsChange: SettingsWidgetProps['onSettingsChange'] =
+    SettingsWidget.defaultProps.onSettingsChange;
+  #rootElement: HTMLElement | null = null;
+
+  constructor(props: SettingsWidgetProps = {}) {
+    super({...SettingsWidget.defaultProps, ...props});
+
+    if (props.placement !== undefined) {
+      this.placement = props.placement;
+    }
+    if (props.label !== undefined) {
+      this.#label = props.label;
+    }
+    if (props.schema !== undefined) {
+      this.#schema = props.schema;
+    }
+    if (props.settings !== undefined) {
+      this.#settings = props.settings;
+    }
+    if (props.onSettingsChange !== undefined) {
+      this.#onSettingsChange = props.onSettingsChange;
+    }
+  }
+
+  override setProps(props: Partial<SettingsWidgetProps>): void {
+    if (props.placement !== undefined) {
+      this.placement = props.placement;
+    }
+    if (props.label !== undefined) {
+      this.#label = props.label;
+    }
+    if (props.schema !== undefined) {
+      this.#schema = props.schema;
+    }
+    if (props.settings !== undefined) {
+      this.#settings = props.settings;
+    }
+    if (props.onSettingsChange !== undefined) {
+      this.#onSettingsChange = props.onSettingsChange;
+    }
+    super.setProps(props);
+  }
+
+  override onRenderHTML(rootElement: HTMLElement): void {
+    this.#rootElement = rootElement;
+
+    const className = ['deck-widget', this.className, this.props.className]
+      .filter(Boolean)
+      .join(' ');
+
+    rootElement.className = className;
+
+    render(
+      <SettingsWidgetView
+        label={this.#label}
+        schema={this.#schema}
+        settings={this.#settings}
+        onSettingsChange={this.#onSettingsChange}
+      />,
+      rootElement
+    );
+  }
+
+  override onRemove(): void {
+    if (this.#rootElement) {
+      render(null, this.#rootElement);
+    }
+  }
+}

--- a/modules/widgets/src/widgets/time-measure-widget.tsx
+++ b/modules/widgets/src/widgets/time-measure-widget.tsx
@@ -2,7 +2,7 @@
 import {Deck, Widget} from '@deck.gl/core';
 import {render} from 'preact';
 
-import {IconButton, makeTextIcon} from '../preact/icon-button';
+import {IconButton, makeTextIcon, WidgetTooltip} from '@deck.gl-community/panels';
 
 import type {PickingInfo, Viewport, WidgetPlacement, WidgetProps} from '@deck.gl/core';
 import type {
@@ -12,30 +12,55 @@ import type {
   MjolnirPointerEvent
 } from 'mjolnir.js';
 
-export type TimeMeasureRange = {startTimeMs: number; endTimeMs: number};
+/** Absolute time range selected by the time-measure widget. */
+export type TimeMeasureRange = {
+  /** Start timestamp of the measured range in milliseconds. */
+  startTimeMs: number;
+  /** End timestamp of the measured range in milliseconds. */
+  endTimeMs: number;
+};
 
-type TimeMeasureWidgetProps = WidgetProps & {
+/** Props accepted by {@link TimeMeasureWidget}. */
+export type TimeMeasureWidgetProps = WidgetProps & {
+  /** Widget placement within the deck widget layout. */
   placement?: WidgetPlacement;
+  /** Deck view id that owns the widget root. */
   viewId?: string | null;
   /** View to listen to for interactions. Defaults to 'main'. */
   eventViewId?: string | string[] | null;
   /** View to use for projecting pointer -> time. Defaults to event view. */
   projectionViewId?: string | null;
+  /** Trigger label shown while no range is selected. */
   label?: string;
+  /** Trigger label shown after a range has been selected. */
   activeLabel?: string;
+  /** Optional command id metadata used by external command wiring. */
+  commandId?: string;
+  /** Optional caller-owned HTML renderer for the trigger tooltip. */
+  renderTooltipHTML?: ({widget}: {widget: TimeMeasureWidget}) => HTMLElement | string;
+  /** Called when time-range selection starts. */
   onActivate?: () => void;
+  /** Called when time-range selection completes or is cleared. */
   onDeactivate?: () => void;
+  /** Called when the completed measured range changes. */
   onRangeChange?: (range: TimeMeasureRange | null) => void;
+  /** Called when any time-measure interaction state changes. */
   onSelectionChange?: (selection: TimeMeasureSelectionState) => void;
 };
 
+/** Current time-measure interaction state. */
 export type TimeMeasureSelectionState = {
+  /** Current interaction phase for range selection. */
   phase: 'idle' | 'selecting-start' | 'selecting-end' | 'selected';
+  /** Time under the cursor while the widget is active. */
   cursorTimeMs: number | null;
+  /** Provisional start timestamp while selecting a range. */
   draftStartTimeMs: number | null;
+  /** Completed selected time range, or null when none is selected. */
   range: TimeMeasureRange | null;
 };
 
+/** Deck widget that lets users measure a time range by interacting with a trace view. */
 export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
   static defaultProps: Required<TimeMeasureWidgetProps> = {
     ...Widget.defaultProps,
@@ -46,6 +71,8 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     projectionViewId: 'main',
     label: 'Measure time',
     activeLabel: 'Time range selected',
+    commandId: 'time-measure.toggle',
+    renderTooltipHTML: undefined!,
     onActivate: undefined!,
     onDeactivate: undefined!,
     onRangeChange: undefined!,
@@ -69,17 +96,27 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
   #projectionViewId: string | null = null;
   #eventManager?: EventManager | null;
   #dragSelecting = false;
+  /** Command id registered for toggling the measure-time interaction. */
+  commandId = TimeMeasureWidget.defaultProps.commandId;
 
+  /** Creates a time-measure widget. */
   constructor(props: TimeMeasureWidgetProps = {}) {
     super(props);
     this.setProps(this.props);
   }
 
+  /** Performs the measure-time trigger action for external command wiring. */
+  static performAction({widget}: {widget: TimeMeasureWidget}): void {
+    widget.#handleWidgetCommand();
+  }
+
+  /** Updates time-measure widget props. */
   setProps(props: Partial<TimeMeasureWidgetProps>): void {
     this.placement = props.placement ?? this.placement;
     this.viewId = props.viewId ?? this.viewId;
     this.#eventViewId = props.eventViewId ?? this.#eventViewId;
     this.#projectionViewId = props.projectionViewId ?? this.#projectionViewId;
+    this.commandId = props.commandId ?? this.commandId;
     super.setProps(props);
   }
 
@@ -89,7 +126,7 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     }
     // @ts-expect-error accessing protected member
     // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-    const eventManager = deck?.eventManager;
+    const eventManager = deck?.eventManager!;
     this.#attachEventListeners(eventManager);
     return this.onCreateRootElement();
   }
@@ -100,14 +137,17 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
 
   onRenderHTML(rootElement: HTMLElement): void {
     const appearance = this.#getAppearance();
+    const tooltipHTML = this.props.renderTooltipHTML?.({widget: this});
     render(
-      <IconButton
-        icon={appearance.icon}
-        color={appearance.color}
-        title={appearance.title}
-        className={appearance.isActive ? 'deck-widget-button-active' : ''}
-        onClick={() => this.#handleWidgetClick()}
-      />,
+      <WidgetTooltip label={appearance.title} html={tooltipHTML} placement="right">
+        <IconButton
+          icon={appearance.icon}
+          color={appearance.color}
+          ariaLabel={appearance.title}
+          className={appearance.isActive ? 'deck-widget-button-active' : ''}
+          onClick={() => TimeMeasureWidget.performAction({widget: this})}
+        />
+      </WidgetTooltip>,
       rootElement
     );
   }
@@ -124,7 +164,6 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     this.#emitSelectionChange();
   }
 
-  // eslint-disable-next-line complexity
   onClick(info: PickingInfo, event: MjolnirGestureEvent): void {
     if (this.#dragSelecting) {
       return;
@@ -219,7 +258,14 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
   }
 
   #handleKeyDown = (event: MjolnirKeyEvent) => {
-    if (event.srcEvent.key === 'Shift' && this.#phase === 'selected' && this.#timeMeasureRange) {
+    if (
+      event.srcEvent.key === 'Shift' &&
+      !event.srcEvent.metaKey &&
+      !event.srcEvent.ctrlKey &&
+      !event.srcEvent.altKey &&
+      this.#phase === 'selected' &&
+      this.#timeMeasureRange
+    ) {
       this.#cancelSelection();
       return;
     }
@@ -312,7 +358,6 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     return viewportId === eventViewId;
   }
 
-  // eslint-disable-next-line complexity
   #eventToTimeMs(
     info: PickingInfo,
     event: MjolnirGestureEvent | MjolnirPointerEvent
@@ -323,7 +368,7 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     }
     if (info.coordinate && Number.isFinite(info.coordinate[0])) {
       if (!projectionViewport.id || info.viewport?.id === projectionViewport.id) {
-        return info.coordinate[0];
+        return info.coordinate[0] as number;
       }
     }
     const center = (event as any).offsetCenter ?? (event as any).center;
@@ -392,7 +437,7 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     return this.#phase === 'selecting-start' || this.#phase === 'selecting-end';
   }
 
-  #handleWidgetClick() {
+  #handleWidgetCommand() {
     if (this.#isSelecting()) {
       this.#cancelSelection();
       return;
@@ -415,12 +460,12 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     isActive: boolean;
     title: string;
   } {
-    const focusColor = '#10374b';
-    const activeColor = '#1a95d3';
+    const completedColor = '#000000';
+    const selectingColor = '#4b5563';
 
     if (this.#phase === 'selecting-start' || this.#phase === 'selecting-end') {
       return {
-        color: activeColor,
+        color: selectingColor,
         icon: makeTextIcon(this.#phase === 'selecting-start' ? '│' : '││'),
         isActive: true,
         title: 'Select time range…'
@@ -429,7 +474,7 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
 
     if (this.#phase === 'selected' && this.#timeMeasureRange) {
       return {
-        color: focusColor,
+        color: completedColor,
         icon: makeTextIcon('Δt'),
         isActive: true,
         title: this.props.activeLabel

--- a/modules/widgets/src/widgets/y-zoom-widget.tsx
+++ b/modules/widgets/src/widgets/y-zoom-widget.tsx
@@ -2,7 +2,7 @@
 import {OrthographicViewport, Widget} from '@deck.gl/core';
 import {render} from 'preact';
 
-import {IconButton, makeTextIcon} from '../preact/icon-button';
+import {IconButton, makeTextIcon} from '@deck.gl-community/panels';
 
 import type {Deck, OrthographicViewState, WidgetPlacement, WidgetProps} from '@deck.gl/core';
 import type {JSX} from 'preact';

--- a/modules/widgets/test/imports.node.spec.ts
+++ b/modules/widgets/test/imports.node.spec.ts
@@ -12,7 +12,8 @@ vi.mock('@deck.gl-community/panels', () => {
     SidebarPanelContainer: class SidebarPanelContainer {},
     FullScreenPanelContainer: class FullScreenPanelContainer {},
     ToolbarComponent: class ToolbarComponent {},
-    ToastComponent: class ToastComponent {}
+    ToastComponent: class ToastComponent {},
+    makeTextIcon: vi.fn(() => '')
   };
 });
 


### PR DESCRIPTION
## Summary
- extract shared panels and widget controls needed by trace-layers
- keep the support change landable independently of the trace-layers implementation

## Testing
- `yarn test`
- `yarn lint`