### PR TITLE
Fix editable terrain no-pick events

### DIFF
--- a/examples/editable-layers/3d-tiles/example.tsx
+++ b/examples/editable-layers/3d-tiles/example.tsx
@@ -4,7 +4,7 @@
 
 import {useState, useEffect, useCallback, useMemo} from 'react';
 import DeckGL from '@deck.gl/react';
-import {TerrainController} from '@deck.gl/core';
+import {MapView, TerrainController} from '@deck.gl/core';
 import {Tile3DLayer} from '@deck.gl/geo-layers';
 import {_TerrainExtension as TerrainExtension} from '@deck.gl/extensions';
 import {
@@ -233,11 +233,13 @@ export function Example() {
     <div>
       <DeckGL
         style={{backgroundColor: '#061714'}}
+        views={new MapView({maxPitch: 90})}
         initialViewState={INITIAL_VIEW_STATE}
         controller={{
           type: TerrainController,
+          maxPitch: 90,
           touchRotate: true,
-          inertia: 500,
+          inertia: false,
           doubleClickZoom: false
         }}
         layers={[tile3DLayer, editableLayer]}

--- a/modules/editable-layers/src/editable-layers/editable-layer.ts
+++ b/modules/editable-layers/src/editable-layers/editable-layer.ts
@@ -136,11 +136,19 @@ export abstract class EditableLayer<
   }
 
   _onclick(event: MjolnirGestureEvent) {
-    this.onLayerClick(this.toBasePointerEvent(event));
+    const basePointerEvent = this.toBasePointerEvent(event);
+    if (!basePointerEvent) {
+      return;
+    }
+    this.onLayerClick(basePointerEvent);
   }
 
   _ondblclick(event: MjolnirGestureEvent) {
-    this.onLayerDoubleClick(this.toBasePointerEvent(event));
+    const basePointerEvent = this.toBasePointerEvent(event);
+    if (!basePointerEvent) {
+      return;
+    }
+    this.onLayerDoubleClick(basePointerEvent);
   }
 
   _onkeyup({srcEvent}: MjolnirKeyEvent) {
@@ -149,6 +157,9 @@ export abstract class EditableLayer<
 
   _onpanstart(event: MjolnirGestureEvent) {
     const basePointerEvent = this.toBasePointerEvent(event);
+    if (!basePointerEvent) {
+      return;
+    }
     const {picks, screenCoords, mapCoords} = basePointerEvent;
 
     this.setState({
@@ -176,6 +187,9 @@ export abstract class EditableLayer<
 
   _onpanmove(event: MjolnirGestureEvent) {
     const basePointerEvent = this.toBasePointerEvent(event);
+    if (!basePointerEvent) {
+      return;
+    }
     const {pointerDownPicks, pointerDownScreenCoords, pointerDownMapCoords} =
       this.state._editableLayerState;
 
@@ -198,12 +212,14 @@ export abstract class EditableLayer<
     const {pointerDownPicks, pointerDownScreenCoords, pointerDownMapCoords} =
       this.state._editableLayerState;
 
-    this.onStopDragging({
-      ...basePointerEvent,
-      pointerDownPicks,
-      pointerDownScreenCoords,
-      pointerDownMapCoords
-    });
+    if (basePointerEvent) {
+      this.onStopDragging({
+        ...basePointerEvent,
+        pointerDownPicks,
+        pointerDownScreenCoords,
+        pointerDownMapCoords
+      });
+    }
 
     this.setState({
       _editableLayerState: {
@@ -217,6 +233,9 @@ export abstract class EditableLayer<
 
   _onpointermove(event: MjolnirGestureEvent) {
     const basePointerEvent = this.toBasePointerEvent(event);
+    if (!basePointerEvent) {
+      return;
+    }
     const {pointerDownPicks, pointerDownScreenCoords, pointerDownMapCoords} =
       this.state._editableLayerState;
 
@@ -229,9 +248,12 @@ export abstract class EditableLayer<
     });
   }
 
-  toBasePointerEvent(event: MjolnirGestureEvent): BasePointerEvent {
+  toBasePointerEvent(event: MjolnirGestureEvent): BasePointerEvent | null {
     const screenCoords: ScreenCoordinates = [event.offsetCenter.x, event.offsetCenter.y];
     const mapCoords = this.getMapCoords(screenCoords);
+    if (!mapCoords) {
+      return null;
+    }
     const picks = this.getPicks(screenCoords);
     return {
       screenCoords,
@@ -260,7 +282,7 @@ export abstract class EditableLayer<
     ];
   }
 
-  getMapCoords(screenCoords: Position): Position {
+  getMapCoords(screenCoords: Position): Position | null {
     if (this.context.deck) {
       const layerIds = this.context.layerManager
         .getLayers()
@@ -273,12 +295,13 @@ export abstract class EditableLayer<
           layerIds,
           unproject3D: true
         });
-        const position =
-          pickInfo?.coordinate ??
-          this.context.viewport.unproject([screenCoords[0], screenCoords[1]]);
+        if (!pickInfo?.coordinate) {
+          return null;
+        }
+        const position = pickInfo.coordinate;
 
         // Keep terrain-edited geometry 2D. TerrainExtension applies height at
-        // render time, so both terrain hits and no-hit fallbacks must discard Z.
+        // render time, so editable coordinates should not carry picked terrain Z.
         return [position[0], position[1]] as Position;
       }
     }

--- a/modules/editable-layers/test/editable-layers/editable-layer.spec.ts
+++ b/modules/editable-layers/test/editable-layers/editable-layer.spec.ts
@@ -21,7 +21,6 @@ class TestEditableLayer extends EditableLayer {
 
 const MOCK_EVENT_SCREEN_COORDS: ScreenCoordinates = [50, 100];
 const MOCK_EVENT_MAP_COORDS: Position = [12.34, 56.78];
-const MOCK_EVENT_MAP_COORDS_3D: Position = [12.34, 56.78, 200];
 const MOCK_TERRAIN_PICK_COORDS: Position = [98.76, 54.32, 300];
 const MOCK_EVENT_PICK: PickingInfo = {
   color: new Uint8Array([255, 0, 0, 255]),
@@ -125,7 +124,8 @@ test('toBasePointerEvent uses offsetCenter, not clientX/Y', () => {
   const event = makeMockGestureEvent('click');
   const result = layer.toBasePointerEvent(event);
 
-  assertBasePointerEvent(result, event);
+  expect(result).not.toBeNull();
+  assertBasePointerEvent(result!, event);
 });
 
 test('getMapCoords strips Z from terrain pick coordinates', () => {
@@ -146,23 +146,22 @@ test('getMapCoords strips Z from terrain pick coordinates', () => {
   expect(mockContext.viewport.unproject).not.toHaveBeenCalled();
 });
 
-test('getMapCoords strips fallback Z when terrain pick misses', () => {
+test('getMapCoords returns null when terrain pick misses', () => {
   mockContext.layerManager.getLayers.mockReturnValue([
     {id: 'terrain-source', props: {pickable: '3d'}}
   ] as any);
   mockContext.deck.pickObject.mockReturnValue(null);
-  mockContext.viewport.unproject.mockReturnValue(MOCK_EVENT_MAP_COORDS_3D);
 
   const result = layer.getMapCoords(MOCK_EVENT_SCREEN_COORDS);
 
-  expect(result).toEqual([MOCK_EVENT_MAP_COORDS_3D[0], MOCK_EVENT_MAP_COORDS_3D[1]]);
+  expect(result).toBeNull();
   expect(mockContext.deck.pickObject).toHaveBeenCalledWith({
     x: MOCK_EVENT_SCREEN_COORDS[0],
     y: MOCK_EVENT_SCREEN_COORDS[1],
     layerIds: ['terrain-source'],
     unproject3D: true
   });
-  expect(mockContext.viewport.unproject).toHaveBeenCalledWith(MOCK_EVENT_SCREEN_COORDS);
+  expect(mockContext.viewport.unproject).not.toHaveBeenCalled();
 });
 
 test('initializeState registers event handlers', () => {
@@ -194,6 +193,19 @@ test('_onclick calls onLayerClick with correct event', () => {
   layer._onclick(mockEvent);
 
   expectBasePointerEvent(onLayerClickSpy, mockEvent);
+});
+
+test('_onclick ignores terrain pick misses', () => {
+  const onLayerClickSpy = vi.spyOn(layer, 'onLayerClick');
+  mockContext.layerManager.getLayers.mockReturnValue([
+    {id: 'terrain-source', props: {pickable: '3d'}}
+  ] as any);
+  mockContext.deck.pickObject.mockReturnValue(null);
+
+  layer._onclick(makeMockGestureEvent('click'));
+
+  expect(onLayerClickSpy).not.toHaveBeenCalled();
+  expect(mockContext.deck.pickMultipleObjects).not.toHaveBeenCalled();
 });
 
 test('_ondblclick calls onLayerDoubleClick with correct event', () => {
@@ -263,6 +275,23 @@ test('_onpanend resets pointerDown state to null', () => {
   layer.state._editableLayerState = {...MOCK_POINTER_DOWN_STATE};
   layer._onpanend(makeMockGestureEvent('panend'));
 
+  const s = layer.state._editableLayerState;
+  expect(s.pointerDownScreenCoords).toBeNull();
+  expect(s.pointerDownMapCoords).toBeNull();
+  expect(s.pointerDownPicks).toBeNull();
+});
+
+test('_onpanend resets pointerDown state when terrain pick misses', () => {
+  const stopDragSpy = vi.spyOn(layer, 'onStopDragging');
+  mockContext.layerManager.getLayers.mockReturnValue([
+    {id: 'terrain-source', props: {pickable: '3d'}}
+  ] as any);
+  mockContext.deck.pickObject.mockReturnValue(null);
+  layer.state._editableLayerState = {...MOCK_POINTER_DOWN_STATE};
+
+  layer._onpanend(makeMockGestureEvent('panend'));
+
+  expect(stopDragSpy).not.toHaveBeenCalled();
   const s = layer.state._editableLayerState;
   expect(s.pointerDownScreenCoords).toBeNull();
   expect(s.pointerDownMapCoords).toBeNull();


### PR DESCRIPTION
## Summary
- Ignore editable-layer pointer events when a terrain-aware pick misses instead of falling back to `viewport.unproject` through a horizon/background pixel.
- Keep terrain-hit editable coordinates 2D so `TerrainExtension` remains responsible for render-time height.
- Let the 3D tiles demo pitch up to `90` via user interaction, and disable controller inertia there to avoid invalid rotate-end overshoot at the horizon.

## Verification
- `yarn vitest run --project node modules/editable-layers/test`
- `yarn lint`
- `ocular-build layers,panels,widgets,editable-layers` with existing panels CJS `import.meta` warnings
- Local demo on `localhost:5173` with NEWHEAT-compatible Google key/port config:
  - right-drag pitched the 3D tiles demo to the horizon/no-terrain band
  - Point mode click in the no-terrain band stayed at `0 features`
  - no page errors or unhandled rejections; only favicon 404
  - Google 3D tile responses sampled as `200`

## Notes
- The repo-wide pre-commit `yarn test` hook still fails in unrelated trace-layers setup: unresolved `@deck.gl-community/infovis-layers` package entry, missing `protobufjs`, and missing `happy-dom`. The relevant editable-layers test slice passes.