### PR TITLE
Fix fork PR coverage summary failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      issues: write
       pull-requests: write
       checks: write
 
@@ -137,7 +138,7 @@ jobs:
           run-id: ${{ steps.find-baseline.outputs.result }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Post coverage summary to PR
+      - name: Prepare coverage summary
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
@@ -187,6 +188,19 @@ jobs:
               testLine.trim() ? `> ${testLine.trim()}` : '',
             ].filter(Boolean).join('\n');
 
+            fs.writeFileSync('/tmp/coverage-pr-summary.md', body);
+
+      - name: Write coverage summary to job summary
+        if: github.event_name == 'pull_request'
+        run: cat /tmp/coverage-pr-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post coverage summary to PR
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('/tmp/coverage-pr-summary.md', 'utf8');
             const {data: comments} = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Summary

Related to #623 and #672.

- avoids failing `test-node` on fork PRs when the coverage comment cannot be written with a read-only fork token
- writes the coverage Markdown to the Actions job summary for every pull request
- keeps the PR coverage comment for same-repository PR branches, where the workflow token can write comments
- adds the missing `issues: write` permission needed by the same-repo comment path

## Classification

Dependency/infra: GitHub Actions workflow hardening.

## Why

The recent fork PR runs for #623 and #672 completed the node test suite successfully, then failed at the final coverage comment step with:

```text
Resource not accessible by integration
```

GitHub provides read-only tokens to forked pull requests, so the workflow should not treat inability to create/update an issue comment as a failing test result.

## Validation

- `yarn`
- `yarn lint`
- `git diff --check`
- pre-commit `yarn test`: 163 files passed, 1379 tests passed, 9 skipped

`actionlint` is not installed in this worktree, so I could not run it locally.

## Visual proof

Not applicable. This is a CI workflow-only infra change with no rendered UI or interactive behavior.

## Residual risk

This PR has not yet proven the fork-token path on GitHub Actions. The expected proof is a fork PR rerun where `test-node` reports success after writing coverage to the job summary and skipping the PR comment step.
