### PR TITLE
fix(editable-layers): edit mode constructor types (#676)

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -6,6 +6,14 @@ Please refer the documentation of each module for detailed upgrade guides.
 
 ## v9.4
 
+### `@deck.gl-community/editable-layers`
+
+- TypeScript change: edit mode constructors now use `SimpleFeatureCollection`
+  consistently across the base classes and exported modes. Consumers that typed
+  editable mode data as the broader GeoJSON `FeatureCollection` should migrate
+  those edit-mode generics to `SimpleFeatureCollection` or `SimpleFeature` from
+  `@deck.gl-community/editable-layers`.
+
 ### `@deck.gl-community/panels`
 
 - Breaking change: panel composition APIs no longer expose `Widget*` names from `@deck.gl-community/panels`.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -9,6 +9,13 @@ Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community
 - `DependencyArrowLayer` - NEW directional marker layer for dependency links with path, line, or arc routing.
 - `PathOutlineLayer` and `PathMarkerLayer` now use deck.gl v9-native sublayers for outlined paths, dashed strokes, and pixel-sized directional markers, restoring the path outline and marker example.
 
+### `@deck.gl-community/editable-layers`
+
+- Edit mode constructor and base-class types now use the package's editable
+  `SimpleFeatureCollection` contract consistently, so exported edit mode
+  constructors can be assigned to `GeoJsonEditModeConstructor[]` in strict
+  TypeScript projects.
+
 ### `@deck.gl-community/infovis-layers`
 
 - Added generic animation, block, fast-text, UTF8 Arrow string-view, view-layout, and viewport-bounds helpers for trace-style visualizations.

--- a/modules/editable-layers/src/edit-modes/composite-mode.ts
+++ b/modules/editable-layers/src/edit-modes/composite-mode.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {FeatureCollection} from '../utils/geojson-types';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {
   ModeProps,
   ClickEvent,
@@ -40,27 +40,27 @@ export class CompositeMode extends GeoJsonEditMode {
     return result;
   }
 
-  handleClick(event: ClickEvent, props: ModeProps<FeatureCollection>): void {
+  handleClick(event: ClickEvent, props: ModeProps<SimpleFeatureCollection>): void {
     this._coalesce(handler => handler.handleClick(event, props));
   }
 
-  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>): void {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>): void {
     return this._coalesce(handler => handler.handlePointerMove(event, props));
   }
 
-  handleStartDragging(event: StartDraggingEvent, props: ModeProps<FeatureCollection>): void {
+  handleStartDragging(event: StartDraggingEvent, props: ModeProps<SimpleFeatureCollection>): void {
     return this._coalesce(handler => handler.handleStartDragging(event, props));
   }
 
-  handleStopDragging(event: StopDraggingEvent, props: ModeProps<FeatureCollection>): void {
+  handleStopDragging(event: StopDraggingEvent, props: ModeProps<SimpleFeatureCollection>): void {
     return this._coalesce(handler => handler.handleStopDragging(event, props));
   }
 
-  handleDragging(event: DraggingEvent, props: ModeProps<FeatureCollection>): void {
+  handleDragging(event: DraggingEvent, props: ModeProps<SimpleFeatureCollection>): void {
     return this._coalesce(handler => handler.handleDragging(event, props));
   }
 
-  getGuides(props: ModeProps<FeatureCollection>): GuideFeatureCollection {
+  getGuides(props: ModeProps<SimpleFeatureCollection>): GuideFeatureCollection {
     // TODO: Combine the guides *BUT* make sure if none of the results have
     // changed to return the same object so that "guides !== this.state.guides"
     // in editable-geojson-layer works.

--- a/modules/editable-layers/src/edit-modes/delete-mode.ts
+++ b/modules/editable-layers/src/edit-modes/delete-mode.ts
@@ -1,9 +1,9 @@
-import {FeatureCollection} from '../utils/geojson-types';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 
 import {GeoJsonEditMode} from './geojson-edit-mode';
 import {ClickEvent, ModeProps} from './types';
 export class DeleteMode extends GeoJsonEditMode {
-  handleClick(_event: ClickEvent, props: ModeProps<FeatureCollection>): void {
+  handleClick(_event: ClickEvent, props: ModeProps<SimpleFeatureCollection>): void {
     const selectedFeatureIndexes = props.lastPointerMoveEvent.picks.map(pick => pick.index);
     if (selectedFeatureIndexes.length > 0) {
       const indexToDelete = selectedFeatureIndexes[0];

--- a/modules/editable-layers/src/edit-modes/draw-90degree-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-90degree-polygon-mode.ts
@@ -19,17 +19,11 @@ import {
   GuideFeatureCollection,
   TentativeFeature
 } from './types';
-import {
-  Polygon,
-  LineString,
-  Position,
-  FeatureCollection,
-  SimpleFeatureCollection
-} from '../utils/geojson-types';
+import {Polygon, LineString, Position, SimpleFeatureCollection} from '../utils/geojson-types';
 import {GeoJsonEditMode} from './geojson-edit-mode';
 
 export class Draw90DegreePolygonMode extends GeoJsonEditMode {
-  createTentativeFeature(props: ModeProps<FeatureCollection>): TentativeFeature {
+  createTentativeFeature(props: ModeProps<SimpleFeatureCollection>): TentativeFeature {
     const clickSequence = this.getClickSequence();
 
     const {mapCoords} = props.lastPointerMoveEvent;
@@ -74,7 +68,7 @@ export class Draw90DegreePolygonMode extends GeoJsonEditMode {
     return tentativeFeature;
   }
 
-  getGuides(props: ModeProps<FeatureCollection>): GuideFeatureCollection {
+  getGuides(props: ModeProps<SimpleFeatureCollection>): GuideFeatureCollection {
     const guides: GuideFeatureCollection = {
       type: 'FeatureCollection',
       features: []
@@ -99,7 +93,7 @@ export class Draw90DegreePolygonMode extends GeoJsonEditMode {
     return guides;
   }
 
-  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>) {
     props.onUpdateCursor('cell');
     super.handlePointerMove(event, props);
   }

--- a/modules/editable-layers/src/edit-modes/draw-circle-by-diameter-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-circle-by-diameter-mode.ts
@@ -7,7 +7,7 @@ import turfDistance from '@turf/distance';
 import turfArea from '@turf/area';
 import {memoize} from '../utils/memoize';
 import {ModeProps, Tooltip} from './types';
-import {Position, Polygon, Feature, FeatureCollection} from '../utils/geojson-types';
+import {Position, Polygon, Feature, SimpleFeatureCollection} from '../utils/geojson-types';
 import {getIntermediatePosition} from './geojson-edit-mode';
 import {TwoClickPolygonMode} from './two-click-polygon-mode';
 
@@ -53,7 +53,7 @@ export class DrawCircleByDiameterMode extends TwoClickPolygonMode {
    * nebula geometry mode type
    * @param props properties of geometry nebula mode
    */
-  getTooltips(props: ModeProps<FeatureCollection>): Tooltip[] {
+  getTooltips(props: ModeProps<SimpleFeatureCollection>): Tooltip[] {
     return this._getTooltips({
       modeConfig: props.modeConfig,
       radius: this.radius,

--- a/modules/editable-layers/src/edit-modes/draw-circle-from-center-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-circle-from-center-mode.ts
@@ -7,7 +7,7 @@ import turfDistance from '@turf/distance';
 import turfArea from '@turf/area';
 import {memoize} from '../utils/memoize';
 import {ModeProps, Tooltip} from './types';
-import {Position, Polygon, Feature, FeatureCollection} from '../utils/geojson-types';
+import {Position, Polygon, Feature, SimpleFeatureCollection} from '../utils/geojson-types';
 import {TwoClickPolygonMode} from './two-click-polygon-mode';
 
 export class DrawCircleFromCenterMode extends TwoClickPolygonMode {
@@ -47,7 +47,7 @@ export class DrawCircleFromCenterMode extends TwoClickPolygonMode {
    * nebula geometry mode type
    * @param props properties of geometry nebula mode
    */
-  getTooltips(props: ModeProps<FeatureCollection>): Tooltip[] {
+  getTooltips(props: ModeProps<SimpleFeatureCollection>): Tooltip[] {
     return this._getTooltips({
       modeConfig: props?.modeConfig,
       radius: this.radius,

--- a/modules/editable-layers/src/edit-modes/draw-line-string-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-line-string-mode.ts
@@ -3,12 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {memoize} from '../utils/memoize';
-import {
-  LineString,
-  FeatureCollection,
-  Position,
-  SimpleFeatureCollection
-} from '../utils/geojson-types';
+import {LineString, Position, SimpleFeatureCollection} from '../utils/geojson-types';
 import {
   ClickEvent,
   PointerMoveEvent,
@@ -105,7 +100,7 @@ export class DrawLineStringMode extends GeoJsonEditMode {
     }
   }
 
-  getGuides(props: ModeProps<FeatureCollection>): GuideFeatureCollection {
+  getGuides(props: ModeProps<SimpleFeatureCollection>): GuideFeatureCollection {
     const {lastPointerMoveEvent} = props;
     const clickSequence = this.getClickSequence();
 
@@ -152,7 +147,7 @@ export class DrawLineStringMode extends GeoJsonEditMode {
     return guides;
   }
 
-  handlePointerMove(_event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
+  handlePointerMove(_event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>) {
     props.onUpdateCursor('cell');
   }
 
@@ -161,7 +156,7 @@ export class DrawLineStringMode extends GeoJsonEditMode {
    * nebula geometry mode type
    * @param props properties of geometry nebula mode
    */
-  getTooltips(props: ModeProps<FeatureCollection>): Tooltip[] {
+  getTooltips(props: ModeProps<SimpleFeatureCollection>): Tooltip[] {
     return this._getTooltips({
       modeConfig: props.modeConfig,
       dist: this.dist,

--- a/modules/editable-layers/src/edit-modes/draw-point-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-point-mode.ts
@@ -3,11 +3,11 @@
 // Copyright (c) vis.gl contributors
 
 import {ClickEvent, PointerMoveEvent, ModeProps, TentativeFeature} from './types';
-import {FeatureCollection, SimpleFeatureCollection, Point} from '../utils/geojson-types';
+import {SimpleFeatureCollection, Point} from '../utils/geojson-types';
 import {GeoJsonEditMode} from './geojson-edit-mode';
 
 export class DrawPointMode extends GeoJsonEditMode {
-  createTentativeFeature(props: ModeProps<FeatureCollection>): TentativeFeature {
+  createTentativeFeature(props: ModeProps<SimpleFeatureCollection>): TentativeFeature {
     const {lastPointerMoveEvent} = props;
     const lastCoords = lastPointerMoveEvent ? [lastPointerMoveEvent.mapCoords] : [];
 
@@ -32,7 +32,7 @@ export class DrawPointMode extends GeoJsonEditMode {
     props.onEdit(this.getAddFeatureAction(geometry, props.data));
   }
 
-  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>) {
     props.onUpdateCursor('cell');
     super.handlePointerMove(event, props);
   }

--- a/modules/editable-layers/src/edit-modes/draw-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-polygon-mode.ts
@@ -16,7 +16,7 @@ import {
   GuideFeature,
   DoubleClickEvent
 } from './types';
-import {Position, FeatureCollection, SimpleFeatureCollection} from '../utils/geojson-types';
+import {Position, SimpleFeatureCollection} from '../utils/geojson-types';
 import {getPickedEditHandle} from './utils';
 import {GeoJsonEditMode} from './geojson-edit-mode';
 import {ImmutableFeatureCollection} from './immutable-feature-collection';
@@ -31,7 +31,7 @@ export class DrawPolygonMode extends GeoJsonEditMode {
   holeSequence: Position[] = [];
   isDrawingHole = false;
 
-  createTentativeFeature(props: ModeProps<FeatureCollection>): TentativeFeature {
+  createTentativeFeature(props: ModeProps<SimpleFeatureCollection>): TentativeFeature {
     const {lastPointerMoveEvent} = props;
     const clickSequence = this.getClickSequence();
     const holeSequence = this.holeSequence;
@@ -68,7 +68,7 @@ export class DrawPolygonMode extends GeoJsonEditMode {
     };
   }
 
-  getGuides(props: ModeProps<FeatureCollection>): GuideFeatureCollection {
+  getGuides(props: ModeProps<SimpleFeatureCollection>): GuideFeatureCollection {
     const guides: GuideFeatureCollection = {
       type: 'FeatureCollection',
       features: []
@@ -192,7 +192,7 @@ export class DrawPolygonMode extends GeoJsonEditMode {
     }
   }
 
-  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>) {
     props.onUpdateCursor('cell');
     super.handlePointerMove(event, props);
   }
@@ -351,21 +351,21 @@ function isNearFirstPoint(click: Position, first: Position, threshold = 1e-4): b
 }
 
 // Helper function to determine if a hole can be added to a polygon
-function canAddHoleToPolygon(props: ModeProps<FeatureCollection>): boolean {
+function canAddHoleToPolygon(props: ModeProps<SimpleFeatureCollection>): boolean {
   // For simplicity, always return true in this example.
   // Implement your own logic based on application requirements.
   return props.modeConfig?.allowHoles ?? false;
 }
 
 // Helper function to determine if a polygon can intersect itself
-function canPolygonOverlap(props: ModeProps<FeatureCollection>): boolean {
+function canPolygonOverlap(props: ModeProps<SimpleFeatureCollection>): boolean {
   // Return the value of allowSelfIntersection (defaults to false for safety)
   return props.modeConfig?.allowSelfIntersection ?? false;
 }
 
 function getPolygonFeature(
   polygonGeometry: Position[][],
-  props: ModeProps<FeatureCollection>
+  props: ModeProps<SimpleFeatureCollection>
 ): Feature<Polygon> {
   return props.coordinateSystem instanceof CartesianCoordinateSystem
     ? {type: 'Feature', properties: {}, geometry: {type: 'Polygon', coordinates: polygonGeometry}}

--- a/modules/editable-layers/src/edit-modes/duplicate-mode.ts
+++ b/modules/editable-layers/src/edit-modes/duplicate-mode.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {StartDraggingEvent, ModeProps} from './types';
-import {FeatureCollection, SimpleFeatureCollection} from '../utils/geojson-types';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {TranslateMode} from './translate-mode';
 
 export class DuplicateMode extends TranslateMode {
@@ -15,7 +15,7 @@ export class DuplicateMode extends TranslateMode {
     }
   }
 
-  updateCursor(props: ModeProps<FeatureCollection>) {
+  updateCursor(props: ModeProps<SimpleFeatureCollection>) {
     if (this._isTranslatable) {
       props.onUpdateCursor('copy');
     } else {

--- a/modules/editable-layers/src/edit-modes/elevation-mode.ts
+++ b/modules/editable-layers/src/edit-modes/elevation-mode.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {ModeProps, PointerMoveEvent, StopDraggingEvent} from './types';
-import {Position, FeatureCollection} from '../utils/geojson-types';
+import {Position, SimpleFeatureCollection} from '../utils/geojson-types';
 import {getPickedEditHandle} from './utils';
 import {ModifyMode} from './modify-mode';
 
@@ -21,7 +21,7 @@ export class ElevationMode extends ModifyMode {
   makeElevatedEvent(
     event: PointerMoveEvent | StopDraggingEvent,
     position: Position,
-    props: ModeProps<FeatureCollection>
+    props: ModeProps<SimpleFeatureCollection>
   ): Record<string, any> {
     const {
       minElevation = 0,
@@ -49,14 +49,14 @@ export class ElevationMode extends ModifyMode {
     });
   }
 
-  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>) {
     const editHandle = getPickedEditHandle(event.pointerDownPicks);
     const position = editHandle ? editHandle.geometry.coordinates : event.mapCoords;
     // @ts-expect-error return type too wide
     super.handlePointerMove(this.makeElevatedEvent(event, position, props), props);
   }
 
-  handleStopDragging(event: StopDraggingEvent, props: ModeProps<FeatureCollection>) {
+  handleStopDragging(event: StopDraggingEvent, props: ModeProps<SimpleFeatureCollection>) {
     const editHandle = getPickedEditHandle(event.picks);
     const position = editHandle ? editHandle.geometry.coordinates : event.mapCoords;
     // @ts-expect-error return type too wide

--- a/modules/editable-layers/src/edit-modes/extend-line-string-mode.ts
+++ b/modules/editable-layers/src/edit-modes/extend-line-string-mode.ts
@@ -2,12 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {
-  Position,
-  LineString,
-  FeatureCollection,
-  SimpleFeatureCollection
-} from '../utils/geojson-types';
+import {Position, LineString, SimpleFeatureCollection} from '../utils/geojson-types';
 import {ClickEvent, PointerMoveEvent, ModeProps, GuideFeatureCollection} from './types';
 import {GeoJsonEditMode} from './geojson-edit-mode';
 import {ImmutableFeatureCollection} from './immutable-feature-collection';
@@ -96,7 +91,7 @@ export class ExtendLineStringMode extends GeoJsonEditMode {
     return guides;
   }
 
-  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>) {
     props.onUpdateCursor('cell');
   }
 }

--- a/modules/editable-layers/src/edit-modes/geojson-edit-mode.ts
+++ b/modules/editable-layers/src/edit-modes/geojson-edit-mode.ts
@@ -22,7 +22,6 @@ import {
   TentativeFeature
 } from './types';
 import {
-  FeatureCollection,
   Feature,
   Polygon,
   SimpleGeometry,
@@ -44,20 +43,20 @@ const DEFAULT_GUIDES: GuideFeatureCollection = {
 const DEFAULT_TOOLTIPS: Tooltip[] = [];
 
 // Main interface for `EditMode`s that edit GeoJSON
-export type GeoJsonEditModeType = EditMode<FeatureCollection, FeatureCollection>;
+export type GeoJsonEditModeType = EditMode<SimpleFeatureCollection, GuideFeatureCollection>;
 
 export interface GeoJsonEditModeConstructor {
   new (): GeoJsonEditModeType;
 }
 
-export class GeoJsonEditMode implements EditMode<FeatureCollection, GuideFeatureCollection> {
+export class GeoJsonEditMode implements EditMode<SimpleFeatureCollection, GuideFeatureCollection> {
   _clickSequence: Position[] = [];
 
-  getGuides(_props: ModeProps<FeatureCollection>): GuideFeatureCollection {
+  getGuides(_props: ModeProps<SimpleFeatureCollection>): GuideFeatureCollection {
     return DEFAULT_GUIDES;
   }
 
-  getTooltips(_props: ModeProps<FeatureCollection>): Tooltip[] {
+  getTooltips(_props: ModeProps<SimpleFeatureCollection>): Tooltip[] {
     return DEFAULT_TOOLTIPS;
   }
 
@@ -101,14 +100,16 @@ export class GeoJsonEditMode implements EditMode<FeatureCollection, GuideFeature
     this._clickSequence = [];
   }
 
-  getTentativeGuide(props: ModeProps<FeatureCollection>): TentativeFeature | null | undefined {
+  getTentativeGuide(
+    props: ModeProps<SimpleFeatureCollection>
+  ): TentativeFeature | null | undefined {
     const guides = this.getGuides(props);
     return guides.features.find(
       f => f.properties && f.properties.guideType === 'tentative'
     ) as TentativeFeature;
   }
 
-  isSelectionPicked(picks: Pick[], props: ModeProps<FeatureCollection>): boolean {
+  isSelectionPicked(picks: Pick[], props: ModeProps<SimpleFeatureCollection>): boolean {
     if (!picks.length) return false;
     const pickedFeatures = getNonGuidePicks(picks).map(({index}) => index);
     const pickedHandles = getPickedEditHandles(picks).map(
@@ -258,14 +259,14 @@ export class GeoJsonEditMode implements EditMode<FeatureCollection, GuideFeature
     return this.getAddFeatureAction(featureOrGeometry, props.data, featureProperties);
   }
 
-  createTentativeFeature(_props: ModeProps<FeatureCollection>): TentativeFeature | null {
+  createTentativeFeature(_props: ModeProps<SimpleFeatureCollection>): TentativeFeature | null {
     return null;
   }
 
-  handleClick(_event: ClickEvent, _props: ModeProps<FeatureCollection>): void {}
-  handleDoubleClick(_event: ClickEvent, _props: ModeProps<FeatureCollection>): void {}
+  handleClick(_event: ClickEvent, _props: ModeProps<SimpleFeatureCollection>): void {}
+  handleDoubleClick(_event: ClickEvent, _props: ModeProps<SimpleFeatureCollection>): void {}
 
-  handlePointerMove(_event: PointerMoveEvent, props: ModeProps<FeatureCollection>): void {
+  handlePointerMove(_event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>): void {
     const tentativeFeature = this.createTentativeFeature(props);
     if (tentativeFeature) {
       props.onEdit({
@@ -277,11 +278,14 @@ export class GeoJsonEditMode implements EditMode<FeatureCollection, GuideFeature
       });
     }
   }
-  handleStartDragging(_event: StartDraggingEvent, _props: ModeProps<FeatureCollection>): void {}
-  handleStopDragging(_event: StopDraggingEvent, _props: ModeProps<FeatureCollection>): void {}
-  handleDragging(_event: DraggingEvent, _props: ModeProps<FeatureCollection>): void {}
+  handleStartDragging(
+    _event: StartDraggingEvent,
+    _props: ModeProps<SimpleFeatureCollection>
+  ): void {}
+  handleStopDragging(_event: StopDraggingEvent, _props: ModeProps<SimpleFeatureCollection>): void {}
+  handleDragging(_event: DraggingEvent, _props: ModeProps<SimpleFeatureCollection>): void {}
 
-  handleKeyUp(event: KeyboardEvent, props: ModeProps<FeatureCollection>): void {
+  handleKeyUp(event: KeyboardEvent, props: ModeProps<SimpleFeatureCollection>): void {
     if (event.key === 'Escape') {
       this.resetClickSequence();
       props.onEdit({

--- a/modules/editable-layers/src/edit-modes/measure-angle-mode.ts
+++ b/modules/editable-layers/src/edit-modes/measure-angle-mode.ts
@@ -3,7 +3,7 @@ import turfCenter from '@turf/center';
 import {memoize} from '../utils/memoize';
 
 import {ClickEvent, PointerMoveEvent, Tooltip, ModeProps, GuideFeatureCollection} from './types';
-import {FeatureCollection, Position} from '../utils/geojson-types';
+import {Position, SimpleFeatureCollection} from '../utils/geojson-types';
 import {GeoJsonEditMode} from './geojson-edit-mode';
 
 const DEFAULT_TOOLTIPS: Tooltip[] = [];
@@ -66,7 +66,7 @@ export class MeasureAngleMode extends GeoJsonEditMode {
     }
   );
 
-  handleClick(event: ClickEvent, props: ModeProps<FeatureCollection>): void {
+  handleClick(event: ClickEvent, props: ModeProps<SimpleFeatureCollection>): void {
     if (this.getClickSequence().length >= 3) {
       this.resetClickSequence();
     }
@@ -75,11 +75,11 @@ export class MeasureAngleMode extends GeoJsonEditMode {
   }
 
   // Called when the pointer moved, regardless of whether the pointer is down, up, and whether something was picked
-  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>): void {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>): void {
     props.onUpdateCursor('cell');
   }
 
-  getPoints(props: ModeProps<FeatureCollection>): Position[] {
+  getPoints(props: ModeProps<SimpleFeatureCollection>): Position[] {
     const clickSequence = this.getClickSequence();
 
     const points = [...clickSequence];
@@ -92,7 +92,7 @@ export class MeasureAngleMode extends GeoJsonEditMode {
   }
 
   // Return features that can be used as a guide for editing the data
-  getGuides(props: ModeProps<FeatureCollection>): GuideFeatureCollection {
+  getGuides(props: ModeProps<SimpleFeatureCollection>): GuideFeatureCollection {
     const guides: GuideFeatureCollection = {type: 'FeatureCollection', features: []};
     const {features} = guides;
 
@@ -121,7 +121,7 @@ export class MeasureAngleMode extends GeoJsonEditMode {
     return guides;
   }
 
-  getTooltips(props: ModeProps<FeatureCollection>): Tooltip[] {
+  getTooltips(props: ModeProps<SimpleFeatureCollection>): Tooltip[] {
     const points = this.getPoints(props);
 
     return this._getTooltips({

--- a/modules/editable-layers/src/edit-modes/measure-area-mode.ts
+++ b/modules/editable-layers/src/edit-modes/measure-area-mode.ts
@@ -5,7 +5,7 @@
 import turfArea from '@turf/area';
 import turfCentroid from '@turf/centroid';
 import {ClickEvent, Tooltip, ModeProps} from './types';
-import {FeatureCollection, SimpleFeatureCollection} from '../utils/geojson-types';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {DrawPolygonMode} from './draw-polygon-mode';
 
 const DEFAULT_TOOLTIPS = [];
@@ -29,7 +29,7 @@ export class MeasureAreaMode extends DrawPolygonMode {
     super.handleKeyUp(event, propsWithoutEdit);
   }
 
-  getTooltips(props: ModeProps<FeatureCollection>): Tooltip[] {
+  getTooltips(props: ModeProps<SimpleFeatureCollection>): Tooltip[] {
     const tentativeGuide = this.getTentativeGuide(props);
 
     if (tentativeGuide && tentativeGuide.geometry.type === 'Polygon') {

--- a/modules/editable-layers/src/edit-modes/measure-distance-mode.ts
+++ b/modules/editable-layers/src/edit-modes/measure-distance-mode.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {FeatureCollection} from '../utils/geojson-types';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {
   ClickEvent,
   PointerMoveEvent,
@@ -46,7 +46,7 @@ export class MeasureDistanceMode extends GeoJsonEditMode {
     return text;
   }
 
-  handleClick(event: ClickEvent, props: ModeProps<FeatureCollection>) {
+  handleClick(event: ClickEvent, props: ModeProps<SimpleFeatureCollection>) {
     const {modeConfig, data, onEdit} = props;
     const {centerTooltipsOnLine = false} = modeConfig || {};
     const coordSys = getEditModeCoordinateSystem(props.coordinateSystem);
@@ -112,7 +112,7 @@ export class MeasureDistanceMode extends GeoJsonEditMode {
     }
   }
 
-  handleKeyUp(event: KeyboardEvent, props: ModeProps<FeatureCollection>) {
+  handleKeyUp(event: KeyboardEvent, props: ModeProps<SimpleFeatureCollection>) {
     if (this._isMeasuringSessionFinished) return;
 
     event.stopPropagation();
@@ -139,7 +139,7 @@ export class MeasureDistanceMode extends GeoJsonEditMode {
     }
   }
 
-  getGuides(props: ModeProps<FeatureCollection>): GuideFeatureCollection {
+  getGuides(props: ModeProps<SimpleFeatureCollection>): GuideFeatureCollection {
     const {lastPointerMoveEvent} = props;
     const clickSequence = this.getClickSequence();
 
@@ -185,11 +185,11 @@ export class MeasureDistanceMode extends GeoJsonEditMode {
     return guides;
   }
 
-  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>) {
     props.onUpdateCursor('cell');
   }
 
-  getTooltips(props: ModeProps<FeatureCollection>): Tooltip[] {
+  getTooltips(props: ModeProps<SimpleFeatureCollection>): Tooltip[] {
     const {lastPointerMoveEvent, modeConfig} = props;
     const {centerTooltipsOnLine = false} = modeConfig || {};
     const positions = this.getClickSequence();

--- a/modules/editable-layers/src/edit-modes/modify-mode.ts
+++ b/modules/editable-layers/src/edit-modes/modify-mode.ts
@@ -16,14 +16,7 @@ import {
   NearestPointType,
   shouldCancelPan
 } from './utils';
-import {
-  LineString,
-  Point,
-  Polygon,
-  FeatureCollection,
-  Feature,
-  SimpleFeatureCollection
-} from '../utils/geojson-types';
+import {LineString, Point, Polygon, Feature, SimpleFeatureCollection} from '../utils/geojson-types';
 import {
   ModeProps,
   ClickEvent,
@@ -261,7 +254,7 @@ export class ModifyMode extends GeoJsonEditMode {
     });
   }
 
-  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>): void {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>): void {
     const cursor = this.getCursor(event);
     props.onUpdateCursor(cursor);
   }

--- a/modules/editable-layers/src/edit-modes/resize-circle-mode.ts
+++ b/modules/editable-layers/src/edit-modes/resize-circle-mode.ts
@@ -14,13 +14,7 @@ import {
   getPickedEditHandle,
   NearestPointType
 } from './utils';
-import {
-  LineString,
-  Point,
-  FeatureCollection,
-  Feature,
-  SimpleFeatureCollection
-} from '../utils/geojson-types';
+import {LineString, Point, Feature, SimpleFeatureCollection} from '../utils/geojson-types';
 import {Viewport} from '../utils/types';
 import {
   ModeProps,
@@ -40,7 +34,7 @@ export class ResizeCircleMode extends GeoJsonEditMode {
   _isResizing = false;
 
   // eslint-disable-next-line complexity
-  getGuides(props: ModeProps<FeatureCollection>): GuideFeatureCollection {
+  getGuides(props: ModeProps<SimpleFeatureCollection>): GuideFeatureCollection {
     const handles: GuideFeature[] = [];
     const selectedFeatureIndexes = props.selectedIndexes;
 
@@ -170,7 +164,7 @@ export class ResizeCircleMode extends GeoJsonEditMode {
     }
   }
 
-  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>): void {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>): void {
     if (!this._isResizing) {
       const selectedEditHandle = getPickedEditHandle(event.picks);
       this._selectedEditHandle =
@@ -183,14 +177,14 @@ export class ResizeCircleMode extends GeoJsonEditMode {
     props.onUpdateCursor(cursor);
   }
 
-  handleStartDragging(event: StartDraggingEvent, props: ModeProps<FeatureCollection>) {
+  handleStartDragging(event: StartDraggingEvent, props: ModeProps<SimpleFeatureCollection>) {
     if (this._selectedEditHandle) {
       event.cancelPan();
       this._isResizing = true;
     }
   }
 
-  handleStopDragging(event: StopDraggingEvent, props: ModeProps<FeatureCollection>) {
+  handleStopDragging(event: StopDraggingEvent, props: ModeProps<SimpleFeatureCollection>) {
     if (this._isResizing) {
       this._selectedEditHandle = null;
       this._isResizing = false;

--- a/modules/editable-layers/src/edit-modes/rotate-mode.ts
+++ b/modules/editable-layers/src/edit-modes/rotate-mode.ts
@@ -112,7 +112,7 @@ export class RotateMode extends GeoJsonEditMode {
     event.cancelPan();
   }
 
-  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>) {
     if (!this._isRotating) {
       const selectedEditHandle = getPickedEditHandle(event.picks);
       this._selectedEditHandle =
@@ -152,7 +152,7 @@ export class RotateMode extends GeoJsonEditMode {
     }
   }
 
-  updateCursor(props: ModeProps<FeatureCollection>) {
+  updateCursor(props: ModeProps<SimpleFeatureCollection>) {
     if (this._selectedEditHandle) {
       // TODO: look at doing SVG cursors to get a better "rotate" cursor
       props.onUpdateCursor('crosshair');

--- a/modules/editable-layers/src/edit-modes/snappable-mode.ts
+++ b/modules/editable-layers/src/edit-modes/snappable-mode.ts
@@ -2,12 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {
-  Position,
-  FeatureCollection,
-  SimpleFeatureCollection,
-  SimpleFeature
-} from '../utils/geojson-types';
+import {Position, SimpleFeatureCollection, SimpleFeature} from '../utils/geojson-types';
 import {
   PointerMoveEvent,
   StartDraggingEvent,
@@ -155,7 +150,7 @@ export class SnappableMode extends GeoJsonEditMode {
 
   _getSnapAwareEvent<T extends MovementTypeEvent>(
     event: T,
-    props: ModeProps<FeatureCollection>
+    props: ModeProps<SimpleFeatureCollection>
   ): T {
     const snapSource = this._getPickedSnapSource(props.lastPointerMoveEvent.pointerDownPicks);
     const snapTarget = this._getPickedSnapTarget(event.picks);
@@ -165,19 +160,19 @@ export class SnappableMode extends GeoJsonEditMode {
       : event;
   }
 
-  handleStartDragging(event: StartDraggingEvent, props: ModeProps<FeatureCollection>) {
+  handleStartDragging(event: StartDraggingEvent, props: ModeProps<SimpleFeatureCollection>) {
     this._handler.handleStartDragging(event, props);
   }
 
-  handleStopDragging(event: StopDraggingEvent, props: ModeProps<FeatureCollection>) {
+  handleStopDragging(event: StopDraggingEvent, props: ModeProps<SimpleFeatureCollection>) {
     this._handler.handleStopDragging(this._getSnapAwareEvent(event, props), props);
   }
 
-  handleDragging(event: DraggingEvent, props: ModeProps<FeatureCollection>) {
+  handleDragging(event: DraggingEvent, props: ModeProps<SimpleFeatureCollection>) {
     this._handler.handleDragging(this._getSnapAwareEvent(event, props), props);
   }
 
-  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>) {
     this._handler.handlePointerMove(this._getSnapAwareEvent(event, props), props);
   }
 }

--- a/modules/editable-layers/src/edit-modes/split-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/split-polygon-mode.ts
@@ -14,7 +14,7 @@ import turfDestination from '@turf/destination';
 import turfPolygonToLine from '@turf/polygon-to-line';
 import nearestPointOnLine from '@turf/nearest-point-on-line';
 import {generatePointsParallelToLinePoints} from './utils';
-import {FeatureCollection, PolygonGeometry, SimpleFeatureCollection} from '../utils/geojson-types';
+import {PolygonGeometry, SimpleFeatureCollection} from '../utils/geojson-types';
 import {
   ClickEvent,
   PointerMoveEvent,
@@ -148,7 +148,7 @@ export class SplitPolygonMode extends GeoJsonEditMode {
     }
   }
 
-  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>) {
     props.onUpdateCursor('cell');
   }
 

--- a/modules/editable-layers/src/edit-modes/three-click-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/three-click-polygon-mode.ts
@@ -9,13 +9,7 @@ import {
   GuideFeatureCollection,
   TentativeFeature
 } from './types';
-import {
-  Position,
-  Polygon,
-  Feature,
-  FeatureCollection,
-  SimpleFeatureCollection
-} from '../utils/geojson-types';
+import {Position, Polygon, Feature, SimpleFeatureCollection} from '../utils/geojson-types';
 import {GeoJsonEditMode} from './geojson-edit-mode';
 
 export class ThreeClickPolygonMode extends GeoJsonEditMode {
@@ -42,7 +36,7 @@ export class ThreeClickPolygonMode extends GeoJsonEditMode {
     }
   }
 
-  getGuides(props: ModeProps<FeatureCollection>): GuideFeatureCollection {
+  getGuides(props: ModeProps<SimpleFeatureCollection>): GuideFeatureCollection {
     const {lastPointerMoveEvent, modeConfig} = props;
     const clickSequence = this.getClickSequence();
 
@@ -92,12 +86,12 @@ export class ThreeClickPolygonMode extends GeoJsonEditMode {
     return null;
   }
 
-  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>) {
     props.onUpdateCursor('cell');
     super.handlePointerMove(event, props);
   }
 
-  createTentativeFeature(props: ModeProps<FeatureCollection>): TentativeFeature {
+  createTentativeFeature(props: ModeProps<SimpleFeatureCollection>): TentativeFeature {
     const {lastPointerMoveEvent} = props;
     const clickSequence = this.getClickSequence();
 

--- a/modules/editable-layers/src/edit-modes/transform-mode.ts
+++ b/modules/editable-layers/src/edit-modes/transform-mode.ts
@@ -4,7 +4,7 @@
 
 import {featureCollection} from '@turf/helpers';
 import {PointerMoveEvent, ModeProps, StartDraggingEvent} from './types';
-import {FeatureCollection} from '../utils/geojson-types';
+import {SimpleFeatureCollection} from '../utils/geojson-types';
 import {TranslateMode} from './translate-mode';
 import {ScaleMode} from './scale-mode';
 import {RotateMode} from './rotate-mode';
@@ -17,7 +17,7 @@ export class TransformMode extends CompositeMode {
     super([new TranslateMode(), new ScaleMode(), new RotateMode()]);
   }
 
-  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>) {
     let updatedCursor: string | null = null;
     super.handlePointerMove(event, {
       ...props,
@@ -28,7 +28,7 @@ export class TransformMode extends CompositeMode {
     props.onUpdateCursor(updatedCursor);
   }
 
-  handleStartDragging(event: StartDraggingEvent, props: ModeProps<FeatureCollection>) {
+  handleStartDragging(event: StartDraggingEvent, props: ModeProps<SimpleFeatureCollection>) {
     let scaleMode: ScaleMode | null = null;
     let translateMode: TranslateMode | null = null;
     const filteredModes: GeoJsonEditMode[] = [];
@@ -59,7 +59,7 @@ export class TransformMode extends CompositeMode {
     filteredModes.filter(Boolean).forEach(mode => mode.handleStartDragging(event, props));
   }
 
-  getGuides(props: ModeProps<FeatureCollection>) {
+  getGuides(props: ModeProps<SimpleFeatureCollection>) {
     let compositeGuides = super.getGuides(props);
     const rotateMode = (this._modes || []).find(mode => mode instanceof RotateMode);
 

--- a/modules/editable-layers/src/edit-modes/translate-mode.ts
+++ b/modules/editable-layers/src/edit-modes/translate-mode.ts
@@ -4,12 +4,7 @@
 
 import turfClone from '@turf/clone';
 import {WebMercatorViewport} from '@math.gl/web-mercator';
-import {
-  FeatureCollection,
-  Position,
-  SimpleGeometry,
-  SimpleFeatureCollection
-} from '../utils/geojson-types';
+import {Position, SimpleGeometry, SimpleFeatureCollection} from '../utils/geojson-types';
 import {
   PointerMoveEvent,
   StartDraggingEvent,
@@ -51,7 +46,7 @@ export class TranslateMode extends GeoJsonEditMode {
     event.cancelPan();
   }
 
-  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>) {
     this._isTranslatable = this.isSelectionPicked(event.pointerDownPicks || event.picks, props);
 
     this.updateCursor(props);
@@ -84,7 +79,7 @@ export class TranslateMode extends GeoJsonEditMode {
     }
   }
 
-  updateCursor(props: ModeProps<FeatureCollection>) {
+  updateCursor(props: ModeProps<SimpleFeatureCollection>) {
     if (this._isTranslatable) {
       props.onUpdateCursor('move');
     } else {

--- a/modules/editable-layers/src/edit-modes/two-click-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/two-click-polygon-mode.ts
@@ -11,13 +11,7 @@ import {
   GuideFeatureCollection,
   TentativeFeature
 } from './types';
-import {
-  Polygon,
-  FeatureCollection,
-  Feature,
-  Position,
-  SimpleFeatureCollection
-} from '../utils/geojson-types';
+import {Polygon, Feature, Position, SimpleFeatureCollection} from '../utils/geojson-types';
 import {GeoJsonEditMode} from './geojson-edit-mode';
 
 export class TwoClickPolygonMode extends GeoJsonEditMode {
@@ -81,7 +75,7 @@ export class TwoClickPolygonMode extends GeoJsonEditMode {
     }
   }
 
-  getGuides(props: ModeProps<FeatureCollection>): GuideFeatureCollection {
+  getGuides(props: ModeProps<SimpleFeatureCollection>): GuideFeatureCollection {
     const {lastPointerMoveEvent, modeConfig} = props;
     const clickSequence = this.getClickSequence();
 
@@ -121,12 +115,12 @@ export class TwoClickPolygonMode extends GeoJsonEditMode {
     return null;
   }
 
-  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<SimpleFeatureCollection>) {
     props.onUpdateCursor('cell');
     super.handlePointerMove(event, props);
   }
 
-  createTentativeFeature(props: ModeProps<FeatureCollection>): TentativeFeature {
+  createTentativeFeature(props: ModeProps<SimpleFeatureCollection>): TentativeFeature {
     const {lastPointerMoveEvent} = props;
     const clickSequence = this.getClickSequence();
 

--- a/modules/editable-layers/src/editable-layers/editable-geojson-layer.ts
+++ b/modules/editable-layers/src/editable-layers/editable-geojson-layer.ts
@@ -51,7 +51,7 @@ import {PROJECTED_PIXEL_SIZE_MULTIPLIER} from '../constants';
 
 import {EditableLayer, EditableLayerProps} from './editable-layer';
 import {EditablePathLayer} from './editable-path-layer';
-import {Feature, FeatureCollection} from '../utils/geojson-types';
+import {Feature, FeatureCollection, SimpleFeatureCollection} from '../utils/geojson-types';
 
 const DEFAULT_LINE_COLOR: Color = [0x0, 0x0, 0x0, 0x99];
 const DEFAULT_FILL_COLOR: Color = [0x0, 0x0, 0x0, 0x90];
@@ -274,8 +274,8 @@ const modeNameMapping = {
 };
 
 export class EditableGeoJsonLayer extends EditableLayer<
-  FeatureCollection,
-  EditableGeoJsonLayerProps<FeatureCollection>
+  SimpleFeatureCollection,
+  EditableGeoJsonLayerProps<SimpleFeatureCollection>
 > {
   static layerName = 'EditableGeoJsonLayer';
   static defaultProps = defaultProps;

--- a/modules/editable-layers/test/imports.node.spec.ts
+++ b/modules/editable-layers/test/imports.node.spec.ts
@@ -7,6 +7,7 @@
 
 import {it, expect} from 'vitest';
 import * as EditableLayers from '../src/index';
+import type {GeoJsonEditModeConstructor} from '../src/index';
 
 it('exports ImmutableFeatureCollection', () => {
   expect(EditableLayers.ImmutableFeatureCollection).toBeDefined();
@@ -58,4 +59,26 @@ it('exports composite modes', () => {
   expect(EditableLayers.CompositeMode).toBeDefined();
   expect(EditableLayers.SnappableMode).toBeDefined();
   expect(EditableLayers.ViewMode).toBeDefined();
+});
+
+it('exports mode constructors matching the public edit mode type', () => {
+  const modeConstructors: GeoJsonEditModeConstructor[] = [
+    EditableLayers.ViewMode,
+    EditableLayers.DrawPointMode,
+    EditableLayers.DrawLineStringMode,
+    EditableLayers.DrawPolygonMode,
+    EditableLayers.DrawRectangleMode,
+    EditableLayers.DrawCircleByDiameterMode,
+    EditableLayers.DrawCircleFromCenterMode,
+    EditableLayers.ModifyMode,
+    EditableLayers.TranslateMode,
+    EditableLayers.ScaleMode,
+    EditableLayers.RotateMode,
+    EditableLayers.DeleteMode,
+    EditableLayers.DuplicateMode,
+    EditableLayers.SplitPolygonMode,
+    EditableLayers.TransformMode
+  ];
+
+  expect(modeConstructors).toHaveLength(15);
 });


### PR DESCRIPTION
## Summary

Fixes #676.

Aligns the editable-layers public edit-mode type contract with the actual editable geometry surface. `GeoJsonEditModeType`, `GeoJsonEditMode`, `CompositeMode`, `EditableGeoJsonLayer`, and exported edit-mode entry points now use `SimpleFeatureCollection` instead of the wider GeoJSON `FeatureCollection` that includes `GeometryCollection`. This prevents strict TypeScript consumers from seeing exported mode constructors like `TranslateMode` as incompatible with `GeoJsonEditModeConstructor`.

Also adds a focused export/type regression in `imports.node.spec.ts` that assigns the common exported mode constructors to `GeoJsonEditModeConstructor[]`, plus release/upgrade notes for TypeScript consumers in `docs/whats-new.md` and `docs/upgrade-guide.md`.

## Classification

Bug fix: TypeScript declaration/API compatibility for editable-layers mode constructors.

Visual proof is not applicable. This is a type-only compatibility fix with no rendered, interactive, or example behavior change.

## Validation

- `yarn`
- `yarn tsc -p modules/editable-layers/tsconfig.json --noEmit`
- `yarn test-node modules/editable-layers/test/imports.node.spec.ts`
- `yarn test-node modules/editable-layers/test`
- `yarn lint`
- `cd website && yarn && yarn build`
- pre-commit `yarn test`: 163 files passed, 1380 tests passed, 9 skipped

Strict-mode reproduction note:

- `yarn tsc -p modules/editable-layers/tsconfig.json --strict --noEmit` still fails on pre-existing internal strictness issues, but no longer reports edit-mode constructor incompatibility or edit-mode `GeoJsonEditMode` override incompatibility. The remaining `TS2416` hits are unrelated widget `deck` nullability overrides.

## Manual verification

No UI route required. Review the generated declarations/build output from `yarn build`, the type assertion in `modules/editable-layers/test/imports.node.spec.ts`, and the v9.4 TypeScript migration note in `docs/upgrade-guide.md`.

## Residual risk

This narrows the public editable data contract away from `GeometryCollection`. That matches the existing `SimpleFeatureCollection` edit-mode implementation and avoids promising support for geometries the edit logic does not handle.
