### PR TITLE
fix(editable-layers): use named turf imports to fix .default is not a function in CJS/esbuild consumers

### DIFF
--- a/modules/editable-layers/src/edit-modes/coordinate-system.ts
+++ b/modules/editable-layers/src/edit-modes/coordinate-system.ts
@@ -4,8 +4,8 @@
 
 import {bearing as turfBearing} from '@turf/bearing';
 import {distance as turfDistance} from '@turf/distance';
-import {destination as turfDestination} from '@turf/destination';
-import {midpoint as turfMidpoint} from '@turf/midpoint';
+import {destination} from '@turf/destination';
+import {midpoint} from '@turf/midpoint';
 import {point} from '@turf/helpers';
 import {COORDINATE_SYSTEM} from '@deck.gl/core';
 import type {CoordinateSystem} from '@deck.gl/core';
@@ -66,11 +66,11 @@ export class GeoCoordinateSystem implements EditModeCoordinateSystem {
   }
 
   destination(origin: Position, distance: number, bearing: number): Position {
-    return turfDestination(point(origin), distance, bearing).geometry.coordinates;
+    return destination(point(origin), distance, bearing).geometry.coordinates;
   }
 
   midpoint(a: Position, b: Position): Position {
-    return turfMidpoint(point(a), point(b)).geometry.coordinates;
+    return midpoint(point(a), point(b)).geometry.coordinates;
   }
 }
 

--- a/modules/editable-layers/src/edit-modes/coordinate-system.ts
+++ b/modules/editable-layers/src/edit-modes/coordinate-system.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfBearing from '@turf/bearing';
-import turfDistance from '@turf/distance';
-import turfDestination from '@turf/destination';
-import turfMidpoint from '@turf/midpoint';
+import {bearing as turfBearing} from '@turf/bearing';
+import {distance as turfDistance} from '@turf/distance';
+import {destination as turfDestination} from '@turf/destination';
+import {midpoint as turfMidpoint} from '@turf/midpoint';
 import {point} from '@turf/helpers';
 import {COORDINATE_SYSTEM} from '@deck.gl/core';
 import type {CoordinateSystem} from '@deck.gl/core';

--- a/modules/editable-layers/src/edit-modes/draw-90degree-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-90degree-polygon-mode.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {destination as turfDestination} from '@turf/destination';
-import {bearing as turfBearing} from '@turf/bearing';
-import {lineIntersect as turfLineIntersect} from '@turf/line-intersect';
+import {destination} from '@turf/destination';
+import {bearing} from '@turf/bearing';
+import {lineIntersect} from '@turf/line-intersect';
 import {distance as turfDistance} from '@turf/distance';
 import {point, lineString as turfLineString} from '@turf/helpers';
 import {
@@ -189,10 +189,10 @@ export class Draw90DegreePolygonMode extends GeoJsonEditMode {
     let pt: Position | null = null;
     if (coordinates.length > 4) {
       const [p1, p2] = [...coordinates];
-      const angle1 = turfBearing(p1, p2);
+      const angle1 = bearing(p1, p2);
       const p3 = coordinates[coordinates.length - 3];
       const p4 = coordinates[coordinates.length - 4];
-      const angle2 = turfBearing(p3, p4);
+      const angle2 = bearing(p3, p4);
 
       const angles = {first: [] as number[], second: [] as number[]};
       // calculate 3 right angle points for first and last points in lineString
@@ -210,14 +210,14 @@ export class Draw90DegreePolygonMode extends GeoJsonEditMode {
       [0, 1, 2].forEach(indexFirst => {
         const line1 = turfLineString([
           p1,
-          turfDestination(p1, distance, angles.first[indexFirst]).geometry.coordinates
+          destination(p1, distance, angles.first[indexFirst]).geometry.coordinates
         ]);
         [0, 1, 2].forEach(indexSecond => {
           const line2 = turfLineString([
             p3,
-            turfDestination(p3, distance, angles.second[indexSecond]).geometry.coordinates
+            destination(p3, distance, angles.second[indexSecond]).geometry.coordinates
           ]);
-          const fc = turfLineIntersect(line1, line2);
+          const fc = lineIntersect(line1, line2);
           if (fc && fc.features.length) {
             // found the intersect point
             pt = fc.features[0].geometry.coordinates;

--- a/modules/editable-layers/src/edit-modes/draw-90degree-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-90degree-polygon-mode.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfDestination from '@turf/destination';
-import turfBearing from '@turf/bearing';
-import turfLineIntersect from '@turf/line-intersect';
-import turfDistance from '@turf/distance';
+import {destination as turfDestination} from '@turf/destination';
+import {bearing as turfBearing} from '@turf/bearing';
+import {lineIntersect as turfLineIntersect} from '@turf/line-intersect';
+import {distance as turfDistance} from '@turf/distance';
 import {point, lineString as turfLineString} from '@turf/helpers';
 import {
   generatePointsParallelToLinePoints,

--- a/modules/editable-layers/src/edit-modes/draw-circle-by-diameter-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-circle-by-diameter-mode.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfCircle from '@turf/circle';
-import turfDistance from '@turf/distance';
-import turfArea from '@turf/area';
+import {circle as turfCircle} from '@turf/circle';
+import {distance as turfDistance} from '@turf/distance';
+import {area as turfArea} from '@turf/area';
 import {memoize} from '../utils/memoize';
 import {ModeProps, Tooltip} from './types';
 import {Position, Polygon, Feature, FeatureCollection} from '../utils/geojson-types';

--- a/modules/editable-layers/src/edit-modes/draw-circle-by-diameter-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-circle-by-diameter-mode.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {circle as turfCircle} from '@turf/circle';
-import {distance as turfDistance} from '@turf/distance';
-import {area as turfArea} from '@turf/area';
+import {circle} from '@turf/circle';
+import {distance} from '@turf/distance';
+import {area} from '@turf/area';
 import {memoize} from '../utils/memoize';
 import {ModeProps, Tooltip} from './types';
 import {Position, Polygon, Feature, FeatureCollection} from '../utils/geojson-types';
@@ -28,13 +28,13 @@ export class DrawCircleByDiameterMode extends TwoClickPolygonMode {
 
     const centerCoordinates = getIntermediatePosition(coord1, coord2);
     // setting value of radius as distance of center and other point
-    this.radius = Math.max(turfDistance(coord1, centerCoordinates), 0.001);
+    this.radius = Math.max(distance(coord1, centerCoordinates), 0.001);
     // setting value of diameter as distance of points
-    this.diameter = Math.max(turfDistance(coord1, coord2), 0.001);
+    this.diameter = Math.max(distance(coord1, coord2), 0.001);
     // setting position tooltip as center of circle
     this.position = centerCoordinates;
 
-    const geometry = turfCircle(centerCoordinates, this.radius, options);
+    const geometry = circle(centerCoordinates, this.radius, options);
 
     geometry.properties = geometry.properties || {};
     geometry.properties.shape = 'Circle';
@@ -43,7 +43,7 @@ export class DrawCircleByDiameterMode extends TwoClickPolygonMode {
     geometry.properties.editProperties.radius = {value: this.radius, unit: 'kilometers'};
     geometry.properties.editProperties.center = centerCoordinates;
     // calculate area of circle with turf function
-    this.areaCircle = turfArea(geometry);
+    this.areaCircle = area(geometry);
 
     return geometry;
   }

--- a/modules/editable-layers/src/edit-modes/draw-circle-from-center-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-circle-from-center-mode.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfCircle from '@turf/circle';
-import turfDistance from '@turf/distance';
-import turfArea from '@turf/area';
+import {circle as turfCircle} from '@turf/circle';
+import {distance as turfDistance} from '@turf/distance';
+import {area as turfArea} from '@turf/area';
 import {memoize} from '../utils/memoize';
 import {ModeProps, Tooltip} from './types';
 import {Position, Polygon, Feature, FeatureCollection} from '../utils/geojson-types';

--- a/modules/editable-layers/src/edit-modes/draw-circle-from-center-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-circle-from-center-mode.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {circle as turfCircle} from '@turf/circle';
-import {distance as turfDistance} from '@turf/distance';
-import {area as turfArea} from '@turf/area';
+import {circle} from '@turf/circle';
+import {distance} from '@turf/distance';
+import {area} from '@turf/area';
 import {memoize} from '../utils/memoize';
 import {ModeProps, Tooltip} from './types';
 import {Position, Polygon, Feature, FeatureCollection} from '../utils/geojson-types';
@@ -27,8 +27,8 @@ export class DrawCircleFromCenterMode extends TwoClickPolygonMode {
     }
 
     // setting value of radius as distance of center and other point
-    this.radius = Math.max(turfDistance(coord1, coord2), 0.001);
-    const geometry = turfCircle(coord1, this.radius, options);
+    this.radius = Math.max(distance(coord1, coord2), 0.001);
+    const geometry = circle(coord1, this.radius, options);
 
     geometry.properties = geometry.properties || {};
     geometry.properties.shape = 'Circle';
@@ -37,7 +37,7 @@ export class DrawCircleFromCenterMode extends TwoClickPolygonMode {
     geometry.properties.editProperties.radius = {value: this.radius, unit: 'kilometers'};
     geometry.properties.editProperties.center = coord1;
     // calculate area of circle with turf function
-    this.areaCircle = turfArea(geometry);
+    this.areaCircle = area(geometry);
 
     return geometry;
   }

--- a/modules/editable-layers/src/edit-modes/draw-ellipse-by-bounding-box-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-ellipse-by-bounding-box-mode.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfBboxPolygon from '@turf/bbox-polygon';
-import turfDistance from '@turf/distance';
-import turfEllipse from '@turf/ellipse';
+import {bboxPolygon as turfBboxPolygon} from '@turf/bbox-polygon';
+import {distance as turfDistance} from '@turf/distance';
+import {ellipse as turfEllipse} from '@turf/ellipse';
 import {point} from '@turf/helpers';
 import {Position, Polygon, Feature} from '../utils/geojson-types';
 import {getIntermediatePosition} from './geojson-edit-mode';

--- a/modules/editable-layers/src/edit-modes/draw-ellipse-by-bounding-box-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-ellipse-by-bounding-box-mode.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {bboxPolygon as turfBboxPolygon} from '@turf/bbox-polygon';
-import {distance as turfDistance} from '@turf/distance';
-import {ellipse as turfEllipse} from '@turf/ellipse';
+import {bboxPolygon} from '@turf/bbox-polygon';
+import {distance} from '@turf/distance';
+import {ellipse} from '@turf/ellipse';
 import {point} from '@turf/helpers';
 import {Position, Polygon, Feature} from '../utils/geojson-types';
 import {getIntermediatePosition} from './geojson-edit-mode';
@@ -17,19 +17,13 @@ export class DrawEllipseByBoundingBoxMode extends TwoClickPolygonMode {
     const maxX = Math.max(coord1[0], coord2[0]);
     const maxY = Math.max(coord1[1], coord2[1]);
 
-    const polygonPoints = turfBboxPolygon([minX, minY, maxX, maxY]).geometry.coordinates[0];
+    const polygonPoints = bboxPolygon([minX, minY, maxX, maxY]).geometry.coordinates[0];
     const centerCoordinates = getIntermediatePosition(coord1, coord2);
 
-    const xSemiAxis = Math.max(
-      turfDistance(point(polygonPoints[0]), point(polygonPoints[1])),
-      0.001
-    );
-    const ySemiAxis = Math.max(
-      turfDistance(point(polygonPoints[0]), point(polygonPoints[3])),
-      0.001
-    );
+    const xSemiAxis = Math.max(distance(point(polygonPoints[0]), point(polygonPoints[1])), 0.001);
+    const ySemiAxis = Math.max(distance(point(polygonPoints[0]), point(polygonPoints[3])), 0.001);
 
-    const geometry = turfEllipse(centerCoordinates, xSemiAxis, ySemiAxis, {});
+    const geometry = ellipse(centerCoordinates, xSemiAxis, ySemiAxis, {});
 
     geometry.properties = geometry.properties || {};
     geometry.properties.editProperties = geometry.properties.editProperties || {};

--- a/modules/editable-layers/src/edit-modes/draw-ellipse-using-three-points-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-ellipse-using-three-points-mode.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfDistance from '@turf/distance';
-import turfEllipse from '@turf/ellipse';
-import turfBearing from '@turf/bearing';
+import {distance as turfDistance} from '@turf/distance';
+import {ellipse as turfEllipse} from '@turf/ellipse';
+import {bearing as turfBearing} from '@turf/bearing';
 import {point} from '@turf/helpers';
 import {Position, Polygon, Feature} from '../utils/geojson-types';
 import {getIntermediatePosition} from './geojson-edit-mode';

--- a/modules/editable-layers/src/edit-modes/draw-ellipse-using-three-points-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-ellipse-using-three-points-mode.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {distance as turfDistance} from '@turf/distance';
-import {ellipse as turfEllipse} from '@turf/ellipse';
-import {bearing as turfBearing} from '@turf/bearing';
+import {distance} from '@turf/distance';
+import {ellipse} from '@turf/ellipse';
+import {bearing} from '@turf/bearing';
 import {point} from '@turf/helpers';
 import {Position, Polygon, Feature} from '../utils/geojson-types';
 import {getIntermediatePosition} from './geojson-edit-mode';
@@ -18,10 +18,10 @@ export class DrawEllipseUsingThreePointsMode extends ThreeClickPolygonMode {
     modeConfig: any
   ): Feature<Polygon> | null | undefined {
     const centerCoordinates = getIntermediatePosition(coord1, coord2);
-    const xSemiAxis = Math.max(turfDistance(centerCoordinates, point(coord3)), 0.001);
-    const ySemiAxis = Math.max(turfDistance(coord1, coord2), 0.001) / 2;
-    const options = {angle: turfBearing(coord1, coord2)};
-    const geometry = turfEllipse(centerCoordinates, xSemiAxis, ySemiAxis, options);
+    const xSemiAxis = Math.max(distance(centerCoordinates, point(coord3)), 0.001);
+    const ySemiAxis = Math.max(distance(coord1, coord2), 0.001) / 2;
+    const options = {angle: bearing(coord1, coord2)};
+    const geometry = ellipse(centerCoordinates, xSemiAxis, ySemiAxis, options);
 
     geometry.properties = geometry.properties || {};
     geometry.properties.editProperties = geometry.properties.editProperties || {};

--- a/modules/editable-layers/src/edit-modes/draw-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-polygon-mode.ts
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import lineIntersect from '@turf/line-intersect';
+import {lineIntersect} from '@turf/line-intersect';
 import {polygon as turfPolygon} from '@turf/helpers';
-import booleanWithin from '@turf/boolean-within';
+import {booleanWithin} from '@turf/boolean-within';
 import type {Feature, Geometry, Polygon} from 'geojson';
-import kinks from '@turf/kinks';
+import {kinks} from '@turf/kinks';
 import {
   ClickEvent,
   PointerMoveEvent,

--- a/modules/editable-layers/src/edit-modes/draw-rectangle-from-center-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-rectangle-from-center-mode.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {bboxPolygon as turfBboxPolygon} from '@turf/bbox-polygon';
+import {bboxPolygon} from '@turf/bbox-polygon';
 import {Position, Polygon, Feature} from '../utils/geojson-types';
 import {TwoClickPolygonMode} from './two-click-polygon-mode';
 
@@ -17,7 +17,7 @@ export class DrawRectangleFromCenterMode extends TwoClickPolygonMode {
         ? coord1[1] + Math.abs(coord1[1] - coord2[1])
         : coord1[1] - Math.abs(coord1[1] - coord2[1]);
 
-    const rectangle = turfBboxPolygon([longitude, latitude, coord2[0], coord2[1]]);
+    const rectangle = bboxPolygon([longitude, latitude, coord2[0], coord2[1]]);
     rectangle.properties = rectangle.properties || {};
     rectangle.properties.shape = 'Rectangle';
 

--- a/modules/editable-layers/src/edit-modes/draw-rectangle-from-center-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-rectangle-from-center-mode.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfBboxPolygon from '@turf/bbox-polygon';
+import {bboxPolygon as turfBboxPolygon} from '@turf/bbox-polygon';
 import {Position, Polygon, Feature} from '../utils/geojson-types';
 import {TwoClickPolygonMode} from './two-click-polygon-mode';
 

--- a/modules/editable-layers/src/edit-modes/draw-rectangle-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-rectangle-mode.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {bboxPolygon as turfBboxPolygon} from '@turf/bbox-polygon';
+import {bboxPolygon} from '@turf/bbox-polygon';
 import {Position, Polygon, Feature} from '../utils/geojson-types';
 import {TwoClickPolygonMode} from './two-click-polygon-mode';
 
 export class DrawRectangleMode extends TwoClickPolygonMode {
   getTwoClickPolygon(coord1: Position, coord2: Position, modeConfig: any): Feature<Polygon> {
-    const rectangle = turfBboxPolygon([coord1[0], coord1[1], coord2[0], coord2[1]]);
+    const rectangle = bboxPolygon([coord1[0], coord1[1], coord2[0], coord2[1]]);
     rectangle.properties = rectangle.properties || {};
     rectangle.properties.shape = 'Rectangle';
 

--- a/modules/editable-layers/src/edit-modes/draw-rectangle-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-rectangle-mode.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfBboxPolygon from '@turf/bbox-polygon';
+import {bboxPolygon as turfBboxPolygon} from '@turf/bbox-polygon';
 import {Position, Polygon, Feature} from '../utils/geojson-types';
 import {TwoClickPolygonMode} from './two-click-polygon-mode';
 

--- a/modules/editable-layers/src/edit-modes/draw-square-from-center-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-square-from-center-mode.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {bboxPolygon as turfBboxPolygon} from '@turf/bbox-polygon';
-import {distance as turfDistance} from '@turf/distance';
-import {along as turfAlong} from '@turf/along';
+import {bboxPolygon} from '@turf/bbox-polygon';
+import {distance} from '@turf/distance';
+import {along} from '@turf/along';
 import {point, lineString as turfLineString} from '@turf/helpers';
 import {Position, Polygon, Feature} from '../utils/geojson-types';
 import {TwoClickPolygonMode} from './two-click-polygon-mode';
@@ -16,8 +16,8 @@ export class DrawSquareFromCenterMode extends TwoClickPolygonMode {
     const coord4 = [coord1[0], coord2[1]];
 
     // determine the shortest distance to the origin, which will be the length of each square side
-    const distance1 = turfDistance(point(coord3), point(coord1));
-    const distance2 = turfDistance(point(coord4), point(coord1));
+    const distance1 = distance(point(coord3), point(coord1));
+    const distance2 = distance(point(coord4), point(coord1));
     const shortestDistance = distance1 <= distance2 ? distance1 : distance2;
 
     // determine which coordinate pair of the two is closest to the origin
@@ -27,7 +27,7 @@ export class DrawSquareFromCenterMode extends TwoClickPolygonMode {
     const line = turfLineString([closestPoint, coord2]);
 
     // get the coordinates of the second square vertex
-    const newPoint = turfAlong(line, shortestDistance);
+    const newPoint = along(line, shortestDistance);
     const corner = newPoint.geometry.coordinates;
 
     // determine the longitude and latitude values of the opposite corner
@@ -40,7 +40,7 @@ export class DrawSquareFromCenterMode extends TwoClickPolygonMode {
         ? coord1[1] + Math.abs(coord1[1] - corner[1])
         : coord1[1] - Math.abs(coord1[1] - corner[1]);
 
-    const square = turfBboxPolygon([longitude, latitude, corner[0], corner[1]]);
+    const square = bboxPolygon([longitude, latitude, corner[0], corner[1]]);
     square.properties = square.properties || {};
     square.properties.shape = 'Square';
 

--- a/modules/editable-layers/src/edit-modes/draw-square-from-center-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-square-from-center-mode.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfBboxPolygon from '@turf/bbox-polygon';
-import turfDistance from '@turf/distance';
-import turfAlong from '@turf/along';
+import {bboxPolygon as turfBboxPolygon} from '@turf/bbox-polygon';
+import {distance as turfDistance} from '@turf/distance';
+import {along as turfAlong} from '@turf/along';
 import {point, lineString as turfLineString} from '@turf/helpers';
 import {Position, Polygon, Feature} from '../utils/geojson-types';
 import {TwoClickPolygonMode} from './two-click-polygon-mode';

--- a/modules/editable-layers/src/edit-modes/draw-square-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-square-mode.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {bboxPolygon as turfBboxPolygon} from '@turf/bbox-polygon';
-import {distance as turfDistance} from '@turf/distance';
-import {along as turfAlong} from '@turf/along';
+import {bboxPolygon} from '@turf/bbox-polygon';
+import {distance} from '@turf/distance';
+import {along} from '@turf/along';
 import {point, lineString as turfLineString} from '@turf/helpers';
 import {Position, Polygon, Feature} from '../utils/geojson-types';
 import {TwoClickPolygonMode} from './two-click-polygon-mode';
@@ -16,8 +16,8 @@ export class DrawSquareMode extends TwoClickPolygonMode {
     const coord4 = [coord1[0], coord2[1]];
 
     // determine the shortest distance to the origin, which will be the length of each square side
-    const distance1 = turfDistance(point(coord3), point(coord1));
-    const distance2 = turfDistance(point(coord4), point(coord1));
+    const distance1 = distance(point(coord3), point(coord1));
+    const distance2 = distance(point(coord4), point(coord1));
     const shortestDistance = distance1 <= distance2 ? distance1 : distance2;
 
     // determine which coordinate pair of the two is closest to the origin
@@ -27,10 +27,10 @@ export class DrawSquareMode extends TwoClickPolygonMode {
     const line = turfLineString([closestPoint, coord2]);
 
     // get the coordinates of the second square vertex
-    const newPoint = turfAlong(line, shortestDistance);
+    const newPoint = along(line, shortestDistance);
     const corner = newPoint.geometry.coordinates;
 
-    const square = turfBboxPolygon([coord1[0], coord1[1], corner[0], corner[1]]);
+    const square = bboxPolygon([coord1[0], coord1[1], corner[0], corner[1]]);
     square.properties = square.properties || {};
     square.properties.shape = 'Square';
 

--- a/modules/editable-layers/src/edit-modes/draw-square-mode.ts
+++ b/modules/editable-layers/src/edit-modes/draw-square-mode.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfBboxPolygon from '@turf/bbox-polygon';
-import turfDistance from '@turf/distance';
-import turfAlong from '@turf/along';
+import {bboxPolygon as turfBboxPolygon} from '@turf/bbox-polygon';
+import {distance as turfDistance} from '@turf/distance';
+import {along as turfAlong} from '@turf/along';
 import {point, lineString as turfLineString} from '@turf/helpers';
 import {Position, Polygon, Feature} from '../utils/geojson-types';
 import {TwoClickPolygonMode} from './two-click-polygon-mode';

--- a/modules/editable-layers/src/edit-modes/extrude-mode.ts
+++ b/modules/editable-layers/src/edit-modes/extrude-mode.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {bearing as turfBearing} from '@turf/bearing';
+import {bearing} from '@turf/bearing';
 import {
   generatePointsParallelToLinePoints,
   getPickedEditHandle,
@@ -179,7 +179,7 @@ export class ExtrudeMode extends ModifyMode {
   }
 
   getBearing(p1: any, p2: any) {
-    const angle = turfBearing(p1, p2);
+    const angle = bearing(p1, p2);
     if (angle < 0) {
       return Math.floor(360 + angle);
     }

--- a/modules/editable-layers/src/edit-modes/extrude-mode.ts
+++ b/modules/editable-layers/src/edit-modes/extrude-mode.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfBearing from '@turf/bearing';
+import {bearing as turfBearing} from '@turf/bearing';
 import {
   generatePointsParallelToLinePoints,
   getPickedEditHandle,

--- a/modules/editable-layers/src/edit-modes/geojson-edit-mode.ts
+++ b/modules/editable-layers/src/edit-modes/geojson-edit-mode.ts
@@ -3,10 +3,10 @@
 // Copyright (c) vis.gl contributors
 
 import {featureCollection} from '@turf/helpers';
-import {union as turfUnion} from '@turf/union';
-import {difference as turfDifference} from '@turf/difference';
-import {intersect as turfIntersect} from '@turf/intersect';
-import {rewind as turfRewind} from '@turf/rewind';
+import {union} from '@turf/union';
+import {difference} from '@turf/difference';
+import {intersect} from '@turf/intersect';
+import {rewind} from '@turf/rewind';
 
 import {
   EditAction,
@@ -123,7 +123,7 @@ export class GeoJsonEditMode implements EditMode<FeatureCollection, GuideFeature
 
     const isPolygonal = geometry.type === 'Polygon' || geometry.type === 'MultiPolygon';
     if (isPolygonal) {
-      return turfRewind(feature) as SimpleFeature;
+      return rewind(feature) as SimpleFeature;
     }
 
     return feature;
@@ -222,11 +222,11 @@ export class GeoJsonEditMode implements EditMode<FeatureCollection, GuideFeature
 
       let updatedGeometry: Feature<Polygon | MultiPolygon> | null;
       if (modeConfig.booleanOperation === 'union') {
-        updatedGeometry = turfUnion(featureCollection([selectedFeature, feature]));
+        updatedGeometry = union(featureCollection([selectedFeature, feature]));
       } else if (modeConfig.booleanOperation === 'difference') {
-        updatedGeometry = turfDifference(featureCollection([selectedFeature, feature]));
+        updatedGeometry = difference(featureCollection([selectedFeature, feature]));
       } else if (modeConfig.booleanOperation === 'intersection') {
-        updatedGeometry = turfIntersect(featureCollection([selectedFeature, feature]));
+        updatedGeometry = intersect(featureCollection([selectedFeature, feature]));
       } else {
         // eslint-disable-next-line no-console,no-undef
         console.warn(`Invalid booleanOperation ${modeConfig.booleanOperation}`);

--- a/modules/editable-layers/src/edit-modes/geojson-edit-mode.ts
+++ b/modules/editable-layers/src/edit-modes/geojson-edit-mode.ts
@@ -3,10 +3,10 @@
 // Copyright (c) vis.gl contributors
 
 import {featureCollection} from '@turf/helpers';
-import turfUnion from '@turf/union';
-import turfDifference from '@turf/difference';
-import turfIntersect from '@turf/intersect';
-import turfRewind from '@turf/rewind';
+import {union as turfUnion} from '@turf/union';
+import {difference as turfDifference} from '@turf/difference';
+import {intersect as turfIntersect} from '@turf/intersect';
+import {rewind as turfRewind} from '@turf/rewind';
 
 import {
   EditAction,

--- a/modules/editable-layers/src/edit-modes/measure-angle-mode.ts
+++ b/modules/editable-layers/src/edit-modes/measure-angle-mode.ts
@@ -1,5 +1,5 @@
-import {bearing as turfBearing} from '@turf/bearing';
-import {center as turfCenter} from '@turf/center';
+import {bearing} from '@turf/bearing';
+import {center} from '@turf/center';
 import {memoize} from '../utils/memoize';
 
 import {ClickEvent, PointerMoveEvent, Tooltip, ModeProps, GuideFeatureCollection} from './types';
@@ -27,8 +27,8 @@ export class MeasureAngleMode extends GeoJsonEditMode {
         const {formatTooltip, measurementCallback} = modeConfig || {};
         const units = 'deg';
 
-        const angle1 = turfBearing(vertex, point1);
-        const angle2 = turfBearing(vertex, point2);
+        const angle1 = bearing(vertex, point1);
+        const angle2 = bearing(vertex, point2);
         let angle = Math.abs(angle1 - angle2);
         if (angle > 180) {
           angle = 360 - angle;
@@ -47,7 +47,7 @@ export class MeasureAngleMode extends GeoJsonEditMode {
           measurementCallback(angle);
         }
 
-        const position = turfCenter({
+        const position = center({
           type: 'FeatureCollection',
           features: [point1, point2].map(p => ({
             type: 'Feature',

--- a/modules/editable-layers/src/edit-modes/measure-angle-mode.ts
+++ b/modules/editable-layers/src/edit-modes/measure-angle-mode.ts
@@ -1,5 +1,5 @@
-import turfBearing from '@turf/bearing';
-import turfCenter from '@turf/center';
+import {bearing as turfBearing} from '@turf/bearing';
+import {center as turfCenter} from '@turf/center';
 import {memoize} from '../utils/memoize';
 
 import {ClickEvent, PointerMoveEvent, Tooltip, ModeProps, GuideFeatureCollection} from './types';

--- a/modules/editable-layers/src/edit-modes/measure-area-mode.ts
+++ b/modules/editable-layers/src/edit-modes/measure-area-mode.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfArea from '@turf/area';
-import turfCentroid from '@turf/centroid';
+import {area as turfArea} from '@turf/area';
+import {centroid as turfCentroid} from '@turf/centroid';
 import {ClickEvent, Tooltip, ModeProps} from './types';
 import {FeatureCollection, SimpleFeatureCollection} from '../utils/geojson-types';
 import {DrawPolygonMode} from './draw-polygon-mode';

--- a/modules/editable-layers/src/edit-modes/resize-circle-mode.ts
+++ b/modules/editable-layers/src/edit-modes/resize-circle-mode.ts
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfNearestPointOnLine from '@turf/nearest-point-on-line';
+import {nearestPointOnLine as turfNearestPointOnLine} from '@turf/nearest-point-on-line';
 import {point, lineString as toLineString} from '@turf/helpers';
-import turfCircle from '@turf/circle';
-import turfDistance from '@turf/distance';
-import turfCenter from '@turf/center';
+import {circle as turfCircle} from '@turf/circle';
+import {distance as turfDistance} from '@turf/distance';
+import {center as turfCenter} from '@turf/center';
 import {
   recursivelyTraverseNestedArrays,
   nearestPointOnProjectedLine,

--- a/modules/editable-layers/src/edit-modes/resize-circle-mode.ts
+++ b/modules/editable-layers/src/edit-modes/resize-circle-mode.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {nearestPointOnLine as turfNearestPointOnLine} from '@turf/nearest-point-on-line';
+import {nearestPointOnLine} from '@turf/nearest-point-on-line';
 import {point, lineString as toLineString} from '@turf/helpers';
-import {circle as turfCircle} from '@turf/circle';
-import {distance as turfDistance} from '@turf/distance';
+import {circle} from '@turf/circle';
+import {distance} from '@turf/distance';
 import {center as turfCenter} from '@turf/center';
 import {
   recursivelyTraverseNestedArrays,
@@ -134,7 +134,7 @@ export class ResizeCircleMode extends GeoJsonEditMode {
         'Editing 3D point but modeConfig.viewport not provided. Falling back to 2D logic.'
       );
     }
-    return turfNearestPointOnLine(line, inPoint);
+    return nearestPointOnLine(line, inPoint);
   }
 
   handleDragging(event: DraggingEvent, props: ModeProps<SimpleFeatureCollection>): void {
@@ -149,11 +149,11 @@ export class ResizeCircleMode extends GeoJsonEditMode {
       const feature = this.getSelectedFeature(props);
       const center = turfCenter(feature).geometry.coordinates;
       const numberOfSteps = Object.entries(feature.geometry.coordinates[0]).length - 1;
-      const radius = Math.max(turfDistance(center, event.mapCoords), 0.001);
+      const radius = Math.max(distance(center, event.mapCoords), 0.001);
 
       const {steps = numberOfSteps} = {};
       const options = {steps};
-      const updatedFeature = turfCircle(center, radius, options);
+      const updatedFeature = circle(center, radius, options);
       const geometry = updatedFeature.geometry;
 
       const updatedData = new ImmutableFeatureCollection(props.data)

--- a/modules/editable-layers/src/edit-modes/rotate-mode.ts
+++ b/modules/editable-layers/src/edit-modes/rotate-mode.ts
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {bbox as turfBbox} from '@turf/bbox';
+import {bbox} from '@turf/bbox';
 import {centroid as turfCentroid} from '@turf/centroid';
-import {bearing as turfBearing} from '@turf/bearing';
-import {bboxPolygon as turfBboxPolygon} from '@turf/bbox-polygon';
-import {distance as turfDistance} from '@turf/distance';
+import {bearing} from '@turf/bearing';
+import {bboxPolygon} from '@turf/bbox-polygon';
+import {distance} from '@turf/distance';
 import {coordEach} from '@turf/meta';
 import {getGeom} from '@turf/invariant';
 import {point, featureCollection, lineString} from '@turf/helpers';
-import {transformRotate as turfTransformRotate} from '@turf/transform-rotate';
+import {transformRotate} from '@turf/transform-rotate';
 import {polygonToLine} from '@turf/polygon-to-line';
 import {
   PointerMoveEvent,
@@ -55,7 +55,7 @@ export class RotateMode extends GeoJsonEditMode {
       return featureCollection([turfCentroid(selectedGeometry)]) as GuideFeatureCollection;
     }
 
-    const boundingBox = turfBboxPolygon(turfBbox(selectedGeometry));
+    const boundingBox = bboxPolygon(bbox(selectedGeometry));
 
     let previousCoord: Position | null = null;
     let topEdgeMidpointCoords: Position | null = null;
@@ -69,7 +69,7 @@ export class RotateMode extends GeoJsonEditMode {
           topEdgeMidpointCoords = edgeMidpoint;
         }
         // Get the length of the longest edge of the enveloping box
-        const edgeDistance = turfDistance(coord, previousCoord);
+        const edgeDistance = distance(coord, previousCoord);
         longestEdgeLength = Math.max(longestEdgeLength, edgeDistance);
       }
       previousCoord = coord;
@@ -172,7 +172,7 @@ export class RotateMode extends GeoJsonEditMode {
     }
     const centroid = turfCentroid(this._geometryBeingRotated);
     const angle = getRotationAngle(centroid.geometry.coordinates, startDragPoint, currentPoint);
-    const rotatedFeatures = turfTransformRotate(this._geometryBeingRotated, angle, {
+    const rotatedFeatures = transformRotate(this._geometryBeingRotated, angle, {
       pivot: centroid
     });
 
@@ -196,7 +196,7 @@ export class RotateMode extends GeoJsonEditMode {
 }
 
 function getRotationAngle(centroid: Position, startDragPoint: Position, currentPoint: Position) {
-  const bearing1 = turfBearing(centroid, startDragPoint);
-  const bearing2 = turfBearing(centroid, currentPoint);
+  const bearing1 = bearing(centroid, startDragPoint);
+  const bearing2 = bearing(centroid, currentPoint);
   return bearing2 - bearing1;
 }

--- a/modules/editable-layers/src/edit-modes/rotate-mode.ts
+++ b/modules/editable-layers/src/edit-modes/rotate-mode.ts
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfBbox from '@turf/bbox';
-import turfCentroid from '@turf/centroid';
-import turfBearing from '@turf/bearing';
-import turfBboxPolygon from '@turf/bbox-polygon';
-import turfDistance from '@turf/distance';
+import {bbox as turfBbox} from '@turf/bbox';
+import {centroid as turfCentroid} from '@turf/centroid';
+import {bearing as turfBearing} from '@turf/bearing';
+import {bboxPolygon as turfBboxPolygon} from '@turf/bbox-polygon';
+import {distance as turfDistance} from '@turf/distance';
 import {coordEach} from '@turf/meta';
 import {getGeom} from '@turf/invariant';
 import {point, featureCollection, lineString} from '@turf/helpers';
-import turfTransformRotate from '@turf/transform-rotate';
+import {transformRotate as turfTransformRotate} from '@turf/transform-rotate';
 import {polygonToLine} from '@turf/polygon-to-line';
 import {
   PointerMoveEvent,

--- a/modules/editable-layers/src/edit-modes/scale-mode.ts
+++ b/modules/editable-layers/src/edit-modes/scale-mode.ts
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfBbox from '@turf/bbox';
-import turfCentroid from '@turf/centroid';
-import turfBearing from '@turf/bearing';
-import turfBboxPolygon from '@turf/bbox-polygon';
+import {bbox as turfBbox} from '@turf/bbox';
+import {centroid as turfCentroid} from '@turf/centroid';
+import {bearing as turfBearing} from '@turf/bearing';
+import {bboxPolygon as turfBboxPolygon} from '@turf/bbox-polygon';
 import {point, featureCollection} from '@turf/helpers';
 import {polygonToLine} from '@turf/polygon-to-line';
 import {coordEach} from '@turf/meta';
-import turfDistance from '@turf/distance';
-import turfTransformScale from '@turf/transform-scale';
+import {distance as turfDistance} from '@turf/distance';
+import {transformScale as turfTransformScale} from '@turf/transform-scale';
 import {getCoord, getGeom} from '@turf/invariant';
 import {FeatureCollection, Position, SimpleFeatureCollection} from '../utils/geojson-types';
 import {

--- a/modules/editable-layers/src/edit-modes/scale-mode.ts
+++ b/modules/editable-layers/src/edit-modes/scale-mode.ts
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {bbox as turfBbox} from '@turf/bbox';
+import {bbox} from '@turf/bbox';
 import {centroid as turfCentroid} from '@turf/centroid';
 import {bearing as turfBearing} from '@turf/bearing';
-import {bboxPolygon as turfBboxPolygon} from '@turf/bbox-polygon';
+import {bboxPolygon} from '@turf/bbox-polygon';
 import {point, featureCollection} from '@turf/helpers';
 import {polygonToLine} from '@turf/polygon-to-line';
 import {coordEach} from '@turf/meta';
-import {distance as turfDistance} from '@turf/distance';
-import {transformScale as turfTransformScale} from '@turf/transform-scale';
+import {distance} from '@turf/distance';
+import {transformScale} from '@turf/transform-scale';
 import {getCoord, getGeom} from '@turf/invariant';
 import {FeatureCollection, Position, SimpleFeatureCollection} from '../utils/geojson-types';
 import {
@@ -95,7 +95,7 @@ export class ScaleMode extends GeoJsonEditMode {
 
     const scaleFactor = getScaleFactor(origin, startDragPoint, currentPoint);
 
-    const scaledFeatures = turfTransformScale(this._geometryBeingScaled, scaleFactor, {origin});
+    const scaledFeatures = transformScale(this._geometryBeingScaled, scaleFactor, {origin});
 
     return {
       updatedData: this._getUpdatedData(props, scaledFeatures),
@@ -204,7 +204,7 @@ export class ScaleMode extends GeoJsonEditMode {
       return {type: 'FeatureCollection', features: []};
     }
 
-    const boundingBox = turfBboxPolygon(turfBbox(selectedGeometry));
+    const boundingBox = bboxPolygon(bbox(selectedGeometry));
     boundingBox.properties.mode = 'scale';
     const cornerGuidePoints: EditHandleFeature[] = [];
 
@@ -227,7 +227,7 @@ export class ScaleMode extends GeoJsonEditMode {
 }
 
 function getScaleFactor(centroid: Position, startDragPoint: Position, currentPoint: Position) {
-  const startDistance = turfDistance(centroid, startDragPoint);
-  const endDistance = turfDistance(centroid, currentPoint);
+  const startDistance = distance(centroid, startDragPoint);
+  const endDistance = distance(centroid, currentPoint);
   return endDistance / startDistance;
 }

--- a/modules/editable-layers/src/edit-modes/split-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/split-polygon-mode.ts
@@ -3,15 +3,15 @@
 // Copyright (c) vis.gl contributors
 
 import {booleanPointInPolygon} from '@turf/boolean-point-in-polygon';
-import {difference as turfDifference} from '@turf/difference';
+import {difference} from '@turf/difference';
 import {buffer as turfBuffer} from '@turf/buffer';
 import {lineIntersect} from '@turf/line-intersect';
 import type {Point} from 'geojson';
 import {feature as turfFeature, featureCollection, lineString} from '@turf/helpers';
-import {bearing as turfBearing} from '@turf/bearing';
-import {distance as turfDistance} from '@turf/distance';
-import {destination as turfDestination} from '@turf/destination';
-import {polygonToLine as turfPolygonToLine} from '@turf/polygon-to-line';
+import {bearing} from '@turf/bearing';
+import {distance} from '@turf/distance';
+import {destination} from '@turf/destination';
+import {polygonToLine} from '@turf/polygon-to-line';
 import {nearestPointOnLine} from '@turf/nearest-point-on-line';
 import {generatePointsParallelToLinePoints} from './utils';
 import {FeatureCollection, PolygonGeometry, SimpleFeatureCollection} from '../utils/geojson-types';
@@ -39,7 +39,7 @@ export class SplitPolygonMode extends GeoJsonEditMode {
       // if first point is clicked, then find closest polygon point and build ~90deg vector
       const firstPoint = clickSequence[0];
       const selectedGeometry = this.getSelectedGeometry(props);
-      const feature = turfPolygonToLine(selectedGeometry as PolygonGeometry);
+      const feature = polygonToLine(selectedGeometry as PolygonGeometry);
 
       const lines = feature.type === 'FeatureCollection' ? feature.features : [feature];
       let minDistance = Number.MAX_SAFE_INTEGER;
@@ -47,7 +47,7 @@ export class SplitPolygonMode extends GeoJsonEditMode {
       // If Multipolygon, then we should find nearest polygon line and stick split to it.
       lines.forEach(line => {
         const snapPoint = nearestPointOnLine(line, firstPoint);
-        const distanceFromOrigin = turfDistance(snapPoint, firstPoint);
+        const distanceFromOrigin = distance(snapPoint, firstPoint);
         if (minDistance > distanceFromOrigin) {
           minDistance = distanceFromOrigin;
           closestPoint = snapPoint;
@@ -56,9 +56,9 @@ export class SplitPolygonMode extends GeoJsonEditMode {
 
       if (closestPoint) {
         // closest point is used as 90degree entry to the polygon
-        const lastBearing = turfBearing(firstPoint, closestPoint);
-        const currentDistance = turfDistance(firstPoint, mapCoords, {units: 'meters'});
-        return turfDestination(firstPoint, currentDistance, lastBearing, {
+        const lastBearing = bearing(firstPoint, closestPoint);
+        const currentDistance = distance(firstPoint, mapCoords, {units: 'meters'});
+        return destination(firstPoint, currentDistance, lastBearing, {
           units: 'meters'
         }).geometry.coordinates;
       }
@@ -165,7 +165,7 @@ export class SplitPolygonMode extends GeoJsonEditMode {
     }
 
     const buffer = turfBuffer(tentativeFeature, gap, {units});
-    const updatedGeometry = turfDifference(
+    const updatedGeometry = difference(
       featureCollection([turfFeature(selectedGeometry as PolygonGeometry), buffer])
     );
     if (!updatedGeometry) {

--- a/modules/editable-layers/src/edit-modes/split-polygon-mode.ts
+++ b/modules/editable-layers/src/edit-modes/split-polygon-mode.ts
@@ -2,17 +2,17 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
-import turfDifference from '@turf/difference';
-import turfBuffer from '@turf/buffer';
-import lineIntersect from '@turf/line-intersect';
+import {booleanPointInPolygon} from '@turf/boolean-point-in-polygon';
+import {difference as turfDifference} from '@turf/difference';
+import {buffer as turfBuffer} from '@turf/buffer';
+import {lineIntersect} from '@turf/line-intersect';
 import type {Point} from 'geojson';
 import {feature as turfFeature, featureCollection, lineString} from '@turf/helpers';
-import turfBearing from '@turf/bearing';
-import turfDistance from '@turf/distance';
-import turfDestination from '@turf/destination';
-import turfPolygonToLine from '@turf/polygon-to-line';
-import nearestPointOnLine from '@turf/nearest-point-on-line';
+import {bearing as turfBearing} from '@turf/bearing';
+import {distance as turfDistance} from '@turf/distance';
+import {destination as turfDestination} from '@turf/destination';
+import {polygonToLine as turfPolygonToLine} from '@turf/polygon-to-line';
+import {nearestPointOnLine} from '@turf/nearest-point-on-line';
 import {generatePointsParallelToLinePoints} from './utils';
 import {FeatureCollection, PolygonGeometry, SimpleFeatureCollection} from '../utils/geojson-types';
 import {

--- a/modules/editable-layers/src/edit-modes/translate-mode.ts
+++ b/modules/editable-layers/src/edit-modes/translate-mode.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {clone as turfClone} from '@turf/clone';
+import {clone} from '@turf/clone';
 import {WebMercatorViewport} from '@math.gl/web-mercator';
 import {
   FeatureCollection,
@@ -146,7 +146,7 @@ export class TranslateMode extends GeoJsonEditMode {
       const direction = coordinateSystem.bearing(startDragPoint, currentPoint);
 
       const movedFeatures = this._geometryBeforeTranslate.features.map(feature =>
-        translateFromCenter(turfClone(feature), distanceMoved, direction, coordinateSystem)
+        translateFromCenter(clone(feature), distanceMoved, direction, coordinateSystem)
       );
 
       for (let i = 0; i < selectedIndexes.length; i++) {

--- a/modules/editable-layers/src/edit-modes/translate-mode.ts
+++ b/modules/editable-layers/src/edit-modes/translate-mode.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfClone from '@turf/clone';
+import {clone as turfClone} from '@turf/clone';
 import {WebMercatorViewport} from '@math.gl/web-mercator';
 import {
   FeatureCollection,

--- a/modules/editable-layers/src/edit-modes/utils.ts
+++ b/modules/editable-layers/src/edit-modes/utils.ts
@@ -4,9 +4,9 @@
 
 /* eslint-disable no-shadow */
 
-import turfDestination from '@turf/destination';
-import turfBearing from '@turf/bearing';
-import turfPointToLineDistance from '@turf/point-to-line-distance';
+import {destination as turfDestination} from '@turf/destination';
+import {bearing as turfBearing} from '@turf/bearing';
+import {pointToLineDistance as turfPointToLineDistance} from '@turf/point-to-line-distance';
 import {point} from '@turf/helpers';
 import {getCoords} from '@turf/invariant';
 import {WebMercatorViewport} from '@math.gl/web-mercator';

--- a/modules/editable-layers/src/edit-modes/utils.ts
+++ b/modules/editable-layers/src/edit-modes/utils.ts
@@ -4,9 +4,9 @@
 
 /* eslint-disable no-shadow */
 
-import {destination as turfDestination} from '@turf/destination';
-import {bearing as turfBearing} from '@turf/bearing';
-import {pointToLineDistance as turfPointToLineDistance} from '@turf/point-to-line-distance';
+import {destination} from '@turf/destination';
+import {bearing} from '@turf/bearing';
+import {pointToLineDistance} from '@turf/point-to-line-distance';
 import {point} from '@turf/helpers';
 import {getCoords} from '@turf/invariant';
 import {WebMercatorViewport} from '@math.gl/web-mercator';
@@ -93,8 +93,8 @@ export function generatePointsParallelToLinePoints(
     coordinates: [p1, p2]
   };
   const pt = point(coords);
-  const ddistance = turfPointToLineDistance(pt, lineString);
-  const lineBearing = turfBearing(p1, p2);
+  const ddistance = pointToLineDistance(pt, lineString);
+  const lineBearing = bearing(p1, p2);
 
   // Check if current point is to the left or right of line
   // Line from A=(x1,y1) to B=(x2,y2) a point P=(x,y)
@@ -107,8 +107,8 @@ export function generatePointsParallelToLinePoints(
 
   // Get coordinates for the point p3 and p4 which are perpendicular to the lineString
   // Add the distance as the current position moves away from the lineString
-  const p3 = turfDestination(p2, ddistance, orthogonalBearing);
-  const p4 = turfDestination(p1, ddistance, orthogonalBearing);
+  const p3 = destination(p2, ddistance, orthogonalBearing);
+  const p4 = destination(p1, ddistance, orthogonalBearing);
 
   return [p3.geometry.coordinates, p4.geometry.coordinates] as Position[];
 }

--- a/modules/editable-layers/src/editable-layers/selection-layer.ts
+++ b/modules/editable-layers/src/editable-layers/selection-layer.ts
@@ -8,8 +8,8 @@ import type {CompositeLayerProps, DefaultProps} from '@deck.gl/core';
 import {CompositeLayer} from '@deck.gl/core';
 import {PolygonLayer} from '@deck.gl/layers';
 import {featureCollection, polygon} from '@turf/helpers';
-import turfBuffer from '@turf/buffer';
-import turfDifference from '@turf/difference';
+import {buffer as turfBuffer} from '@turf/buffer';
+import {difference as turfDifference} from '@turf/difference';
 
 import {EditableGeoJsonLayer} from './editable-geojson-layer';
 import {DrawRectangleMode} from '../edit-modes/draw-rectangle-mode';

--- a/modules/editable-layers/src/editable-layers/selection-layer.ts
+++ b/modules/editable-layers/src/editable-layers/selection-layer.ts
@@ -8,8 +8,8 @@ import type {CompositeLayerProps, DefaultProps} from '@deck.gl/core';
 import {CompositeLayer} from '@deck.gl/core';
 import {PolygonLayer} from '@deck.gl/layers';
 import {featureCollection, polygon} from '@turf/helpers';
-import {buffer as turfBuffer} from '@turf/buffer';
-import {difference as turfDifference} from '@turf/difference';
+import {buffer} from '@turf/buffer';
+import {difference} from '@turf/difference';
 
 import {EditableGeoJsonLayer} from './editable-geojson-layer';
 import {DrawRectangleMode} from '../edit-modes/draw-rectangle-mode';
@@ -83,7 +83,7 @@ export class SelectionLayer<DataT, ExtraPropsT> extends CompositeLayer<
 
   state: {
     pendingPolygonSelection: {
-      bigPolygon: ReturnType<typeof turfDifference>;
+      bigPolygon: ReturnType<typeof difference>;
     };
   } = undefined!;
 
@@ -116,12 +116,12 @@ export class SelectionLayer<DataT, ExtraPropsT> extends CompositeLayer<
     // Use a polygon to hide the outside, because pickObjects()
     // does not support polygons
     const landPointsPoly = polygon(coordinates);
-    const bigBuffer = turfBuffer(landPointsPoly, EXPANSION_KM);
+    const bigBuffer = buffer(landPointsPoly, EXPANSION_KM);
     let bigPolygon;
     try {
       // turfDifference throws an exception if the polygon
       // intersects with itself (TODO: check if true in all versions)
-      bigPolygon = turfDifference(featureCollection([bigBuffer, landPointsPoly]));
+      bigPolygon = difference(featureCollection([bigBuffer, landPointsPoly]));
     } catch (e) {
       // invalid selection polygon
       console.log('turfDifference() error', e); // eslint-disable-line

--- a/modules/editable-layers/src/mode-handlers/draw-90degree-polygon-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/draw-90degree-polygon-handler.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import destination from '@turf/destination';
-import bearing from '@turf/bearing';
-import lineIntersect from '@turf/line-intersect';
-import turfDistance from '@turf/distance';
+import {destination} from '@turf/destination';
+import {bearing} from '@turf/bearing';
+import {lineIntersect} from '@turf/line-intersect';
+import {distance as turfDistance} from '@turf/distance';
 import {point, lineString} from '@turf/helpers';
 import {Polygon, Position} from '../utils/geojson-types';
 import {generatePointsParallelToLinePoints} from '../utils/utils';

--- a/modules/editable-layers/src/mode-handlers/draw-circle-by-bounding-box-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/draw-circle-by-bounding-box-handler.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import circle from '@turf/circle';
-import distance from '@turf/distance';
+import {circle} from '@turf/circle';
+import {distance} from '@turf/distance';
 import {PointerMoveEvent} from '../edit-modes/types';
 import {EditAction, getIntermediatePosition} from './mode-handler';
 import {TwoClickPolygonHandler} from './two-click-polygon-handler';

--- a/modules/editable-layers/src/mode-handlers/draw-circle-from-center-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/draw-circle-from-center-handler.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import circle from '@turf/circle';
-import distance from '@turf/distance';
+import {circle} from '@turf/circle';
+import {distance} from '@turf/distance';
 import {PointerMoveEvent} from '../edit-modes/types';
 import {EditAction} from './mode-handler';
 import {TwoClickPolygonHandler} from './two-click-polygon-handler';

--- a/modules/editable-layers/src/mode-handlers/draw-ellipse-by-bounding-box-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/draw-ellipse-by-bounding-box-handler.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import bboxPolygon from '@turf/bbox-polygon';
-import distance from '@turf/distance';
-import ellipse from '@turf/ellipse';
+import {bboxPolygon} from '@turf/bbox-polygon';
+import {distance} from '@turf/distance';
+import {ellipse} from '@turf/ellipse';
 import {point} from '@turf/helpers';
 import {PointerMoveEvent} from '../edit-modes/types';
 import {EditAction, getIntermediatePosition} from './mode-handler';

--- a/modules/editable-layers/src/mode-handlers/draw-ellipse-using-three-points-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/draw-ellipse-using-three-points-handler.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import distance from '@turf/distance';
-import ellipse from '@turf/ellipse';
-import bearing from '@turf/bearing';
+import {distance} from '@turf/distance';
+import {ellipse} from '@turf/ellipse';
+import {bearing} from '@turf/bearing';
 import {point} from '@turf/helpers';
 import {PointerMoveEvent} from '../edit-modes/types';
 import {EditAction, getIntermediatePosition} from './mode-handler';

--- a/modules/editable-layers/src/mode-handlers/draw-rectangle-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/draw-rectangle-handler.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import bboxPolygon from '@turf/bbox-polygon';
+import {bboxPolygon} from '@turf/bbox-polygon';
 import {PointerMoveEvent} from '../edit-modes/types';
 import {EditAction} from './mode-handler';
 import {TwoClickPolygonHandler} from './two-click-polygon-handler';

--- a/modules/editable-layers/src/mode-handlers/extrude-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/extrude-handler.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import bearing from '@turf/bearing';
+import {bearing} from '@turf/bearing';
 import {generatePointsParallelToLinePoints} from '../utils/utils';
 import {PointerMoveEvent, StartDraggingEvent, StopDraggingEvent} from '../edit-modes/types';
 import {EditAction, getPickedEditHandle} from './mode-handler';

--- a/modules/editable-layers/src/mode-handlers/mode-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/mode-handler.ts
@@ -5,9 +5,9 @@
 // TODO edit-modes: delete handlers once EditMode fully implemented
 
 import {featureCollection as turfFeatureCollection} from '@turf/helpers';
-import turfUnion from '@turf/union';
-import turfDifference from '@turf/difference';
-import turfIntersect from '@turf/intersect';
+import {union as turfUnion} from '@turf/union';
+import {difference as turfDifference} from '@turf/difference';
+import {intersect as turfIntersect} from '@turf/intersect';
 
 import {
   FeatureCollection,

--- a/modules/editable-layers/src/mode-handlers/mode-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/mode-handler.ts
@@ -5,9 +5,9 @@
 // TODO edit-modes: delete handlers once EditMode fully implemented
 
 import {featureCollection as turfFeatureCollection} from '@turf/helpers';
-import {union as turfUnion} from '@turf/union';
-import {difference as turfDifference} from '@turf/difference';
-import {intersect as turfIntersect} from '@turf/intersect';
+import {union} from '@turf/union';
+import {difference} from '@turf/difference';
+import {intersect} from '@turf/intersect';
 
 import {
   FeatureCollection,
@@ -236,15 +236,15 @@ export class ModeHandler {
 
       let updatedGeometry;
       if (modeConfig.booleanOperation === 'union') {
-        updatedGeometry = turfUnion(
+        updatedGeometry = union(
           turfFeatureCollection([selectedFeature as Feature<PolygonGeometry>, feature])
         );
       } else if (modeConfig.booleanOperation === 'difference') {
-        updatedGeometry = turfDifference(
+        updatedGeometry = difference(
           turfFeatureCollection([selectedFeature as Feature<PolygonGeometry>, feature])
         );
       } else if (modeConfig.booleanOperation === 'intersection') {
-        updatedGeometry = turfIntersect(
+        updatedGeometry = intersect(
           turfFeatureCollection([selectedFeature as Feature<PolygonGeometry>, feature])
         );
       } else {

--- a/modules/editable-layers/src/mode-handlers/modify-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/modify-handler.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import nearestPointOnLine from '@turf/nearest-point-on-line';
+import {nearestPointOnLine} from '@turf/nearest-point-on-line';
 import {point, lineString as toLineString} from '@turf/helpers';
 import {Position, Feature, Point, LineString} from '../utils/geojson-types';
 import {

--- a/modules/editable-layers/src/mode-handlers/rotate-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/rotate-handler.ts
@@ -3,8 +3,8 @@
 // Copyright (c) vis.gl contributors
 
 import {centroid as turfCentroid} from '@turf/centroid';
-import {bearing as turfBearing} from '@turf/bearing';
-import {transformRotate as turfTransformRotate} from '@turf/transform-rotate';
+import {bearing} from '@turf/bearing';
+import {transformRotate} from '@turf/transform-rotate';
 import {SimpleFeatureCollection, Position} from '../utils/geojson-types';
 import {PointerMoveEvent, StartDraggingEvent, StopDraggingEvent} from '../edit-modes/types';
 import {EditAction, ModeHandler} from './mode-handler';
@@ -69,7 +69,7 @@ export class RotateHandler extends ModeHandler {
     const centroid = turfCentroid(this._geometryBeingRotated);
     const angle = getRotationAngle(centroid.geometry.coordinates, startPosition, currentPoint);
 
-    const rotatedFeatures = turfTransformRotate(this._geometryBeingRotated, angle);
+    const rotatedFeatures = transformRotate(this._geometryBeingRotated, angle);
 
     let updatedData = this.getImmutableFeatureCollection();
 
@@ -90,7 +90,7 @@ export class RotateHandler extends ModeHandler {
 }
 
 function getRotationAngle(centroid: Position, startDragPoint: Position, currentPoint: Position) {
-  const bearing1 = turfBearing(centroid, startDragPoint);
-  const bearing2 = turfBearing(centroid, currentPoint);
+  const bearing1 = bearing(centroid, startDragPoint);
+  const bearing2 = bearing(centroid, currentPoint);
   return bearing2 - bearing1;
 }

--- a/modules/editable-layers/src/mode-handlers/rotate-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/rotate-handler.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfCentroid from '@turf/centroid';
-import turfBearing from '@turf/bearing';
-import turfTransformRotate from '@turf/transform-rotate';
+import {centroid as turfCentroid} from '@turf/centroid';
+import {bearing as turfBearing} from '@turf/bearing';
+import {transformRotate as turfTransformRotate} from '@turf/transform-rotate';
 import {SimpleFeatureCollection, Position} from '../utils/geojson-types';
 import {PointerMoveEvent, StartDraggingEvent, StopDraggingEvent} from '../edit-modes/types';
 import {EditAction, ModeHandler} from './mode-handler';

--- a/modules/editable-layers/src/mode-handlers/scale-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/scale-handler.ts
@@ -3,8 +3,8 @@
 // Copyright (c) vis.gl contributors
 
 import {centroid as turfCentroid} from '@turf/centroid';
-import {distance as turfDistance} from '@turf/distance';
-import {transformScale as turfTransformScale} from '@turf/transform-scale';
+import {distance} from '@turf/distance';
+import {transformScale} from '@turf/transform-scale';
 import {SimpleFeatureCollection, Position} from '../utils/geojson-types';
 import {PointerMoveEvent, StartDraggingEvent, StopDraggingEvent} from '../edit-modes/types';
 import {EditAction, ModeHandler} from './mode-handler';
@@ -68,7 +68,7 @@ export class ScaleHandler extends ModeHandler {
     const startPosition = startDragPoint;
     const centroid = turfCentroid(this._geometryBeingScaled);
     const factor = getScaleFactor(centroid.geometry.coordinates, startPosition, currentPoint);
-    const scaledFeatures = turfTransformScale(this._geometryBeingScaled, factor, {
+    const scaledFeatures = transformScale(this._geometryBeingScaled, factor, {
       origin: centroid
     });
 
@@ -91,7 +91,7 @@ export class ScaleHandler extends ModeHandler {
 }
 
 function getScaleFactor(centroid: Position, startDragPoint: Position, currentPoint: Position) {
-  const startDistance = turfDistance(centroid, startDragPoint);
-  const endDistance = turfDistance(centroid, currentPoint);
+  const startDistance = distance(centroid, startDragPoint);
+  const endDistance = distance(centroid, currentPoint);
   return endDistance / startDistance;
 }

--- a/modules/editable-layers/src/mode-handlers/scale-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/scale-handler.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfCentroid from '@turf/centroid';
-import turfDistance from '@turf/distance';
-import turfTransformScale from '@turf/transform-scale';
+import {centroid as turfCentroid} from '@turf/centroid';
+import {distance as turfDistance} from '@turf/distance';
+import {transformScale as turfTransformScale} from '@turf/transform-scale';
 import {SimpleFeatureCollection, Position} from '../utils/geojson-types';
 import {PointerMoveEvent, StartDraggingEvent, StopDraggingEvent} from '../edit-modes/types';
 import {EditAction, ModeHandler} from './mode-handler';

--- a/modules/editable-layers/src/mode-handlers/split-polygon-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/split-polygon-handler.ts
@@ -3,14 +3,14 @@
 // Copyright (c) vis.gl contributors
 
 import {booleanPointInPolygon} from '@turf/boolean-point-in-polygon';
-import {difference as turfDifference} from '@turf/difference';
+import {difference} from '@turf/difference';
 import {buffer as turfBuffer} from '@turf/buffer';
 import {lineIntersect} from '@turf/line-intersect';
 import {feature as turfFeature, featureCollection, lineString} from '@turf/helpers';
-import {bearing as turfBearing} from '@turf/bearing';
-import {distance as turfDistance} from '@turf/distance';
-import {destination as turfDestination} from '@turf/destination';
-import {polygonToLine as turfPolygonToLine} from '@turf/polygon-to-line';
+import {bearing} from '@turf/bearing';
+import {distance} from '@turf/distance';
+import {destination} from '@turf/destination';
+import {polygonToLine} from '@turf/polygon-to-line';
 import {nearestPointOnLine} from '@turf/nearest-point-on-line';
 import {generatePointsParallelToLinePoints} from '../utils/utils';
 import {EditAction, ModeHandler} from './mode-handler';
@@ -29,7 +29,7 @@ export class SplitPolygonHandler extends ModeHandler {
       const firstPoint = clickSequence[0];
       const selectedGeometry = this.getSelectedGeometry();
       // @ts-expect-error turf type diff
-      const feature = turfPolygonToLine(selectedGeometry);
+      const feature = polygonToLine(selectedGeometry);
 
       const lines = feature.type === 'FeatureCollection' ? feature.features : [feature];
       let minDistance = Number.MAX_SAFE_INTEGER;
@@ -37,7 +37,7 @@ export class SplitPolygonHandler extends ModeHandler {
       // If Multipolygon, then we should find nearest polygon line and stick split to it.
       lines.forEach(line => {
         const snapPoint = nearestPointOnLine(line, firstPoint);
-        const distanceFromOrigin = turfDistance(snapPoint, firstPoint);
+        const distanceFromOrigin = distance(snapPoint, firstPoint);
         if (minDistance > distanceFromOrigin) {
           minDistance = distanceFromOrigin;
           closestPoint = snapPoint;
@@ -46,9 +46,9 @@ export class SplitPolygonHandler extends ModeHandler {
 
       if (closestPoint) {
         // closest point is used as 90degree entry to the polygon
-        const lastBearing = turfBearing(firstPoint, closestPoint);
-        const currentDistance = turfDistance(firstPoint, mapCoords, {units: 'meters'});
-        return turfDestination(firstPoint, currentDistance, lastBearing, {
+        const lastBearing = bearing(firstPoint, closestPoint);
+        const currentDistance = distance(firstPoint, mapCoords, {units: 'meters'});
+        return destination(firstPoint, currentDistance, lastBearing, {
           units: 'meters'
         }).geometry.coordinates;
       }
@@ -140,7 +140,7 @@ export class SplitPolygonHandler extends ModeHandler {
       units = 'centimeters';
     }
     const buffer = turfBuffer(tentativeFeature, gap, {units});
-    const updatedGeometry = turfDifference(
+    const updatedGeometry = difference(
       featureCollection([turfFeature(selectedGeometry as PolygonGeometry), buffer])
     );
     this._setTentativeFeature(null);

--- a/modules/editable-layers/src/mode-handlers/split-polygon-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/split-polygon-handler.ts
@@ -2,16 +2,16 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
-import turfDifference from '@turf/difference';
-import turfBuffer from '@turf/buffer';
-import lineIntersect from '@turf/line-intersect';
+import {booleanPointInPolygon} from '@turf/boolean-point-in-polygon';
+import {difference as turfDifference} from '@turf/difference';
+import {buffer as turfBuffer} from '@turf/buffer';
+import {lineIntersect} from '@turf/line-intersect';
 import {feature as turfFeature, featureCollection, lineString} from '@turf/helpers';
-import turfBearing from '@turf/bearing';
-import turfDistance from '@turf/distance';
-import turfDestination from '@turf/destination';
-import turfPolygonToLine from '@turf/polygon-to-line';
-import nearestPointOnLine from '@turf/nearest-point-on-line';
+import {bearing as turfBearing} from '@turf/bearing';
+import {distance as turfDistance} from '@turf/distance';
+import {destination as turfDestination} from '@turf/destination';
+import {polygonToLine as turfPolygonToLine} from '@turf/polygon-to-line';
+import {nearestPointOnLine} from '@turf/nearest-point-on-line';
 import {generatePointsParallelToLinePoints} from '../utils/utils';
 import {EditAction, ModeHandler} from './mode-handler';
 import {ClickEvent, PointerMoveEvent} from '../edit-modes/types';

--- a/modules/editable-layers/src/mode-handlers/translate-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/translate-handler.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {bearing as turfBearing} from '@turf/bearing';
-import {distance as turfDistance} from '@turf/distance';
-import {transformTranslate as turfTransformTranslate} from '@turf/transform-translate';
+import {bearing} from '@turf/bearing';
+import {distance} from '@turf/distance';
+import {transformTranslate} from '@turf/transform-translate';
 import {point} from '@turf/helpers';
 import {SimpleFeatureCollection, Position} from '../utils/geojson-types';
 import {PointerMoveEvent, StartDraggingEvent, StopDraggingEvent} from '../edit-modes/types';
@@ -84,10 +84,10 @@ export class TranslateHandler extends ModeHandler {
     const p1 = point(startDragPoint);
     const p2 = point(currentPoint);
 
-    const distanceMoved = turfDistance(p1, p2);
-    const direction = turfBearing(p1, p2);
+    const distanceMoved = distance(p1, p2);
+    const direction = bearing(p1, p2);
 
-    const movedFeatures: SimpleFeatureCollection = turfTransformTranslate(
+    const movedFeatures: SimpleFeatureCollection = transformTranslate(
       this._geometryBeforeTranslate,
       distanceMoved,
       direction

--- a/modules/editable-layers/src/mode-handlers/translate-handler.ts
+++ b/modules/editable-layers/src/mode-handlers/translate-handler.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfBearing from '@turf/bearing';
-import turfDistance from '@turf/distance';
-import turfTransformTranslate from '@turf/transform-translate';
+import {bearing as turfBearing} from '@turf/bearing';
+import {distance as turfDistance} from '@turf/distance';
+import {transformTranslate as turfTransformTranslate} from '@turf/transform-translate';
 import {point} from '@turf/helpers';
 import {SimpleFeatureCollection, Position} from '../utils/geojson-types';
 import {PointerMoveEvent, StartDraggingEvent, StopDraggingEvent} from '../edit-modes/types';

--- a/modules/editable-layers/src/utils/translate-from-center.ts
+++ b/modules/editable-layers/src/utils/translate-from-center.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {center as turfCenter} from '@turf/center';
+import {center} from '@turf/center';
 import {mapCoords} from '../edit-modes/utils';
 import {geoCoordinateSystem} from '../edit-modes/coordinate-system';
 import type {EditModeCoordinateSystem} from '../edit-modes/coordinate-system';
@@ -16,7 +16,7 @@ export function translateFromCenter(
   direction: number,
   coordinateSystem: EditModeCoordinateSystem = geoCoordinateSystem
 ) {
-  const initialCenter = turfCenter(feature).geometry.coordinates;
+  const initialCenter = center(feature).geometry.coordinates;
 
   const movedCenter = coordinateSystem.destination(initialCenter, distance, direction);
 

--- a/modules/editable-layers/src/utils/translate-from-center.ts
+++ b/modules/editable-layers/src/utils/translate-from-center.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfCenter from '@turf/center';
+import {center as turfCenter} from '@turf/center';
 import {mapCoords} from '../edit-modes/utils';
 import {geoCoordinateSystem} from '../edit-modes/coordinate-system';
 import type {EditModeCoordinateSystem} from '../edit-modes/coordinate-system';

--- a/modules/editable-layers/src/utils/utils.ts
+++ b/modules/editable-layers/src/utils/utils.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {destination as turfDestination} from '@turf/destination';
-import {bearing as turfBearing} from '@turf/bearing';
-import {pointToLineDistance as turfPointToLineDistance} from '@turf/point-to-line-distance';
+import {destination} from '@turf/destination';
+import {bearing} from '@turf/bearing';
+import {pointToLineDistance} from '@turf/point-to-line-distance';
 import {point} from '@turf/helpers';
 import {WebMercatorViewport} from '@math.gl/web-mercator';
 import {Feature, LineString, Point, Position} from './geojson-types';
@@ -76,8 +76,8 @@ export function generatePointsParallelToLinePoints(
     coordinates: [p1, p2]
   };
   const pt = point(mapCoords);
-  const ddistance = turfPointToLineDistance(pt, lineString);
-  const lineBearing = turfBearing(p1, p2);
+  const ddistance = pointToLineDistance(pt, lineString);
+  const lineBearing = bearing(p1, p2);
 
   // Check if current point is to the left or right of line
   // Line from A=(x1,y1) to B=(x2,y2) a point P=(x,y)
@@ -90,8 +90,8 @@ export function generatePointsParallelToLinePoints(
 
   // Get coordinates for the point p3 and p4 which are perpendicular to the lineString
   // Add the distance as the current position moves away from the lineString
-  const p3 = turfDestination(p2, ddistance, orthogonalBearing);
-  const p4 = turfDestination(p1, ddistance, orthogonalBearing);
+  const p3 = destination(p2, ddistance, orthogonalBearing);
+  const p4 = destination(p1, ddistance, orthogonalBearing);
   return [p3.geometry.coordinates, p4.geometry.coordinates] as [Position, Position];
 }
 

--- a/modules/editable-layers/src/utils/utils.ts
+++ b/modules/editable-layers/src/utils/utils.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import turfDestination from '@turf/destination';
-import turfBearing from '@turf/bearing';
-import turfPointToLineDistance from '@turf/point-to-line-distance';
+import {destination as turfDestination} from '@turf/destination';
+import {bearing as turfBearing} from '@turf/bearing';
+import {pointToLineDistance as turfPointToLineDistance} from '@turf/point-to-line-distance';
 import {point} from '@turf/helpers';
 import {WebMercatorViewport} from '@math.gl/web-mercator';
 import {Feature, LineString, Point, Position} from './geojson-types';

--- a/modules/editable-layers/test/edit-modes/lib/draw-rectangle-mode.spec.ts
+++ b/modules/editable-layers/test/edit-modes/lib/draw-rectangle-mode.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {beforeEach, afterEach, describe, test, it, expect} from 'vitest';
-import {area as turfArea} from '@turf/area';
+import {area} from '@turf/area';
 import {Feature, FeatureCollection} from '../../../src/utils/geojson-types';
 import {DrawRectangleMode} from '../../../src/edit-modes/draw-rectangle-mode';
 import {
@@ -209,7 +209,7 @@ describe('modeConfig.booleanOperation', () => {
         modeConfig: {booleanOperation: 'union'}
       });
       // @ts-expect-error TODO
-      const areaBefore = turfArea(featureCollection.features[polygonFeatureIndex]);
+      const areaBefore = area(featureCollection.features[polygonFeatureIndex]);
 
       props.lastPointerMoveEvent = createPointerMoveEvent([0, 0]);
       mode.handleClick(createClickEvent([0, 0]), props);
@@ -219,7 +219,7 @@ describe('modeConfig.booleanOperation', () => {
       expect(props.onEdit).toHaveBeenCalledTimes(1);
       // @ts-expect-error TODO
       const action = props.onEdit.mock.calls[0][0];
-      const areaAfter = turfArea(action.updatedData.features[polygonFeatureIndex]);
+      const areaAfter = area(action.updatedData.features[polygonFeatureIndex]);
 
       expect(areaAfter).toBeGreaterThan(areaBefore);
     });
@@ -234,7 +234,7 @@ describe('modeConfig.booleanOperation', () => {
         modeConfig: {booleanOperation: 'difference'}
       });
       // @ts-expect-error TODO
-      const areaBefore = turfArea(featureCollection.features[polygonFeatureIndex]);
+      const areaBefore = area(featureCollection.features[polygonFeatureIndex]);
 
       props.lastPointerMoveEvent = createPointerMoveEvent([0, 0]);
       mode.handleClick(createClickEvent([0, 0]), props);
@@ -244,7 +244,7 @@ describe('modeConfig.booleanOperation', () => {
       expect(props.onEdit).toHaveBeenCalledTimes(1);
       // @ts-expect-error TODO
       const action = props.onEdit.mock.calls[0][0];
-      const areaAfter = turfArea(action.updatedData.features[polygonFeatureIndex]);
+      const areaAfter = area(action.updatedData.features[polygonFeatureIndex]);
 
       expect(areaAfter).toBeLessThan(areaBefore);
     });
@@ -259,7 +259,7 @@ describe('modeConfig.booleanOperation', () => {
         modeConfig: {booleanOperation: 'intersection'}
       });
       // @ts-expect-error TODO
-      const areaBefore = turfArea(featureCollection.features[polygonFeatureIndex]);
+      const areaBefore = area(featureCollection.features[polygonFeatureIndex]);
 
       props.lastPointerMoveEvent = createPointerMoveEvent([0, 0]);
       mode.handleClick(createClickEvent([0, 0]), props);
@@ -269,7 +269,7 @@ describe('modeConfig.booleanOperation', () => {
       expect(props.onEdit).toHaveBeenCalledTimes(1);
       // @ts-expect-error TODO
       const action = props.onEdit.mock.calls[0][0];
-      const areaAfter = turfArea(action.updatedData.features[polygonFeatureIndex]);
+      const areaAfter = area(action.updatedData.features[polygonFeatureIndex]);
 
       expect(areaAfter).toBeLessThan(areaBefore);
     });

--- a/modules/editable-layers/test/edit-modes/lib/draw-rectangle-mode.spec.ts
+++ b/modules/editable-layers/test/edit-modes/lib/draw-rectangle-mode.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {beforeEach, afterEach, describe, test, it, expect} from 'vitest';
-import turfArea from '@turf/area';
+import {area as turfArea} from '@turf/area';
 import {Feature, FeatureCollection} from '../../../src/utils/geojson-types';
 import {DrawRectangleMode} from '../../../src/edit-modes/draw-rectangle-mode';
 import {


### PR DESCRIPTION
## Summary

Switch every `@turf/*` import in editable-layers from a default import to the
equivalent named import (`import turfX from '@turf/x'` → `import {x as turfX} from '@turf/x'`).
Local names and call sites are unchanged.

turf v7 exposes each function as a named export; its `default` only resolves when
a bundler's ESM/CJS interop preserves it. When editable-layers is consumed through
a CommonJS package and re-bundled by esbuild, turf gets wrapped as
`__toESM(require("@turf/x"), 1)`, making `.default` a namespace object rather than
the function, so `(0, import_x.default)(...)` throws `.default is not a function`
at runtime (breaks rectangle/polygon drawing, rewind, etc.).

Named imports don't depend on interop heuristics and match how the codebase already
imports `@turf/helpers`.

## Note on reproduction

This does not reproduce via the Vite-based examples here (Rollup's interop preserves
`.default`). It reproduces when editable-layers is bundled with esbuild through a CJS
consumer — e.g. `new DrawRectangleMode().getTwoClickPolygon(...)` throws
`(0, import_bbox_polygon.default) is not a function`. The named imports run cleanly
in that same pipeline.