### PR TITLE
feat: add first-wave WebGPU community layer support

### DIFF
--- a/dev/timeline-layers/examples/horizon-graph-layer/app.tsx
+++ b/dev/timeline-layers/examples/horizon-graph-layer/app.tsx
@@ -11,7 +11,12 @@ import {
   type SettingsSchema,
   type SettingsState
 } from '@deck.gl-community/panels';
-import {BoxPanelWidget, SidebarPanelWidget} from '@deck.gl-community/widgets';
+import {
+  BoxPanelWidget,
+  DeviceManagerController,
+  DeviceTabsWidget,
+  SidebarPanelWidget
+} from '@deck.gl-community/widgets';
 
 import '@deck.gl/widgets/stylesheet.css';
 
@@ -265,6 +270,8 @@ export function mountHorizonGraphLayerExample(
   const rootElement = container.ownerDocument.createElement('div');
   applyElementStyle(rootElement, ROOT_STYLE);
   container.replaceChildren(rootElement);
+  const deviceManager = new DeviceManagerController();
+  deviceManager.reparentCanvas(rootElement);
 
   const state: ExampleState = {
     settings: cloneSettings(INITIAL_SETTINGS),
@@ -311,7 +318,15 @@ export function mountHorizonGraphLayerExample(
     );
   }
 
-  widgets.push(sidebarWidget);
+  widgets.push(
+    sidebarWidget,
+    new DeviceTabsWidget({
+      id: `${resolvedConfig.layerId}-device-tabs`,
+      devices: ['webgpu', 'webgl2'],
+      manager: deviceManager,
+      placement: 'bottom-right'
+    })
+  );
 
   const deck = new Deck({
     parent: rootElement,
@@ -335,9 +350,17 @@ export function mountHorizonGraphLayerExample(
       syncDeck();
     }
   });
+  const unsubscribeDevice = deviceManager.subscribe(({device}) => {
+    if (device && deck.device !== device) {
+      deck.setProps({device});
+    }
+  });
+  void deviceManager.initialize();
 
   return () => {
+    unsubscribeDevice();
     deck.finalize();
+    deviceManager.reset();
     rootElement.remove();
     container.replaceChildren();
   };

--- a/dev/timeline-layers/src/layers/horizon-graph-layer/horizon-graph-layer-uniforms.ts
+++ b/dev/timeline-layers/src/layers/horizon-graph-layer/horizon-graph-layer-uniforms.ts
@@ -30,6 +30,7 @@ export type HorizonLayerProps = HorizonLayerBindingProps & HorizonLayerUniformPr
 
 export const horizonLayerUniforms = {
   name: 'horizonLayer',
+  source: '',
   vs: uniformBlock,
   fs: uniformBlock,
   uniformTypes: {

--- a/dev/timeline-layers/src/layers/horizon-graph-layer/horizon-graph-layer.ts
+++ b/dev/timeline-layers/src/layers/horizon-graph-layer/horizon-graph-layer.ts
@@ -7,6 +7,7 @@ import {Layer, project32} from '@deck.gl/core';
 import {Model, Geometry} from '@luma.gl/engine';
 import vs from './horizon-graph-layer.vs';
 import fs from './horizon-graph-layer.fs';
+import source from './horizon-graph-layer.wgsl';
 import {Texture} from '@luma.gl/core';
 import {horizonLayerUniforms} from './horizon-graph-layer-uniforms';
 
@@ -61,6 +62,7 @@ export class HorizonGraphLayer<ExtraProps extends {} = {}> extends Layer<
 
   getShaders() {
     return super.getShaders({
+      source,
       vs,
       fs,
       modules: [project32, horizonLayerUniforms]
@@ -191,6 +193,7 @@ export class HorizonGraphLayer<ExtraProps extends {} = {}> extends Layer<
         negativeColor: negativeColor.map(c => c / 255)
       }
     });
+    model.setBindings({dataTexture});
     model.draw(this.context.renderPass);
   }
 

--- a/dev/timeline-layers/src/layers/horizon-graph-layer/horizon-graph-layer.wgsl.ts
+++ b/dev/timeline-layers/src/layers/horizon-graph-layer/horizon-graph-layer.wgsl.ts
@@ -1,0 +1,64 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** WebGPU shaders for floating-point horizon graphs. */
+export default /* wgsl */ `
+struct HorizonLayerUniforms {
+  dataTextureSize: f32,
+  dataTextureSizeInv: f32,
+  dataTextureCount: f32,
+  bands: f32,
+  bandsInv: f32,
+  yAxisScaleInv: f32,
+  positiveColor: vec3<f32>,
+  negativeColor: vec3<f32>,
+};
+
+@group(0) @binding(auto) var<uniform> horizonLayer: HorizonLayerUniforms;
+@group(0) @binding(auto) var dataTexture: texture_2d<f32>;
+
+struct HorizonAttributes {
+  @location(0) positions: vec3<f32>,
+  @location(1) uv: vec2<f32>,
+};
+
+struct HorizonVaryings {
+  @builtin(position) position: vec4<f32>,
+  @location(0) uv: vec2<f32>,
+};
+
+@vertex
+fn vertexMain(attributes: HorizonAttributes) -> HorizonVaryings {
+  geometry.worldPosition = attributes.positions;
+  let commonPosition = project_position_vec4_f32(vec4<f32>(attributes.positions.xy, 0.0, 1.0));
+  geometry.position = commonPosition;
+
+  var varyings: HorizonVaryings;
+  varyings.position = project_common_position_to_clipspace(commonPosition);
+  varyings.uv = attributes.uv;
+  return varyings;
+}
+
+@fragment
+fn fragmentMain(varyings: HorizonVaryings) -> @location(0) vec4<f32> {
+  let index = clamp(
+    floor(varyings.uv.x * horizonLayer.dataTextureCount),
+    0.0,
+    max(horizonLayer.dataTextureCount - 1.0, 0.0)
+  );
+  let row = floor(index * horizonLayer.dataTextureSizeInv);
+  let column = index - row * horizonLayer.dataTextureSize;
+  let value = textureLoad(dataTexture, vec2<i32>(i32(column), i32(row)), 0).r *
+    horizonLayer.yAxisScaleInv;
+  let scaledBand = abs(value) * horizonLayer.bands;
+  let bandIndex = clamp(floor(scaledBand), 0.0, horizonLayer.bands - 1.0);
+  let bandFraction = fract(scaledBand);
+  let positive = value >= 0.0;
+  let baseColor = select(horizonLayer.negativeColor, horizonLayer.positiveColor, positive);
+  let currentPosition = select(varyings.uv.y, 1.0 - varyings.uv.y, positive);
+  let band = bandIndex + select(0.0, 1.0, currentPosition <= bandFraction);
+  let whiten = 1.0 - band * horizonLayer.bandsInv;
+  return vec4<f32>(mix(baseColor, vec3<f32>(1.0), whiten), 1.0);
+}
+`;

--- a/dev/timeline-layers/src/layers/horizon-graph-layer/multi-horizon-graph-layer.ts
+++ b/dev/timeline-layers/src/layers/horizon-graph-layer/multi-horizon-graph-layer.ts
@@ -4,7 +4,7 @@
 
 import type {DefaultProps, LayerProps, Color, LayerDataSource, Accessor} from '@deck.gl/core';
 import {CompositeLayer} from '@deck.gl/core';
-import {SolidPolygonLayer} from '@deck.gl/layers';
+import {LineLayer} from '@deck.gl/layers';
 import {HorizonGraphLayer} from './horizon-graph-layer';
 
 export type _MultiHorizonGraphLayerProps<DataT> = {
@@ -82,50 +82,41 @@ export class MultiHorizonGraphLayer<DataT = any, ExtraProps extends {} = {}> ext
 
     const layers = [];
 
-    // Create divider rectangles
+    // Draw divider bands with the upstream dual-backend LineLayer.
     if (dividerWidth > 0) {
       const dividerData = [];
 
       // Top divider
       dividerData.push({
-        polygon: [
-          [x, y],
-          [x + width, y],
-          [x + width, y + dividerWidth],
-          [x, y + dividerWidth]
-        ]
+        source: [x, y + dividerWidth / 2],
+        target: [x + width, y + dividerWidth / 2]
       });
 
       // Dividers between series
       for (let i = 0; i < seriesCount - 1; i++) {
         const dividerY = y + dividerWidth + (i + 1) * seriesHeight + i * dividerWidth;
         dividerData.push({
-          polygon: [
-            [x, dividerY],
-            [x + width, dividerY],
-            [x + width, dividerY + dividerWidth],
-            [x, dividerY + dividerWidth]
-          ]
+          source: [x, dividerY + dividerWidth / 2],
+          target: [x + width, dividerY + dividerWidth / 2]
         });
       }
 
       // Bottom divider
       const bottomDividerY = y + height - dividerWidth;
       dividerData.push({
-        polygon: [
-          [x, bottomDividerY],
-          [x + width, bottomDividerY],
-          [x + width, y + height],
-          [x, y + height]
-        ]
+        source: [x, bottomDividerY + dividerWidth / 2],
+        target: [x + width, bottomDividerY + dividerWidth / 2]
       });
 
       layers.push(
-        new SolidPolygonLayer({
+        new LineLayer({
           id: `${this.props.id}-dividers`,
           data: dividerData,
-          getPolygon: (d: any) => d.polygon,
-          getFillColor: dividerColor,
+          getSourcePosition: datum => datum.source,
+          getTargetPosition: datum => datum.target,
+          getColor: dividerColor,
+          getWidth: dividerWidth,
+          widthUnits: 'common',
           pickable: false
         })
       );

--- a/dev/timeline-layers/test/horizon-graph-layer.spec.ts
+++ b/dev/timeline-layers/test/horizon-graph-layer.spec.ts
@@ -1,0 +1,54 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {LineLayer} from '@deck.gl/layers';
+import {describe, expect, it} from 'vitest';
+
+import {HorizonGraphLayer, MultiHorizonGraphLayer} from '../src';
+
+describe('MultiHorizonGraphLayer', () => {
+  it('renders portable line dividers alongside each horizon series', () => {
+    const layer = new MultiHorizonGraphLayer({
+      id: 'portable-horizons',
+      data: [
+        {values: [1, -2, 3], scale: 10},
+        {values: [-3, 2, -1], scale: 10}
+      ],
+      getSeries: series => series.values,
+      getScale: series => series.scale,
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 50,
+      dividerWidth: 2
+    });
+
+    const [dividers, ...horizons] = layer.renderLayers();
+
+    expect(dividers).toBeInstanceOf(LineLayer);
+    expect(dividers.props.id).toBe('portable-horizons-dividers');
+    expect(dividers.props.widthUnits).toBe('common');
+    expect(dividers.props.getWidth).toBe(2);
+    expect(dividers.props.data).toHaveLength(3);
+    expect(horizons).toHaveLength(2);
+    expect(horizons.every(horizon => horizon instanceof HorizonGraphLayer)).toBe(true);
+  });
+
+  it('omits divider geometry when dividers are disabled', () => {
+    const layer = new MultiHorizonGraphLayer({
+      id: 'portable-horizons-no-dividers',
+      data: [{values: [1, -2, 3], scale: 10}],
+      getSeries: series => series.values,
+      getScale: series => series.scale,
+      width: 100,
+      height: 50,
+      dividerWidth: 0
+    });
+
+    const horizons = layer.renderLayers();
+
+    expect(horizons).toHaveLength(1);
+    expect(horizons[0]).toBeInstanceOf(HorizonGraphLayer);
+  });
+});

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ common modules type are:
 Some practical goals for this repo:
 - The community modules in this repo are expected to be used with deck.gl v9.0 or later releases. 
 - The version of the published npm modules will follow deck.gl's major and minor version numbering, making it easy to see at a glance which deck.gl version is supported by a specific `@deck.gl-community/...` module.
-- Community modules are expected to support WebGL2 rendering in deck.gl, and will hopefully gradually start supporting WebGPU rendering over time, see detailed documentation for each module / layer.
+- Community modules are expected to support WebGL2 rendering in deck.gl and are gradually adding WebGPU support. See the [WebGPU compatibility and migration roadmap](./webgpu.md) for layer-specific support, backend selection, and remaining porting work.
 
 # Official Support
 

--- a/docs/modules/timeline-layers/api-reference/multi-horizon-graph-layer.md
+++ b/docs/modules/timeline-layers/api-reference/multi-horizon-graph-layer.md
@@ -56,7 +56,7 @@ Position and size of the entire chart. Defaults: `x:0`, `y:0`, `width:800`, `hei
 ## Sub Layers
 
 - One `HorizonGraphLayer` per series
-- Optional `SolidPolygonLayer` for divider rectangles
+- Optional dual-backend `LineLayer` for divider bands
 
 ## Source
 

--- a/docs/webgpu.md
+++ b/docs/webgpu.md
@@ -1,0 +1,108 @@
+# WebGPU Compatibility and Migration
+
+deck.gl-community is adding WebGPU support incrementally while continuing to support WebGL2. Compatibility is tracked per layer and integration: adding a WebGPU adapter to a package does not, by itself, make every shader, extension, or map integration portable.
+
+## Layer support matrix
+
+✅ means implemented and verified, 🚧 means partial, planned, or dependent on additional validation, and ❌ means unavailable or blocked by an upstream renderer.
+
+| Module | Layer or integration | WebGL2 | WebGPU | Notes |
+| --- | --- | :---: | :---: | --- |
+| `@deck.gl-community/layers` | `SkyboxLayer` | ✅ | ✅ | Native GLSL and WGSL cubemap shaders. |
+| `@deck.gl-community/layers` | `DependencyArrowLayer`, `line` mode | ✅ | ✅ | Portable `LineLayer` and native WGSL marker geometry. |
+| `@deck.gl-community/layers` | `DependencyArrowLayer`, `arc` mode | ✅ | 🚧 | Marker geometry is portable; upstream `ArcLayer` requires validation. |
+| `@deck.gl-community/layers` | `DependencyArrowLayer`, `path` mode | ✅ | ❌ | Blocked by upstream `PathLayer`. |
+| `@deck.gl-community/layers` | `PathOutlineLayer` | ✅ | ❌ | Blocked by upstream `PathLayer` and `PathStyleExtension`. |
+| `@deck.gl-community/layers` | `PathMarkerLayer` | ✅ | 🚧 | Marker geometry is portable; outlined and dashed paths remain blocked. |
+| `@deck.gl-community/infovis-layers` | `BlockLayer` | ✅ | ✅ | Native WGSL, projection, picking, fills, and outlines. |
+| `@deck.gl-community/infovis-layers` | `AnimationLayer` | ✅ | 🚧 | Depends on the wrapped layer's backend support. |
+| `@deck.gl-community/infovis-layers` | `TimeDeltaLayer` | ✅ | 🚧 | Upstream line and text sublayers require end-to-end validation. |
+| `@deck.gl-community/infovis-layers` | `FastTextLayer` | ✅ | ❌ | Native WGSL glyph rendering and atlas bindings are not implemented. |
+| `@deck.gl-community/timeline-layers` | `HorizonGraphLayer` | ✅ | ✅ | Native WGSL and `r32float` data textures. |
+| `@deck.gl-community/timeline-layers` | `MultiHorizonGraphLayer` | ✅ | ✅ | Portable horizon shaders and dual-backend line dividers. |
+| `@deck.gl-community/timeline-layers` | `TimeAxisLayer` | ✅ | 🚧 | Upstream line and text sublayers require validation. |
+| `@deck.gl-community/timeline-layers` | `VerticalGridLayer` | ✅ | 🚧 | Upstream `LineLayer` is portable; dedicated rendering validation is pending. |
+| `@deck.gl-community/timeline-layers` | `TimelineLayer` | ✅ | ❌ | Blocked by upstream `SolidPolygonLayer`. |
+| `@deck.gl-community/graph-layers` | `GraphLayer`, `EdgeLayer`, and node layers | ✅ | 🚧 | Custom shaders, picking, and graph styling require porting and validation. |
+| `@deck.gl-community/graph-layers` | `RoundedRectangleLayer` | ✅ | ❌ | Custom fragment shader has no native WGSL implementation. |
+| `@deck.gl-community/graph-layers` | `FlowPathLayer` | ❌ | ❌ | Existing transform-feedback implementation is incomplete; requires redesign. |
+| `@deck.gl-community/geo-layers` | Tile and global-grid layers | ✅ | 🚧 | Validate upstream sublayers, tile formats, and picking. |
+| `@deck.gl-community/arrow-layers` | GeoArrow layers | ✅ | 🚧 | Validate binary attributes and each upstream rendering layer. |
+| `@deck.gl-community/editable-layers` | Editing and selection layers | ✅ | 🚧 | Validate editing interactions and upstream GeoJSON and path layers. |
+| `@deck.gl-community/basemap-layers` | `BasemapLayer` | ✅ | 🚧 | Support depends on the selected style's polygon, path, and label sublayers. |
+| `@deck.gl-community/three` | `TreeLayer` | ✅ | ❌ | Depends on the external Three.js renderer and canvas integration. |
+| `@deck.gl-community/leaflet` | Leaflet map overlay | ✅ | ❌ | A host-owned WebGL context cannot be switched to WebGPU. |
+| `@deck.gl-community/bing-maps` | Bing Maps overlay | ✅ | ❌ | A host-owned WebGL context cannot be switched to WebGPU. |
+| `@deck.gl-community/widgets` | `DeviceManagerController` and `DeviceTabsWidget` | ✅ | ✅ | Selects and attaches an independently managed real rendering device. |
+
+## Selecting a graphics backend
+
+The `@deck.gl-community/widgets` package provides `DeviceManagerController` and `DeviceTabsWidget`, modeled on luma.gl's device tabs. Use an independent manager for each mounted example or application surface, and pass the manager's selected luma.gl device to the actual `Deck` instance:
+
+```ts
+import {Deck} from '@deck.gl/core';
+import {DeviceManagerController, DeviceTabsWidget} from '@deck.gl-community/widgets';
+
+const manager = new DeviceManagerController();
+manager.reparentCanvas(container);
+
+const deck = new Deck({
+  parent: container,
+  layers,
+  widgets: [
+    new DeviceTabsWidget({
+      devices: ['webgpu', 'webgl2'],
+      manager
+    })
+  ]
+});
+
+const unsubscribe = manager.subscribe(({device}) => {
+  if (device && deck.device !== device) {
+    deck.setProps({device});
+  }
+});
+
+void manager.initialize();
+
+// When the surface is removed:
+unsubscribe();
+deck.finalize();
+manager.reset();
+```
+
+WebGPU is preferred when available. The manager respects a previously selected backend, disables unavailable devices, and falls back to WebGL2. Switching tabs changes the device used to draw the scene; it is not only a visual indicator.
+
+## Compatibility roadmap
+
+| Stage | Layers or integrations | Status |
+| --- | --- | --- |
+| Existing reference | `SkyboxLayer` | Provides native WGSL and GLSL sources, portable cubemap bindings, and a switchable skybox example. |
+| First wave | `BlockLayer`, `DependencyArrowLayer` marker geometry, `HorizonGraphLayer`, and `MultiHorizonGraphLayer` | Native WGSL and existing GLSL are maintained together. Stacked horizon dividers use the upstream dual-backend `LineLayer`; the path, block, and horizon examples expose real WebGPU/WebGL2 device selection. |
+| Upstream-dependent paths | `PathOutlineLayer`, `PathMarkerLayer`, dashed path routing, and `DependencyArrowLayer` path mode | Full route rendering depends on native WGSL support for deck.gl's `PathLayer` and `PathStyleExtension`. Directional marker geometry and line-mode dependencies can be ported independently, but outlined or dashed paths must not be advertised as fully WebGPU-compatible yet. |
+| Second wave | `FastTextLayer` | Requires native WGSL glyph shaders, portable font-atlas and sampler bindings, clipping, alignment, signed-distance-field rendering, and verified mipmap generation. |
+| Third wave | `RoundedRectangleLayer` and graph node and edge layers | Audit custom fragment shaders, picking, graph styling, and inherited deck.gl layer compatibility before claiming support. |
+| Dedicated redesign | `FlowPathLayer` and animated graph flows | The current transform-feedback implementation is incomplete and WebGL-specific. Replace it with a backend-neutral animation or compute design; do not treat shader translation alone as a port. |
+| Subsequent validation | Arrow, editable, geospatial, and basemap layers | Validate upstream sublayers, binary attributes, picking, shader extensions, tile and texture formats, and each demonstrated example independently. |
+| Host-dependent integrations | Three.js, Leaflet, Bing Maps, and external map renderers | Support depends on the host renderer and canvas ownership. A host-owned WebGL context cannot be switched to WebGPU by adding device tabs. |
+
+The skybox map example also composes a basemap. `SkyboxLayer` itself has native WebGPU shaders, while complete basemap compatibility remains subject to the downstream GeoJSON, polygon, path, and label sublayers used by the selected style.
+
+## Porting a custom layer
+
+Provide one native WGSL `source` in addition to the existing GLSL `vs` and `fs`:
+
+```ts
+getShaders() {
+  return super.getShaders({
+    source: webgpuShader,
+    vs: webglVertexShader,
+    fs: webglFragmentShader,
+    modules: [project32, color, picking, layerUniforms]
+  });
+}
+```
+
+Declare WGSL resource bindings with `@binding(auto)`, keep each shader module's uniform types in the same order as its WGSL structure, and use `Model`, `Geometry`, `Texture`, and `renderPass` rather than a raw WebGL context. Include real browser coverage for available devices, and explicitly skip WebGPU rendering when a browser cannot supply a WebGPU adapter.
+
+Do not update a package-wide WebGPU compatibility badge until all of the package's advertised layers and integrations have been validated.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,21 +1,36 @@
 # What's New
 
-## v9.4 - In Planning
+## v9.4 - In Development
+
+Target Release Date: July 2026
 
 Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community/milestone/5).
+
+### WebGPU
+
+- Added the [WebGPU support matrix and migration roadmap](./webgpu.md), covering WebGL2 and WebGPU support by module and layer, upstream dependencies, and host integration limitations.
+- `SkyboxLayer`: validated the existing native WGSL and GLSL implementation with real WebGPU/WebGL2 device selection in the skybox example.
+- `BlockLayer`: added native WGSL for instanced block fills, outlines, projection, opacity, and picking while preserving the existing WebGL2 shaders.
+- `DependencyArrowLayer`: added native WGSL for directional arrow-marker geometry, picking, and line-mode dependencies; path mode remains blocked on upstream `PathLayer` support.
+- `HorizonGraphLayer`: added native WGSL and portable `r32float` data-texture bindings.
+- `MultiHorizonGraphLayer`: made stacked horizon graphs portable by using dual-backend `LineLayer` dividers alongside the new horizon shaders.
+- Skybox, path and dependency-marker, information-visualization, and horizon-graph examples now provide luma.gl-style device tabs with independent managers, WebGPU preference, WebGL2 fallback, and real renderer switching.
 
 ### `@deck.gl-community/layers`
 
 - `DependencyArrowLayer` - NEW directional marker layer for dependency links with path, line, or arc routing.
+- `DependencyArrowLayer` marker geometry now includes a native WGSL shader alongside its existing WebGL2 shader, including directional markers and picking; complete path-mode compatibility remains dependent on upstream `PathLayer` support.
 - `PathOutlineLayer` and `PathMarkerLayer` now use deck.gl v9-native sublayers for outlined paths, dashed strokes, and pixel-sized directional markers, restoring the path outline and marker example.
 
 ### `@deck.gl-community/infovis-layers`
 
 - Added generic animation, block, fast-text, UTF8 Arrow string-view, view-layout, and viewport-bounds helpers for trace-style visualizations.
+- `BlockLayer` now provides paired WebGPU WGSL and WebGL2 GLSL shaders for instanced fills, outlines, projection, and picking.
 
 ### `@deck.gl-community/timeline-layers`
 
 - `TimeAxisLayer` now supports adaptive trace-style duration and timestamp grids plus exported tick formatting helpers.
+- `HorizonGraphLayer` and `MultiHorizonGraphLayer` can render their floating-point data textures on WebGPU and WebGL2; stacked horizon dividers now use the upstream dual-backend `LineLayer`.
 
 ### `@deck.gl-community/trace-layers`
 

--- a/examples/infovis-layers/layer-primitives/app.ts
+++ b/examples/infovis-layers/layer-primitives/app.ts
@@ -5,6 +5,7 @@
 import {COORDINATE_SYSTEM, Deck, OrthographicView, type Color, type Position} from '@deck.gl/core';
 import {LineLayer, TextLayer} from '@deck.gl/layers';
 import {AnimationLayer, BlockLayer, TimeDeltaLayer} from '@deck.gl-community/infovis-layers';
+import {DeviceManagerController, DeviceTabsWidget} from '@deck.gl-community/widgets';
 
 type InfovisLayerHighlight = 'all' | 'animation-layer' | 'block-layer' | 'time-delta-layer';
 
@@ -41,6 +42,8 @@ export function mountInfovisLayerPrimitivesExample(
     rootElement.appendChild(createInfoOverlay(rootElement.ownerDocument));
   }
 
+  const deviceManager = new DeviceManagerController();
+  deviceManager.reparentCanvas(rootElement);
   const deck = new Deck({
     parent: rootElement,
     views: new OrthographicView({id: 'infovis-layer-primitives', flipY: false}),
@@ -49,11 +52,27 @@ export function mountInfovisLayerPrimitivesExample(
       zoom: 0
     },
     controller: true,
+    widgets: [
+      new DeviceTabsWidget({
+        id: 'infovis-layer-primitives-device-tabs',
+        devices: ['webgpu', 'webgl2'],
+        manager: deviceManager,
+        placement: 'top-right'
+      })
+    ],
     layers: createLayers(highlight)
   });
+  const unsubscribeDevice = deviceManager.subscribe(({device}) => {
+    if (device && deck.device !== device) {
+      deck.setProps({device});
+    }
+  });
+  void deviceManager.initialize();
 
   return () => {
+    unsubscribeDevice();
     deck.finalize();
+    deviceManager.reset();
     rootElement.remove();
     container.replaceChildren();
   };

--- a/examples/infovis-layers/layer-primitives/package.json
+++ b/examples/infovis-layers/layer-primitives/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@deck.gl-community/infovis-layers": "workspace:*",
+    "@deck.gl-community/panels": "workspace:*",
+    "@deck.gl-community/widgets": "workspace:*",
     "@deck.gl/core": "~9.3.0",
     "@deck.gl/layers": "~9.3.0",
     "@loaders.gl/core": "^4.4.1",

--- a/examples/layers/path-marker-outline/app.tsx
+++ b/examples/layers/path-marker-outline/app.tsx
@@ -10,7 +10,11 @@ import {
   PathMarkerLayer
 } from '@deck.gl-community/layers';
 import {MarkdownPanel} from '@deck.gl-community/panels';
-import {BoxPanelWidget} from '@deck.gl-community/widgets';
+import {
+  BoxPanelWidget,
+  DeviceManagerController,
+  DeviceTabsWidget
+} from '@deck.gl-community/widgets';
 
 import '@deck.gl/widgets/stylesheet.css';
 
@@ -214,6 +218,14 @@ export function mountPathOutlineAndMarkersExample(
   rootElement.style.height = '100%';
   container.replaceChildren(rootElement);
 
+  const deviceManager = new DeviceManagerController();
+  deviceManager.reparentCanvas(rootElement);
+  const deviceTabsWidget = new DeviceTabsWidget({
+    id: 'path-outline-and-markers-device-tabs',
+    devices: ['webgpu', 'webgl2'],
+    manager: deviceManager,
+    placement: 'top-right'
+  });
   const deck = new Deck({
     parent: rootElement,
     width: '100%',
@@ -221,8 +233,9 @@ export function mountPathOutlineAndMarkersExample(
     initialViewState: getInitialViewState(rootElement),
     controller: true,
     parameters: {clearColor: [0.96, 0.97, 1, 1]},
-    widgets:
-      options.showInfoWidget === false
+    widgets: [
+      deviceTabsWidget,
+      ...(options.showInfoWidget === false
         ? []
         : [
             new BoxPanelWidget({
@@ -239,7 +252,8 @@ export function mountPathOutlineAndMarkersExample(
                   'Demonstrates `PathOutlineLayer` for outlined dashed routes, `PathMarkerLayer` for directional markers, and `DependencyArrowLayer` for routed handoff links.\n\nHover a path to inspect each route or trail.'
               })
             })
-          ],
+          ])
+    ],
     layers: [
       new PathOutlineLayer<WaterfrontSegment>({
         id: 'trail-outlines',
@@ -310,8 +324,17 @@ export function mountPathOutlineAndMarkersExample(
     ],
     getTooltip: (info: PickingInfo<LayerDatum>) => getTooltip(info)
   });
+  const unsubscribeDevice = deviceManager.subscribe(({device}) => {
+    if (device && deck.device !== device) {
+      deck.setProps({device});
+    }
+  });
+  void deviceManager.initialize();
+
   return () => {
+    unsubscribeDevice();
     deck.finalize();
+    deviceManager.reset();
     rootElement.remove();
     container.replaceChildren();
   };

--- a/examples/layers/skybox-map-view/app.tsx
+++ b/examples/layers/skybox-map-view/app.tsx
@@ -5,6 +5,7 @@
 import {Deck, MapView} from '@deck.gl/core';
 import {BasemapLayer} from '@deck.gl-community/basemap-layers';
 import {SkyboxLayer} from '@deck.gl-community/layers';
+import {DeviceManagerController, DeviceTabsWidget} from '@deck.gl-community/widgets';
 import {SKYBOX_CUBEMAP} from '../skybox-assets/cubemap';
 
 const INITIAL_VIEW_STATE = {
@@ -30,6 +31,8 @@ export function mountSkyboxMapViewExample(
     rootElement.appendChild(createOverlay(rootElement.ownerDocument));
   }
 
+  const deviceManager = new DeviceManagerController();
+  deviceManager.reparentCanvas(rootElement);
   const deck = new Deck({
     parent: rootElement,
     views: new MapView({repeat: true, maxPitch: MAX_PITCH}),
@@ -40,6 +43,14 @@ export function mountSkyboxMapViewExample(
       maxPitch: MAX_PITCH
     },
     parameters: {clearColor: [0, 0, 0, 1]},
+    widgets: [
+      new DeviceTabsWidget({
+        id: 'skybox-map-view-device-tabs',
+        devices: ['webgpu', 'webgl2'],
+        manager: deviceManager,
+        placement: 'top-right'
+      })
+    ],
     layers: [
       new SkyboxLayer({
         id: 'skybox',
@@ -53,9 +64,17 @@ export function mountSkyboxMapViewExample(
       })
     ]
   });
+  const unsubscribeDevice = deviceManager.subscribe(({device}) => {
+    if (device && deck.device !== device) {
+      deck.setProps({device});
+    }
+  });
+  void deviceManager.initialize();
 
   return () => {
+    unsubscribeDevice();
     deck.finalize();
+    deviceManager.reset();
     rootElement.remove();
     container.replaceChildren();
   };

--- a/examples/layers/skybox-map-view/package.json
+++ b/examples/layers/skybox-map-view/package.json
@@ -7,6 +7,8 @@
   "dependencies": {
     "@deck.gl-community/basemap-layers": "workspace:*",
     "@deck.gl-community/layers": "workspace:*",
+    "@deck.gl-community/panels": "workspace:*",
+    "@deck.gl-community/widgets": "workspace:*",
     "@deck.gl/core": "~9.3.0",
     "@deck.gl/extensions": "~9.3.0",
     "@deck.gl/geo-layers": "~9.3.0",
@@ -15,7 +17,9 @@
     "@loaders.gl/core": "^4.4.1",
     "@luma.gl/core": "~9.3.2",
     "@luma.gl/engine": "~9.3.2",
-    "@luma.gl/shadertools": "~9.3.2"
+    "@luma.gl/shadertools": "~9.3.2",
+    "@luma.gl/webgl": "~9.3.2",
+    "@luma.gl/webgpu": "~9.3.2"
   },
   "devDependencies": {
     "vite": "^7.3.1"

--- a/modules/infovis-layers/src/layers/block-layer/block-layer-uniforms.ts
+++ b/modules/infovis-layers/src/layers/block-layer/block-layer-uniforms.ts
@@ -31,6 +31,7 @@ export type BlockProps = {
 /** Shader module that defines uniforms consumed by {@link BlockLayer}. */
 export const blockUniforms = {
   name: 'block',
+  source: '',
   vs: glslUniformBlock,
   fs: glslUniformBlock,
   uniformTypes: {

--- a/modules/infovis-layers/src/layers/block-layer/block-layer.ts
+++ b/modules/infovis-layers/src/layers/block-layer/block-layer.ts
@@ -23,6 +23,7 @@ import {Geometry, Model} from '@luma.gl/engine';
 import fs from './block-layer-fragment.glsl';
 import {BlockProps, blockUniforms} from './block-layer-uniforms';
 import vs from './block-layer-vertex.glsl';
+import source from './block-layer.wgsl';
 
 const DEFAULT_COLOR: [number, number, number, number] = [0, 0, 0, 255];
 
@@ -114,6 +115,7 @@ export class BlockLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
 
   override getShaders() {
     return super.getShaders({
+      source,
       vs,
       fs,
       modules: [project32, color, picking, blockUniforms]

--- a/modules/infovis-layers/src/layers/block-layer/block-layer.wgsl.ts
+++ b/modules/infovis-layers/src/layers/block-layer/block-layer.wgsl.ts
@@ -1,0 +1,127 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** WebGPU vertex and fragment shaders for {@link BlockLayer}. */
+export default /* wgsl */ `
+struct BlockUniforms {
+  sizeUnits: i32,
+  widthMinPixels: f32,
+  heightMinPixels: f32,
+  sizeMaxPixels: f32,
+  lineWidthUnits: i32,
+};
+
+@group(0) @binding(auto) var<uniform> block: BlockUniforms;
+
+struct BlockAttributes {
+  @location(0) positions: vec3<f32>,
+  @location(1) instancePositions: vec3<f32>,
+  @location(2) instancePositions64Low: vec3<f32>,
+  @location(3) instanceSizes: vec2<f32>,
+  @location(4) instanceLineWidths: f32,
+  @location(5) instanceLineColors: vec4<f32>,
+  @location(6) instanceFillColors: vec4<f32>,
+  @location(7) instancePickingColors: vec3<f32>,
+};
+
+struct BlockVaryings {
+  @builtin(position) position: vec4<f32>,
+  @location(0) unitPosition: vec2<f32>,
+  @location(1) @interpolate(flat) fillColor: vec4<f32>,
+  @location(2) @interpolate(flat) lineColor: vec4<f32>,
+  @location(3) @interpolate(flat) lineWidth: f32,
+  @location(4) @interpolate(flat) size: vec2<f32>,
+  @location(5) @interpolate(flat) pickingColor: vec3<f32>,
+};
+
+fn block_size_to_pixels(size: vec2<f32>, unit: i32) -> vec2<f32> {
+  return vec2<f32>(
+    project_unit_size_to_pixel(size.x, unit),
+    project_unit_size_to_pixel(size.y, unit)
+  );
+}
+
+fn block_clamp_signed_size(size: f32, minimum: f32, maximum: f32) -> f32 {
+  return select(1.0, -1.0, size < 0.0) * clamp(abs(size), minimum, maximum);
+}
+
+@vertex
+fn vertexMain(attributes: BlockAttributes) -> BlockVaryings {
+  geometry.worldPosition = attributes.instancePositions;
+  geometry.pickingColor = attributes.instancePickingColors;
+  geometry.uv = attributes.positions.xy;
+
+  var pixelSize = block_size_to_pixels(attributes.instanceSizes, block.sizeUnits);
+  pixelSize.x = block_clamp_signed_size(pixelSize.x, block.widthMinPixels, block.sizeMaxPixels);
+  pixelSize.y = block_clamp_signed_size(pixelSize.y, block.heightMinPixels, block.sizeMaxPixels);
+
+  let offset = vec3<f32>(
+    attributes.positions.xy * project_pixel_size_vec2(pixelSize),
+    0.0
+  );
+  let projected = project_position_to_clipspace_and_commonspace(
+    attributes.instancePositions,
+    attributes.instancePositions64Low,
+    offset
+  );
+  geometry.position = projected.commonPosition;
+
+  var varyings: BlockVaryings;
+  varyings.position = projected.clipPosition;
+  varyings.unitPosition = attributes.positions.xy;
+  varyings.fillColor = vec4<f32>(
+    attributes.instanceFillColors.rgb,
+    attributes.instanceFillColors.a * layer.opacity
+  );
+  varyings.lineColor = vec4<f32>(
+    attributes.instanceLineColors.rgb,
+    attributes.instanceLineColors.a * layer.opacity
+  );
+  varyings.lineWidth = project_unit_size_to_pixel(
+    attributes.instanceLineWidths,
+    block.lineWidthUnits
+  );
+  varyings.size = pixelSize;
+  varyings.pickingColor = attributes.instancePickingColors;
+  return varyings;
+}
+
+@fragment
+fn fragmentMain(varyings: BlockVaryings) -> @location(0) vec4<f32> {
+  let relativePosition = varyings.unitPosition * varyings.size;
+  let distanceToBorder = min(
+    min(relativePosition.x, relativePosition.y),
+    min(varyings.size.x - relativePosition.x, varyings.size.y - relativePosition.y)
+  );
+  var fragColor = select(
+    varyings.fillColor,
+    varyings.lineColor,
+    varyings.lineWidth > 0.0 && distanceToBorder <= varyings.lineWidth
+  );
+
+  if (picking.isActive > 0.5) {
+    if (!picking_isColorValid(varyings.pickingColor)) {
+      discard;
+    }
+    return vec4<f32>(picking_normalizeColor(varyings.pickingColor), 1.0);
+  }
+
+  if (picking.isHighlightActive > 0.5) {
+    let highlightedColor = picking_normalizeColor(picking.highlightedObjectColor);
+    let objectColor = picking_normalizeColor(varyings.pickingColor);
+    if (picking_isColorZero(abs(objectColor - highlightedColor))) {
+      let highlightAlpha = picking.highlightColor.a;
+      let blendedAlpha = highlightAlpha + fragColor.a * (1.0 - highlightAlpha);
+      if (blendedAlpha > 0.0) {
+        fragColor = vec4<f32>(
+          mix(fragColor.rgb, picking.highlightColor.rgb, highlightAlpha / blendedAlpha),
+          blendedAlpha
+        );
+      }
+    }
+  }
+
+  return deckgl_premultiplied_alpha(fragColor);
+}
+`;

--- a/modules/layers/src/dependency-arrow-layer/geometry-layer.ts
+++ b/modules/layers/src/dependency-arrow-layer/geometry-layer.ts
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Layer, picking, project32, UNIT} from '@deck.gl/core';
+import {color, Layer, picking, project32, UNIT} from '@deck.gl/core';
 import {Geometry, Model} from '@luma.gl/engine';
+import source from './geometry-layer.wgsl';
 
 import type {
   Accessor,
@@ -60,6 +61,7 @@ type GeometryLayerUniformProps = {
 
 const geometryLayerUniforms = {
   name: 'geometryLayer',
+  source: '',
   vs: `\
 uniform geometryLayerUniforms {
   float sizeScale;
@@ -270,7 +272,12 @@ export class GeometryLayer<DataT = unknown> extends Layer<Required<_GeometryLaye
   } = {};
 
   override getShaders() {
-    return super.getShaders({vs, fs, modules: [project32, picking, geometryLayerUniforms]});
+    return super.getShaders({
+      source,
+      vs,
+      fs,
+      modules: [project32, color, picking, geometryLayerUniforms]
+    });
   }
 
   initializeState() {

--- a/modules/layers/src/dependency-arrow-layer/geometry-layer.wgsl.ts
+++ b/modules/layers/src/dependency-arrow-layer/geometry-layer.wgsl.ts
@@ -1,0 +1,180 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** WebGPU vertex and fragment shaders for dependency-arrow markers. */
+export default /* wgsl */ `
+struct GeometryLayerUniforms {
+  sizeScale: f32,
+  sizeUnits: i32,
+  interpolationMode: i32,
+  markerAnchor: i32,
+};
+
+@group(0) @binding(auto) var<uniform> geometryLayer: GeometryLayerUniforms;
+
+struct GeometryLayerAttributes {
+  @location(0) positions: vec2<f32>,
+  @location(1) instanceSourcePositions: vec3<f32>,
+  @location(2) instanceSourcePositions64Low: vec3<f32>,
+  @location(3) instanceTargetPositions: vec3<f32>,
+  @location(4) instanceTargetPositions64Low: vec3<f32>,
+  @location(5) instanceRatios: f32,
+  @location(6) instanceArcHeights: f32,
+  @location(7) instanceArcTilts: f32,
+  @location(8) instanceSizes: vec2<f32>,
+  @location(9) instanceColors: vec4<f32>,
+  @location(10) instancePickingColors: vec3<f32>,
+};
+
+struct GeometryLayerVaryings {
+  @builtin(position) position: vec4<f32>,
+  @location(0) color: vec4<f32>,
+  @location(1) markerPosition: vec2<f32>,
+  @location(2) @interpolate(flat) pixelSize: vec2<f32>,
+  @location(3) @interpolate(flat) pickingColor: vec3<f32>,
+};
+
+fn geometry_layer_paraboloid(
+  distance: f32,
+  sourceZ: f32,
+  targetZ: f32,
+  ratio: f32,
+  arcHeight: f32
+) -> f32 {
+  let deltaZ = targetZ - sourceZ;
+  let height = distance * arcHeight;
+  if (height == 0.0) {
+    return mix(sourceZ, targetZ, ratio);
+  }
+  let unitZ = deltaZ / height;
+  let descending = deltaZ <= 0.0;
+  let startZ = select(sourceZ, targetZ, descending);
+  let arcRatio = select(ratio, 1.0 - ratio, descending);
+  return sqrt(max(arcRatio * (unitZ * unitZ + 1.0 - arcRatio), 0.0)) * height + startZ;
+}
+
+fn geometry_layer_interpolate(
+  source: vec3<f32>,
+  target: vec3<f32>,
+  ratio: f32,
+  arcHeight: f32,
+  arcTilt: f32
+) -> vec3<f32> {
+  if (geometryLayer.interpolationMode != 1) {
+    return mix(source, target, ratio);
+  }
+
+  let distance = length(source.xy - target.xy);
+  let height = geometry_layer_paraboloid(distance, source.z, target.z, ratio, arcHeight);
+  let tiltAngle = radians(arcTilt);
+  let delta = target.xy - source.xy;
+  let direction = select(vec2<f32>(1.0, 0.0), normalize(delta), length(delta) > 0.0);
+  let tilt = vec2<f32>(-direction.y, direction.x) * height * sin(tiltAngle);
+  return vec3<f32>(mix(source.xy, target.xy, ratio) + tilt, height * cos(tiltAngle));
+}
+
+@vertex
+fn vertexMain(attributes: GeometryLayerAttributes) -> GeometryLayerVaryings {
+  geometry.worldPosition = attributes.instanceSourcePositions;
+  geometry.worldPositionAlt = attributes.instanceTargetPositions;
+  geometry.pickingColor = attributes.instancePickingColors;
+
+  let source = project_position_vec3_f64(
+    attributes.instanceSourcePositions,
+    attributes.instanceSourcePositions64Low
+  );
+  let target = project_position_vec3_f64(
+    attributes.instanceTargetPositions,
+    attributes.instanceTargetPositions64Low
+  );
+  let current = geometry_layer_interpolate(
+    source,
+    target,
+    attributes.instanceRatios,
+    attributes.instanceArcHeights,
+    attributes.instanceArcTilts
+  );
+  let adjacentRatio = select(
+    attributes.instanceRatios - 0.01,
+    attributes.instanceRatios + 0.01,
+    attributes.instanceRatios < 0.01
+  );
+  let adjacent = geometry_layer_interpolate(
+    source,
+    target,
+    adjacentRatio,
+    attributes.instanceArcHeights,
+    attributes.instanceArcTilts
+  );
+  let normal = select(current.xy - adjacent.xy, adjacent.xy - current.xy, attributes.instanceRatios < 0.01);
+  let markerPosition = select(
+    vec2<f32>((attributes.positions.x - 1.0) * 0.5, attributes.positions.y * 0.5),
+    attributes.positions * 0.5,
+    geometryLayer.markerAnchor == 1
+  );
+  let scaledSize = attributes.instanceSizes * geometryLayer.sizeScale;
+  let unrotatedOffset = markerPosition * scaledSize;
+  let angle = atan2(normal.y, normal.x);
+  let cosine = cos(angle);
+  let sine = sin(angle);
+  let rotatedOffset = vec2<f32>(
+    unrotatedOffset.x * cosine - unrotatedOffset.y * sine,
+    unrotatedOffset.x * sine + unrotatedOffset.y * cosine
+  );
+  let offset = select(
+    rotatedOffset,
+    project_pixel_size_vec2(rotatedOffset),
+    geometryLayer.sizeUnits == UNIT_PIXELS
+  );
+  geometry.position = vec4<f32>(current + vec3<f32>(offset, 0.0), 1.0);
+
+  var varyings: GeometryLayerVaryings;
+  varyings.position = project_common_position_to_clipspace(geometry.position);
+  varyings.markerPosition = (attributes.positions + vec2<f32>(1.0)) * 0.5;
+  varyings.pixelSize = select(
+    project_size_vec2(scaledSize),
+    scaledSize,
+    geometryLayer.sizeUnits == UNIT_PIXELS
+  );
+  varyings.color = vec4<f32>(attributes.instanceColors.rgb, attributes.instanceColors.a * layer.opacity);
+  varyings.pickingColor = attributes.instancePickingColors;
+  return varyings;
+}
+
+@fragment
+fn fragmentMain(varyings: GeometryLayerVaryings) -> @location(0) vec4<f32> {
+  let width = max(varyings.pixelSize.x, 1.0);
+  let profile = 1.0 - abs(1.0 - varyings.markerPosition.y * 2.0);
+  let signedDistance = (profile - varyings.markerPosition.x) * width;
+  let edgeRadius = fwidth(signedDistance);
+  let mask = smoothstep(-edgeRadius, edgeRadius, signedDistance);
+  if (mask == 0.0) {
+    discard;
+  }
+
+  if (picking.isActive > 0.5) {
+    if (!picking_isColorValid(varyings.pickingColor)) {
+      discard;
+    }
+    return vec4<f32>(picking_normalizeColor(varyings.pickingColor), 1.0);
+  }
+
+  var fragColor = vec4<f32>(varyings.color.rgb, varyings.color.a * mask);
+  if (picking.isHighlightActive > 0.5) {
+    let highlightedColor = picking_normalizeColor(picking.highlightedObjectColor);
+    let objectColor = picking_normalizeColor(varyings.pickingColor);
+    if (picking_isColorZero(abs(objectColor - highlightedColor))) {
+      let highlightAlpha = picking.highlightColor.a;
+      let blendedAlpha = highlightAlpha + fragColor.a * (1.0 - highlightAlpha);
+      if (blendedAlpha > 0.0) {
+        fragColor = vec4<f32>(
+          mix(fragColor.rgb, picking.highlightColor.rgb, highlightAlpha / blendedAlpha),
+          blendedAlpha
+        );
+      }
+    }
+  }
+  return deckgl_premultiplied_alpha(fragColor);
+}
+`;

--- a/modules/layers/test/webgpu-layers.browser.spec.ts
+++ b/modules/layers/test/webgpu-layers.browser.spec.ts
@@ -1,0 +1,137 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {COORDINATE_SYSTEM, Deck, OrthographicView} from '@deck.gl/core';
+import {luma, type Device} from '@luma.gl/core';
+import {webgl2Adapter} from '@luma.gl/webgl';
+import {webgpuAdapter} from '@luma.gl/webgpu';
+import {describe, expect, it} from 'vitest';
+
+import {HorizonGraphLayer, MultiHorizonGraphLayer} from '../../../dev/timeline-layers/src';
+import {BlockLayer} from '../../infovis-layers/src';
+import {SkyboxLayer} from '../src';
+import {GeometryLayer} from '../src/dependency-arrow-layer/geometry-layer';
+
+type BrowserGpu = {
+  requestAdapter: () => Promise<unknown>;
+};
+
+function createPortableLayers() {
+  return [
+    new SkyboxLayer({id: 'webgpu-test-skybox', cubemap: null}),
+    new BlockLayer({
+      id: 'webgpu-test-block',
+      coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+      data: [{position: [-20, -20, 0], size: [30, 20]}],
+      sizeUnits: 'common',
+      getPosition: datum => datum.position,
+      getSize: datum => datum.size,
+      getFillColor: [37, 99, 235, 255],
+      getLineColor: [15, 23, 42, 255],
+      pickable: true
+    }),
+    new GeometryLayer({
+      id: 'webgpu-test-marker',
+      coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+      data: [{source: [-25, 10, 0], target: [25, 10, 0]}],
+      getSourcePosition: datum => datum.source,
+      getTargetPosition: datum => datum.target,
+      getColor: [16, 185, 129, 255],
+      getSize: [10, 6],
+      pickable: true
+    }),
+    new HorizonGraphLayer({
+      id: 'webgpu-test-horizon',
+      coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+      data: new Float32Array([0, 25, -25, 50, -50, 100]),
+      x: -30,
+      y: 15,
+      width: 60,
+      height: 15,
+      yAxisScale: 100,
+      bands: 2
+    }),
+    new MultiHorizonGraphLayer({
+      id: 'webgpu-test-multi-horizon',
+      coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+      data: [
+        {values: new Float32Array([0, 25, -25, 50]), scale: 100},
+        {values: new Float32Array([50, -50, 25, 0]), scale: 100}
+      ],
+      getSeries: datum => datum.values,
+      getScale: datum => datum.scale,
+      x: -30,
+      y: -5,
+      width: 60,
+      height: 18,
+      dividerWidth: 2,
+      bands: 2
+    })
+  ];
+}
+
+async function renderPortableLayers(type: 'webgl' | 'webgpu'): Promise<void> {
+  const parent = document.createElement('div');
+  parent.style.width = '128px';
+  parent.style.height = '128px';
+  document.body.append(parent);
+
+  let device: Device | undefined;
+  let deck: Deck | undefined;
+
+  try {
+    device = await luma.createDevice({
+      type,
+      adapters: [webgl2Adapter, webgpuAdapter],
+      createCanvasContext: {container: parent}
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = window.setTimeout(() => {
+        reject(new Error(`Timed out while rendering community layers with ${type}.`));
+      }, 10_000);
+
+      deck = new Deck({
+        device,
+        parent,
+        width: 128,
+        height: 128,
+        views: new OrthographicView({id: 'webgpu-layer-test', flipY: false}),
+        initialViewState: {target: [0, 0, 0], zoom: 0},
+        layers: createPortableLayers(),
+        onAfterRender: () => {
+          window.clearTimeout(timeout);
+          resolve();
+        },
+        onError: error => {
+          window.clearTimeout(timeout);
+          reject(error);
+        }
+      });
+    });
+
+    expect(deck.device?.type).toBe(type);
+  } finally {
+    deck?.finalize();
+    device?.destroy();
+    parent.remove();
+  }
+}
+
+describe('community graphics backend compatibility', () => {
+  it('renders skybox, blocks, dependency markers, and horizon textures on WebGL2', async () => {
+    await renderPortableLayers('webgl');
+  }, 20_000);
+
+  it('renders skybox, blocks, dependency markers, and horizon textures on WebGPU', async ({
+    skip
+  }) => {
+    const gpu = (navigator as Navigator & {gpu?: BrowserGpu}).gpu;
+    if (!gpu || !(await gpu.requestAdapter())) {
+      skip('This browser does not expose an available WebGPU adapter.');
+    }
+
+    await renderPortableLayers('webgpu');
+  }, 20_000);
+});

--- a/modules/layers/test/webgpu-shaders.spec.ts
+++ b/modules/layers/test/webgpu-shaders.spec.ts
@@ -1,0 +1,87 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {color, getShaderAssembler, picking, project32} from '@deck.gl/core';
+import type {ShaderModule} from '@luma.gl/shadertools';
+import {describe, expect, it} from 'vitest';
+
+import blockSource from '../../infovis-layers/src/layers/block-layer/block-layer.wgsl';
+import {blockUniforms} from '../../infovis-layers/src/layers/block-layer/block-layer-uniforms';
+import horizonSource from '../../../dev/timeline-layers/src/layers/horizon-graph-layer/horizon-graph-layer.wgsl';
+import {horizonLayerUniforms} from '../../../dev/timeline-layers/src/layers/horizon-graph-layer/horizon-graph-layer-uniforms';
+import geometrySource from '../src/dependency-arrow-layer/geometry-layer.wgsl';
+
+const WEBGPU_PLATFORM = {
+  type: 'webgpu',
+  shaderLanguage: 'wgsl',
+  shaderLanguageVersion: 300,
+  gpu: 'test-webgpu',
+  features: new Set<string>()
+} as const;
+
+const layerUniforms = {
+  name: 'layer',
+  source: /* wgsl */ `
+struct LayerUniforms {
+  opacity: f32,
+};
+
+@group(0) @binding(auto) var<uniform> layer: LayerUniforms;
+`,
+  uniformTypes: {opacity: 'f32'}
+} as const satisfies ShaderModule;
+
+const geometryLayerUniforms = {
+  name: 'geometryLayer',
+  source: '',
+  uniformTypes: {
+    sizeScale: 'f32',
+    sizeUnits: 'i32',
+    interpolationMode: 'i32',
+    markerAnchor: 'i32'
+  }
+} as const satisfies ShaderModule;
+
+function assembleWebgpuShader(source: string, modules: ShaderModule[]) {
+  return getShaderAssembler('wgsl').assembleWGSLShader({
+    source,
+    modules: [layerUniforms, ...modules],
+    platformInfo: WEBGPU_PLATFORM
+  });
+}
+
+describe('community WebGPU shaders', () => {
+  it('assembles block projection, colors, picking, and uniform bindings', () => {
+    const shader = assembleWebgpuShader(blockSource, [project32, color, picking, blockUniforms]);
+
+    expect(shader.source).toContain('fn vertexMain');
+    expect(shader.source).toContain('fn fragmentMain');
+    expect(shader.source).toContain('project_position_to_clipspace_and_commonspace');
+    expect(shader.source).toContain('picking_normalizeColor');
+    expect(shader.source).not.toContain('@binding(auto)');
+  });
+
+  it('assembles directional marker projection, arc interpolation, and picking', () => {
+    const shader = assembleWebgpuShader(geometrySource, [
+      project32,
+      color,
+      picking,
+      geometryLayerUniforms
+    ]);
+
+    expect(shader.source).toContain('geometry_layer_interpolate');
+    expect(shader.source).toContain('geometry_layer_paraboloid');
+    expect(shader.source).toContain('picking_normalizeColor');
+    expect(shader.source).not.toContain('@binding(auto)');
+  });
+
+  it('assembles horizon floating-point texture and uniform bindings', () => {
+    const shader = assembleWebgpuShader(horizonSource, [project32, horizonLayerUniforms]);
+
+    expect(shader.source).toContain('texture_2d<f32>');
+    expect(shader.source).toContain('textureLoad(dataTexture');
+    expect(shader.source).toContain('horizonLayer');
+    expect(shader.source).not.toContain('@binding(auto)');
+  });
+});

--- a/modules/widgets/src/lib/device-manager/device-manager.test.tsx
+++ b/modules/widgets/src/lib/device-manager/device-manager.test.tsx
@@ -96,4 +96,93 @@ describe('DeviceManagerController', () => {
     expect(manager.getState().deviceError).toBe('WebGPU unavailable');
     expect(manager.getState().isLoading).toBe(false);
   });
+
+  it('initializes WebGPU first when no backend preference is stored', async () => {
+    const webgpuDevice = createMockDevice('webgpu');
+    createDeviceMock.mockResolvedValue(webgpuDevice);
+
+    await expect(manager.initialize()).resolves.toBe('webgpu');
+    expect(manager.getState().device).toBe(webgpuDevice);
+    expect(createDeviceMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores the persisted backend preference', async () => {
+    const webglDevice = createMockDevice('webgl');
+    window.localStorage.setItem('deck.gl-community-device-type', 'webgl');
+    createDeviceMock.mockResolvedValue(webglDevice);
+
+    await expect(manager.initialize()).resolves.toBe('webgl');
+    expect(manager.getState().device).toBe(webglDevice);
+    expect(createDeviceMock).toHaveBeenCalledWith(expect.objectContaining({type: 'webgl'}));
+  });
+
+  it('falls back to WebGL when WebGPU is unavailable', async () => {
+    const webglDevice = createMockDevice('webgl');
+    createDeviceMock.mockImplementation(({type}: {type: 'webgl' | 'webgpu'}) =>
+      type === 'webgpu'
+        ? Promise.reject(new Error('WebGPU unavailable'))
+        : Promise.resolve(webglDevice)
+    );
+
+    await expect(manager.initialize()).resolves.toBe('webgl');
+    expect(manager.getState().device).toBe(webglDevice);
+    expect(manager.getState().deviceError).toBeUndefined();
+  });
+
+  it('keeps device caches independent between managers', async () => {
+    const firstDevice = createMockDevice('first');
+    const secondDevice = createMockDevice('second');
+    createDeviceMock.mockResolvedValueOnce(firstDevice).mockResolvedValueOnce(secondDevice);
+    const secondManager = new DeviceManagerController();
+
+    await expect(manager.createDevice('webgpu')).resolves.toBe(firstDevice);
+    await expect(secondManager.createDevice('webgpu')).resolves.toBe(secondDevice);
+    expect(createDeviceMock).toHaveBeenCalledTimes(2);
+
+    secondManager.reset();
+  });
+
+  it('reuses cached devices when switching repeatedly between backends', async () => {
+    const webgpuDevice = createMockDevice('webgpu');
+    const webglDevice = createMockDevice('webgl');
+    createDeviceMock.mockImplementation(({type}: {type: 'webgl' | 'webgpu'}) =>
+      Promise.resolve(type === 'webgpu' ? webgpuDevice : webglDevice)
+    );
+
+    await manager.setDeviceType('webgpu');
+    await manager.setDeviceType('webgl');
+    await manager.setDeviceType('webgpu');
+
+    expect(manager.getState().deviceType).toBe('webgpu');
+    expect(manager.getState().device).toBe(webgpuDevice);
+    expect(createDeviceMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears managed state and its hidden canvas parent on reset', async () => {
+    createDeviceMock.mockResolvedValue(createMockDevice('webgpu'));
+    await manager.setDeviceType('webgpu');
+
+    expect(document.body.querySelector('[data-device-manager-canvas-parent]')).not.toBeNull();
+
+    manager.reset();
+
+    expect(manager.getState()).toEqual({
+      deviceType: undefined,
+      device: undefined,
+      deviceError: undefined,
+      isLoading: false
+    });
+    expect(document.body.querySelector('[data-device-manager-canvas-parent]')).toBeNull();
+  });
+
+  it('stops notifying a listener after it unsubscribes', async () => {
+    createDeviceMock.mockResolvedValue(createMockDevice('webgpu'));
+    const listener = vi.fn();
+    const unsubscribe = manager.subscribe(listener);
+
+    unsubscribe();
+    await manager.setDeviceType('webgpu');
+
+    expect(listener).not.toHaveBeenCalled();
+  });
 });

--- a/modules/widgets/src/widgets/device-tabs-widget.test.tsx
+++ b/modules/widgets/src/widgets/device-tabs-widget.test.tsx
@@ -56,6 +56,11 @@ class MockDeviceManager {
     return Promise.resolve();
   }
 
+  setDeviceError(message: string): void {
+    this.#state = {...this.#state, deviceError: message};
+    this.#emit();
+  }
+
   #emit(): void {
     const state = this.getState();
     for (const listener of this.#listeners) {
@@ -118,5 +123,78 @@ describe('DeviceTabsWidget', () => {
     root.querySelector<HTMLButtonElement>('[data-device-tab-id="webgl"]')?.click();
 
     expect(setDeviceTypeSpy).toHaveBeenCalledWith('webgl');
+  });
+
+  it('reports when neither graphics backend is available', async () => {
+    const root = document.createElement('div');
+    document.body.append(root);
+    const manager = new MockDeviceManager();
+    manager.availability.webgpu = false;
+    manager.availability.webgl = false;
+    const widget = new DeviceTabsWidget({
+      devices: ['webgpu', 'webgl2'],
+      manager: manager as never
+    });
+
+    widget.onRenderHTML(root);
+
+    await vi.waitFor(() => {
+      expect(root.querySelector('[data-device-tabs-message="unavailable"]')?.textContent).toBe(
+        'No supported graphics backend is available.'
+      );
+    });
+    expect(root.querySelector<HTMLButtonElement>('[data-device-tab-id="webgpu"]')?.disabled).toBe(
+      true
+    );
+    expect(root.querySelector<HTMLButtonElement>('[data-device-tab-id="webgl"]')?.disabled).toBe(
+      true
+    );
+  });
+
+  it('displays device creation errors', async () => {
+    const root = document.createElement('div');
+    document.body.append(root);
+    const manager = new MockDeviceManager();
+    const widget = new DeviceTabsWidget({
+      devices: ['webgpu', 'webgl2'],
+      manager: manager as never
+    });
+
+    widget.onRenderHTML(root);
+    manager.setDeviceError('WebGPU device creation failed');
+
+    await vi.waitFor(() => {
+      expect(root.querySelector('[data-device-tabs-message="error"]')?.textContent).toBe(
+        'WebGPU device creation failed'
+      );
+    });
+  });
+
+  it('keeps independently managed backend selections separate', async () => {
+    const firstRoot = document.createElement('div');
+    const secondRoot = document.createElement('div');
+    document.body.append(firstRoot, secondRoot);
+    const firstManager = new MockDeviceManager();
+    const secondManager = new MockDeviceManager();
+    const firstWidget = new DeviceTabsWidget({
+      devices: ['webgpu', 'webgl2'],
+      manager: firstManager as never
+    });
+    const secondWidget = new DeviceTabsWidget({
+      devices: ['webgpu', 'webgl2'],
+      manager: secondManager as never
+    });
+
+    firstWidget.onRenderHTML(firstRoot);
+    secondWidget.onRenderHTML(secondRoot);
+    await vi.waitFor(() => {
+      expect(firstManager.getState().deviceType).toBe('webgpu');
+      expect(secondManager.getState().deviceType).toBe('webgpu');
+    });
+
+    firstRoot.querySelector<HTMLButtonElement>('[data-device-tab-id="webgl"]')?.click();
+
+    expect(firstManager.getState().deviceType).toBe('webgl');
+    expect(secondManager.getState().deviceType).toBe('webgpu');
   });
 });

--- a/website/src/docs-sidebar.js
+++ b/website/src/docs-sidebar.js
@@ -37,7 +37,7 @@ const sidebars = {
       type: 'category',
       label: 'Overview',
       className: 'heading_bold',
-      items: ['README', 'whats-new', 'upgrade-guide', 'CONTRIBUTING']
+      items: ['README', 'whats-new', 'webgpu', 'upgrade-guide', 'CONTRIBUTING']
     },
     {
       type: 'category',

--- a/yarn.lock
+++ b/yarn.lock
@@ -9791,6 +9791,8 @@ __metadata:
   resolution: "infovis-layer-primitives-example@workspace:examples/infovis-layers/layer-primitives"
   dependencies:
     "@deck.gl-community/infovis-layers": "workspace:*"
+    "@deck.gl-community/panels": "workspace:*"
+    "@deck.gl-community/widgets": "workspace:*"
     "@deck.gl/core": "npm:~9.3.0"
     "@deck.gl/layers": "npm:~9.3.0"
     "@loaders.gl/core": "npm:^4.4.1"
@@ -14822,6 +14824,8 @@ __metadata:
   dependencies:
     "@deck.gl-community/basemap-layers": "workspace:*"
     "@deck.gl-community/layers": "workspace:*"
+    "@deck.gl-community/panels": "workspace:*"
+    "@deck.gl-community/widgets": "workspace:*"
     "@deck.gl/core": "npm:~9.3.0"
     "@deck.gl/extensions": "npm:~9.3.0"
     "@deck.gl/geo-layers": "npm:~9.3.0"
@@ -14831,6 +14835,8 @@ __metadata:
     "@luma.gl/core": "npm:~9.3.2"
     "@luma.gl/engine": "npm:~9.3.2"
     "@luma.gl/shadertools": "npm:~9.3.2"
+    "@luma.gl/webgl": "npm:~9.3.2"
+    "@luma.gl/webgpu": "npm:~9.3.2"
     vite: "npm:^7.3.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary

Start the deck.gl-community WebGPU migration while preserving WebGL2 support and keeping trace-layer and Tracevis changes out of scope.

- Add native WGSL alongside existing GLSL for `BlockLayer`, dependency-arrow marker geometry, and `HorizonGraphLayer`.
- Make `MultiHorizonGraphLayer` portable by using WebGPU-compatible `LineLayer` dividers.
- Add independently managed, real WebGPU/WebGL2 device tabs to the skybox, path and dependency-marker, information-visualization, and horizon-graph examples.
- Add a module-by-module WebGPU support matrix using ✅, 🚧, and ❌, documenting upstream `PathLayer`, `PathStyleExtension`, basemap, and integration blockers.
- Update the v9.4 release notes to **In Development**, set the target release to **July 2026**, link the WebGPU support page, and document each ported layer.
- Add WGSL assembly, browser rendering, stacked horizon, device-manager, fallback, backend-switching, cleanup, and device-tab regression tests.

## Validation

- `yarn test --run` — 1,386 tests passed.
- `yarn test-headless` — 422 tests passed; the WebGPU rendering case is explicitly skipped because this environment does not expose a WebGPU adapter.
- `yarn build` — passed.
- `yarn build` from `website/` — passed.
- `yarn lint` — passed.
- Confirmed no changes to `modules/trace-layers` or `examples/trace-layers`.

## Compatibility notes

`SkyboxLayer`, `BlockLayer`, dependency-arrow line-mode marker geometry, `HorizonGraphLayer`, and `MultiHorizonGraphLayer` provide the initial portable layer set. Full dashed and outlined path rendering remains dependent on upstream deck.gl WebGPU support; the compatibility matrix explicitly records those limitations.