### PR TITLE
feat: port historic wind showcase into reusable geo layers

### DIFF
--- a/docs/modules/geo-layers/README.md
+++ b/docs/modules/geo-layers/README.md
@@ -22,6 +22,16 @@ This modules exports various geospatial deck.gl layers developed by the communit
 
 ## API Reference
 
+- [WindLayer](/docs/modules/geo-layers/api-reference/wind-layer) renders Delaunay-interpolated,
+  speed-colored wind arrows.
+- [ParticleLayer](/docs/modules/geo-layers/api-reference/particle-layer) animates fading trails
+  through a geographic wind field.
+- [ElevationLayer](/docs/modules/geo-layers/api-reference/elevation-layer) turns the original
+  grayscale elevation map into illuminated, vertically exaggerated 3D terrain.
+- [DelaunayCoverLayer](/docs/modules/geo-layers/api-reference/delaunay-cover-layer) renders the
+  elevation-colored station triangulation.
+- [DelaunayInterpolation](/docs/modules/geo-layers/api-reference/delaunay-interpolation) samples
+  or rasterizes time-varying station measurements without WebGL-only transforms.
 - [SharedTile2DLayer](/docs/modules/geo-layers/api-reference/shared-tile-2d-layer)
   <img src="https://img.shields.io/badge/from-v9.3-green.svg?style=flat-square" alt="from v9.3" />
   <img src="https://img.shields.io/badge/experimental-orange.svg?style=flat-square" alt="experimental" />
@@ -37,5 +47,7 @@ This modules exports various geospatial deck.gl layers developed by the communit
 
 ## Examples
 
+- [Wind Map](/examples/geo-layers/wind) recreates Nicolas Belmonte's original deck.gl wind showcase
+  using its original 72-hour station forecast and imported, reusable geo-layers.
 - [SharedTile2DLayer example](/examples/geo-layers/shared-tile-2d-layer) demonstrates one shared loaders.gl `TileSource` feeding multiple `SharedTile2DLayer`s across multiple views.
   It also shows shared `SharedTileset2D` cache stats rendered through `SharedTileset2D.stats` and uses `TileGridLayer` to visualize tile loading.

--- a/docs/modules/geo-layers/api-reference/delaunay-cover-layer.md
+++ b/docs/modules/geo-layers/api-reference/delaunay-cover-layer.md
@@ -1,0 +1,29 @@
+# DelaunayCoverLayer
+
+`DelaunayCoverLayer` renders a terrain surface from the same weather-station triangulation used to
+interpolate a `WindField`. Each triangle follows measured station elevations and is colored by its
+average height. It recreates the elevation surface in the original deck.gl wind showcase.
+
+```ts
+import {DelaunayCoverLayer} from '@deck.gl-community/geo-layers';
+
+const layer = new DelaunayCoverLayer({
+  id: 'wind-terrain',
+  windField,
+  elevationScale: 14,
+  lowColor: [17, 34, 49, 220],
+  highColor: [102, 151, 127, 235]
+});
+```
+
+## Properties
+
+- `windField`: A `WindField` returned by `createWindField`.
+- `elevationScale`: Multiplier for each station elevation.
+- `lowColor`, `highColor`: RGBA colors interpolated by average triangle elevation.
+
+## Sub-layers
+
+- `terrain`: A `SolidPolygonLayer` containing the station Delaunay triangles.
+
+See the [Wind Map example](/examples/geo-layers/wind).

--- a/docs/modules/geo-layers/api-reference/delaunay-interpolation.md
+++ b/docs/modules/geo-layers/api-reference/delaunay-interpolation.md
@@ -1,0 +1,40 @@
+# DelaunayInterpolation
+
+`DelaunayInterpolation` samples or rasterizes the station-interpolated vector field used by the
+wind showcase layers. It replaces the original showcase's off-screen WebGL transform with a
+backend-independent implementation suitable for WebGL, WebGPU, preprocessing, and Node.js.
+
+```ts
+import {
+  createWindField,
+  DelaunayInterpolation,
+  parseWindData
+} from '@deck.gl-community/geo-layers';
+
+const stations = await fetch('/stations.json').then(response => response.json());
+const weather = await fetch('/weather.bin').then(response => response.arrayBuffer());
+const field = createWindField(stations, parseWindData(weather, stations.length));
+
+const interpolation = new DelaunayInterpolation({field, width: 256});
+const sample = interpolation.sample([-97, 38], 12.5);
+const raster = interpolation.rasterize(12.5);
+```
+
+`sample` returns direction in radians, wind speed, temperature, elevation, and an east/north
+velocity vector. Points outside the triangulated station coverage return `null`.
+
+`rasterize` returns `{width, height, data}`, where `data` is a `Float32Array` containing direction,
+speed, temperature, and elevation in RGBA component order.
+
+## Related utilities
+
+- `parseWindData(buffer, stationCount, frameCount?)`: Decodes the original station-major binary
+  forecast. The default forecast length is 72 hourly frames.
+- `getWindBounds(stations)`: Converts positive-west legacy station longitudes into geographic
+  bounds.
+- `triangulateWindStations(stations)`: Builds a Delaunay triangulation without external
+  triangulation dependencies.
+- `createWindField(stations, frames, options?)`: Creates a spatially indexed, time-varying wind
+  field shared by all three layers.
+- `sampleWindField(field, position, time?)`: Samples a field without constructing an interpolation
+  wrapper.

--- a/docs/modules/geo-layers/api-reference/elevation-layer.md
+++ b/docs/modules/geo-layers/api-reference/elevation-layer.md
@@ -1,0 +1,39 @@
+# ElevationLayer
+
+`ElevationLayer` renders a grayscale elevation image as a genuinely three-dimensional, illuminated
+terrain mesh. It ports the height-map surface used by Nicolas Belmonte's original wind showcase,
+including the original elevation image, geographic bounds, and elevation range.
+
+```ts
+import {ElevationLayer} from '@deck.gl-community/geo-layers';
+
+const layer = new ElevationLayer({
+  id: 'wind-elevation',
+  elevationData:
+    'https://raw.githubusercontent.com/visgl/deck.gl-data/master/examples/wind/elevation.png',
+  bounds: [-125, 24.4, -66.7, 49.6],
+  elevationRange: [-100, 4126],
+  elevationScale: 80,
+  meshMaxError: 480,
+  color: [42, 60, 77, 255]
+});
+```
+
+The layer decodes the original height map into terrain geometry using the in-process loaders.gl
+terrain loader. It does not require an externally hosted terrain worker.
+
+## Properties
+
+- `elevationData`: URL of the red-channel grayscale terrain height map.
+- `bounds`: Geographic `[west, south, east, north]` extent.
+- `elevationRange`: Minimum and maximum image elevations, in meters.
+- `elevationScale`: Vertical exaggeration applied to the decoded mesh.
+- `meshMaxError`: Simplification error tolerance for the generated terrain mesh.
+- `color`: RGBA color applied to the lit terrain surface.
+- `texture`: Optional image draped over the three-dimensional mesh.
+
+## Sub-layers
+
+- `terrain-mesh`: A `TerrainLayer` containing the decoded elevation mesh.
+
+See the [Wind Map example](/examples/geo-layers/wind).

--- a/docs/modules/geo-layers/api-reference/particle-layer.md
+++ b/docs/modules/geo-layers/api-reference/particle-layer.md
@@ -1,0 +1,47 @@
+# ParticleLayer
+
+`ParticleLayer` renders animated, fading particle trails advected through a Delaunay-interpolated
+geographic wind field. It ports the particle animation from the original deck.gl wind showcase
+without relying on WebGL-only transform feedback.
+
+```ts
+import {ParticleLayer} from '@deck.gl-community/geo-layers';
+
+const layer = new ParticleLayer({
+  id: 'wind-particles',
+  windField,
+  time,
+  numParticles: 2400,
+  trailLength: 12,
+  speedScale: 0.085,
+  color: [194, 246, 224, 210],
+  elevationScale: 10,
+  surfaceOffset: 160,
+  pointRadiusPixels: 1.6
+});
+```
+
+Advance `time` and pass a new `ParticleLayer` with the same `id` to `deck.setProps`. Deck.gl
+transfers the existing particle state into the new layer, preserving continuous trails.
+Particle advection is scaled to elapsed animation time rather than the browser frame rate, and
+direction and speed are interpolated to produce smooth, curved streamlines.
+
+## Properties
+
+- `windField`: A `WindField` returned by `createWindField`.
+- `time`: Fractional, cyclic weather-frame and particle-animation time.
+- `numParticles`: Number of deterministic, continuously advected particles.
+- `trailLength`: Maximum number of positions retained per particle.
+- `speedScale`: Geographic particle movement per elapsed, 30-frame-per-second animation step.
+- `widthMinPixels`: Minimum screen-space trail width.
+- `color`: RGBA trail color; segments fade toward their historical positions.
+- `elevationScale`: Multiplier for interpolated station elevation.
+- `surfaceOffset`: Vertical separation above the rendered terrain surface, in meters.
+- `pointRadiusPixels`: Radius of each bright, moving particle head.
+
+## Sub-layers
+
+- `trails`: A `LineLayer` containing independently faded particle-trail segments.
+- `heads`: A `ScatterplotLayer` containing the animated, bright white particle heads.
+
+See the [Wind Map example](/examples/geo-layers/wind).

--- a/docs/modules/geo-layers/api-reference/wind-layer.md
+++ b/docs/modules/geo-layers/api-reference/wind-layer.md
@@ -1,0 +1,54 @@
+# WindLayer
+
+`WindLayer` renders a time-varying weather vector field as directionally accurate, speed-colored
+arrow glyphs. It ports the wind-vector component of Nicolas Belmonte's original deck.gl wind
+showcase into an independently reusable, WebGL- and WebGPU-compatible composite layer.
+
+```ts
+import {createWindField, parseWindData, WindLayer} from '@deck.gl-community/geo-layers';
+
+const stations = await fetch('/stations.json').then(response => response.json());
+const weather = await fetch('/weather.bin').then(response => response.arrayBuffer());
+const windField = createWindField(stations, parseWindData(weather, stations.length));
+
+const layer = new WindLayer({
+  id: 'wind-vectors',
+  windField,
+  time: 12.5,
+  gridWidth: 64,
+  gridHeight: 32,
+  speedScale: 0.65,
+  elevationScale: 10
+});
+```
+
+## Properties
+
+- `windField`: A `WindField` returned by `createWindField`.
+- `time`: Fractional weather-frame index. Animation wraps at the final frame.
+- `gridWidth`, `gridHeight`: Horizontal and vertical arrow sampling resolution.
+- `speedScale`: Arrow-length multiplier relative to the geographic sample spacing.
+- `widthMinPixels`: Minimum on-screen arrow width.
+- `lowColor`, `highColor`: RGBA colors interpolated by observed wind speed.
+- `elevationScale`: Multiplier for interpolated station elevation.
+- `surfaceOffset`: Vertical separation above the terrain surface, in meters.
+
+## Sub-layers
+
+- `glyphs`: A `SolidPolygonLayer` containing filled directional wind arrows.
+- `shafts`: A `PathLayer` containing wind-vector shafts.
+- `arrowheads`: A `PathLayer` containing directional arrowheads.
+
+See the [Wind Map example](/examples/geo-layers/wind) for the complete recreation of the original
+showcase.
+
+## Historical source
+
+The original implementation lives in deck.gl's
+[6.4-release wind showcase](https://github.com/visgl/deck.gl/tree/6.4-release/showcases/wind).
+Earlier upstream work includes the
+[luma.gl v4 wind-layer port](https://github.com/visgl/deck.gl/pull/794), the
+[transform-feedback and instanced-particle update](https://github.com/visgl/deck.gl/pull/1346),
+and the [Delaunay interpolation transform update](https://github.com/visgl/deck.gl/pull/2318).
+The community port preserves the original station and forecast data while replacing obsolete,
+WebGL-only rendering APIs with modern, backend-portable deck.gl sub-layers.

--- a/docs/modules/geo-layers/sidebar.json
+++ b/docs/modules/geo-layers/sidebar.json
@@ -3,11 +3,16 @@
   "label": "@deck.gl-community/geo-layers",
   "items": [
     "modules/geo-layers/README",
+    "modules/geo-layers/api-reference/delaunay-cover-layer",
+    "modules/geo-layers/api-reference/delaunay-interpolation",
+    "modules/geo-layers/api-reference/elevation-layer",
+    "modules/geo-layers/api-reference/particle-layer",
     "modules/geo-layers/api-reference/shared-tile-2d-layer",
     "modules/geo-layers/api-reference/shared-tileset-2d",
     "modules/geo-layers/api-reference/tile-grid-layer",
     "modules/geo-layers/api-reference/tile-source-layer",
     "modules/geo-layers/api-reference/global-grid-layer",
+    "modules/geo-layers/api-reference/wind-layer",
     {
       "type": "category",
       "label": "Grids",

--- a/examples/geo-layers/wind/app.ts
+++ b/examples/geo-layers/wind/app.ts
@@ -1,0 +1,395 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {
+  AmbientLight,
+  Deck,
+  DirectionalLight,
+  LightingEffect,
+  MapView,
+  type MapViewState
+} from '@deck.gl/core';
+import {GeoJsonLayer, ScatterplotLayer, TextLayer} from '@deck.gl/layers';
+import {
+  createWindField,
+  DelaunayCoverLayer,
+  ElevationLayer,
+  parseWindData,
+  ParticleLayer,
+  sampleWindField,
+  WindLayer,
+  type WindField,
+  type WindStation
+} from '@deck.gl-community/geo-layers';
+
+const WIND_DATA_ROOT = 'https://raw.githubusercontent.com/visgl/deck.gl-data/master/examples/wind';
+const US_STATE_BOUNDARIES =
+  'https://raw.githubusercontent.com/PublicaMundi/MappingAPI/master/data/geojson/us-states.json';
+const ELEVATION_BOUNDS: [number, number, number, number] = [-125, 24.4, -66.7, 49.6];
+const ELEVATION_SCALE = 80;
+const INITIAL_VIEW_STATE: MapViewState = {
+  longitude: -98.319,
+  latitude: 37.614,
+  zoom: 4.05,
+  pitch: 46,
+  bearing: -0.64,
+  minPitch: 0,
+  maxPitch: 85
+};
+
+type WindCity = {name: string; position: [number, number]};
+
+const WIND_CITIES: WindCity[] = [
+  {name: 'Seattle', position: [-122.332, 47.606]},
+  {name: 'Portland', position: [-122.676, 45.523]},
+  {name: 'Boise', position: [-116.202, 43.615]},
+  {name: 'Missoula', position: [-113.995, 46.873]},
+  {name: 'Billings', position: [-108.5, 45.783]},
+  {name: 'San Francisco', position: [-122.419, 37.775]},
+  {name: 'Los Angeles', position: [-118.244, 34.052]},
+  {name: 'Las Vegas', position: [-115.14, 36.17]},
+  {name: 'Salt Lake City', position: [-111.891, 40.761]},
+  {name: 'Phoenix', position: [-112.074, 33.448]},
+  {name: 'Albuquerque', position: [-106.65, 35.084]},
+  {name: 'Denver', position: [-104.99, 39.739]},
+  {name: 'Cheyenne', position: [-104.82, 41.14]},
+  {name: 'Omaha', position: [-95.998, 41.256]},
+  {name: 'Minneapolis', position: [-93.265, 44.978]},
+  {name: 'Kansas City', position: [-94.578, 39.1]},
+  {name: 'Dallas', position: [-96.797, 32.776]},
+  {name: 'Austin', position: [-97.743, 30.267]},
+  {name: 'Houston', position: [-95.37, 29.76]},
+  {name: 'Chicago', position: [-87.63, 41.878]},
+  {name: 'Nashville', position: [-86.781, 36.163]},
+  {name: 'Atlanta', position: [-84.388, 33.749]},
+  {name: 'Washington', position: [-77.037, 38.907]},
+  {name: 'New York', position: [-74.006, 40.713]}
+];
+
+const WIND_LIGHTING = new LightingEffect({
+  ambient: new AmbientLight({color: [194, 210, 235], intensity: 0.8}),
+  sunlight: new DirectionalLight({
+    color: [255, 226, 198],
+    intensity: 1.7,
+    direction: [-1, -2, -2]
+  }),
+  fill: new DirectionalLight({
+    color: [125, 170, 223],
+    intensity: 0.5,
+    direction: [2, 1, -1]
+  })
+});
+
+/** Options accepted by the standalone and embedded historical wind showcase. */
+export type WindExampleOptions = {
+  /** Receives the initialized deck instance when the website manages GPU devices. */
+  onDeckInitialized?: (deck: Deck) => void;
+  /** Overrides the original public wind showcase dataset location. */
+  dataUrl?: string;
+};
+
+type WindSettings = {
+  showParticles: boolean;
+  showWind: boolean;
+  showTerrain: boolean;
+  showStationMesh: boolean;
+  showStations: boolean;
+};
+
+async function loadWindField(dataUrl: string, signal: AbortSignal): Promise<WindField> {
+  const [stationsResponse, weatherResponse] = await Promise.all([
+    fetch(`${dataUrl}/stations.json`, {signal}),
+    fetch(`${dataUrl}/weather.bin`, {signal})
+  ]);
+  if (!stationsResponse.ok) {
+    throw new Error(`Could not load wind stations: ${stationsResponse.status}.`);
+  }
+  if (!weatherResponse.ok) {
+    throw new Error(`Could not load wind measurements: ${weatherResponse.status}.`);
+  }
+
+  const [stations, weather] = await Promise.all([
+    stationsResponse.json() as Promise<WindStation[]>,
+    weatherResponse.arrayBuffer()
+  ]);
+  return createWindField(stations, parseWindData(weather, stations.length));
+}
+
+/** Turns the original grayscale elevation map into a dark, transparent terrain texture. */
+async function loadTerrainTexture(dataUrl: string, signal: AbortSignal): Promise<string> {
+  const response = await fetch(`${dataUrl}/elevation.png`, {signal});
+  if (!response.ok) {
+    throw new Error(`Could not load terrain elevation: ${response.status}.`);
+  }
+
+  const image = await createImageBitmap(await response.blob());
+  const canvas = document.createElement('canvas');
+  canvas.width = image.width;
+  canvas.height = image.height;
+  const context = canvas.getContext('2d', {willReadFrequently: true});
+  if (!context) {
+    image.close();
+    throw new Error('Could not initialize the wind terrain texture.');
+  }
+
+  context.drawImage(image, 0, 0);
+  image.close();
+  const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+  const {data} = imageData;
+  for (let offset = 0; offset < data.length; offset += 4) {
+    const height = data[offset];
+    data[offset] = 20 + Math.round(height * 0.15);
+    data[offset + 1] = 30 + Math.round(height * 0.19);
+    data[offset + 2] = 43 + Math.round(height * 0.22);
+    data[offset + 3] = height > 2 ? 245 : 0;
+  }
+  context.putImageData(imageData, 0, 0);
+  return canvas.toDataURL('image/png');
+}
+
+function createSettingsPanel(settings: WindSettings, onChange: () => void): HTMLElement {
+  const panel = document.createElement('section');
+  panel.style.cssText =
+    'position:absolute;top:18px;left:18px;z-index:1;width:min(286px,calc(100% - 36px));' +
+    'padding:17px 19px;border:1px solid rgba(192,230,217,.2);border-radius:14px;' +
+    'background:rgba(10,20,31,.84);color:#e8f7f0;font:13px/1.6 system-ui,sans-serif;' +
+    'backdrop-filter:blur(14px);box-shadow:0 14px 42px rgba(0,0,0,.24)';
+
+  const title = document.createElement('h2');
+  title.textContent = 'Wind over the United States';
+  title.style.cssText = 'margin:0 0 4px;font-size:17px;font-weight:650;letter-spacing:-.02em';
+  panel.append(title);
+
+  const description = document.createElement('p');
+  description.textContent =
+    'The original Nicolas Belmonte showcase, rebuilt from reusable deck.gl community layers. Right-drag or control-drag to tilt and rotate.';
+  description.style.cssText = 'margin:0 0 13px;color:rgba(232,247,240,.72)';
+  panel.append(description);
+
+  const controls: [keyof WindSettings, string][] = [
+    ['showParticles', 'Animated wind particles'],
+    ['showWind', 'Filled wind-direction arrows'],
+    ['showTerrain', 'Extruded 3D mountain terrain'],
+    ['showStationMesh', 'Delaunay station surface'],
+    ['showStations', 'Weather stations']
+  ];
+  for (const [key, labelText] of controls) {
+    const label = document.createElement('label');
+    label.style.cssText = 'display:flex;align-items:center;gap:9px;margin:7px 0;cursor:pointer';
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = settings[key];
+    checkbox.style.accentColor = '#72d8b2';
+    checkbox.addEventListener('change', () => {
+      settings[key] = checkbox.checked;
+      onChange();
+    });
+    label.append(checkbox, document.createTextNode(labelText));
+    panel.append(label);
+  }
+
+  const status = document.createElement('p');
+  status.dataset.windStatus = 'true';
+  status.textContent = 'Loading original weather stations and 72-hour forecast…';
+  status.style.cssText =
+    'margin:13px 0 0;padding-top:11px;border-top:1px solid rgba(192,230,217,.16);' +
+    'color:rgba(232,247,240,.65);font-size:12px';
+  panel.append(status);
+  return panel;
+}
+
+/** Mounts the original wind showcase using exclusively exported, reusable geo-layers. */
+export function mountWindExample(
+  container: HTMLElement,
+  options: WindExampleOptions = {}
+): () => void {
+  const settings: WindSettings = {
+    showParticles: true,
+    showWind: true,
+    showTerrain: true,
+    showStationMesh: false,
+    showStations: false
+  };
+  const abortController = new AbortController();
+  let field: WindField | null = null;
+  let terrainTexture: string | null = null;
+  let animationFrame = 0;
+  let lastFrameTime = 0;
+  let animationTime = 0;
+  let disposed = false;
+
+  container.style.position = 'relative';
+  container.style.background = '#0b1520';
+  const panel = createSettingsPanel(settings, updateLayers);
+  container.append(panel);
+  const status = panel.querySelector<HTMLElement>('[data-wind-status]');
+
+  const deck = new Deck({
+    parent: container,
+    width: '100%',
+    height: '100%',
+    views: new MapView({repeat: false}),
+    initialViewState: INITIAL_VIEW_STATE,
+    controller: {dragRotate: true, touchRotate: true, keyboard: true, inertia: 180},
+    effects: [WIND_LIGHTING],
+    parameters: {depthWriteEnabled: true},
+    getTooltip: ({object}) => {
+      const station = object as WindStation | undefined;
+      return station?.name ? `${station.name}${station.state ? `, ${station.state}` : ''}` : null;
+    },
+    layers: []
+  });
+  options.onDeckInitialized?.(deck);
+
+  function updateLayers(): void {
+    if (!field || disposed) {
+      return;
+    }
+
+    deck.setProps({
+      layers: [
+        settings.showTerrain &&
+          new ElevationLayer({
+            id: 'wind-height-map',
+            elevationData: `${options.dataUrl ?? WIND_DATA_ROOT}/elevation.png`,
+            bounds: ELEVATION_BOUNDS,
+            elevationRange: [-100, 4126],
+            elevationScale: ELEVATION_SCALE,
+            meshMaxError: 480,
+            color: [42, 60, 77, 255],
+            texture: terrainTexture ?? undefined
+          }),
+        settings.showStationMesh &&
+          new DelaunayCoverLayer({
+            id: 'wind-station-terrain',
+            windField: field,
+            elevationScale: ELEVATION_SCALE,
+            opacity: 0.32
+          }),
+        new GeoJsonLayer({
+          id: 'wind-state-boundaries',
+          data: US_STATE_BOUNDARIES,
+          filled: false,
+          stroked: true,
+          getLineColor: [177, 188, 205, 95],
+          getLineWidth: 1,
+          lineWidthUnits: 'pixels',
+          lineWidthMinPixels: 0.65,
+          parameters: {depthCompare: 'always', depthWriteEnabled: false},
+          pickable: false
+        }),
+        settings.showWind &&
+          new WindLayer({
+            id: 'wind-vectors',
+            windField: field,
+            time: animationTime,
+            gridWidth: 40,
+            gridHeight: 22,
+            speedScale: 1.8,
+            widthMinPixels: 1.1,
+            lowColor: [52, 190, 160, 195],
+            highColor: [239, 163, 137, 230],
+            elevationScale: ELEVATION_SCALE,
+            surfaceOffset: 3_200
+          }),
+        settings.showParticles &&
+          new ParticleLayer({
+            id: 'wind-particles',
+            windField: field,
+            time: animationTime,
+            numParticles: 3_600,
+            trailLength: 20,
+            speedScale: 0.16,
+            widthMinPixels: 1.1,
+            pointRadiusPixels: 1,
+            color: [237, 247, 255, 168],
+            elevationScale: ELEVATION_SCALE,
+            surfaceOffset: 4_600
+          }),
+        new TextLayer<WindCity>({
+          id: 'wind-city-labels',
+          data: WIND_CITIES,
+          getPosition: city => {
+            const sample = sampleWindField(field, city.position, animationTime);
+            return [
+              city.position[0],
+              city.position[1],
+              (sample?.elevation ?? 0) * ELEVATION_SCALE + 6_000
+            ];
+          },
+          getText: city => city.name,
+          getColor: [231, 232, 238, 215],
+          getSize: 12,
+          sizeUnits: 'pixels',
+          getTextAnchor: 'middle',
+          getAlignmentBaseline: 'center',
+          parameters: {depthWriteEnabled: false},
+          pickable: false
+        }),
+        settings.showStations &&
+          new ScatterplotLayer<WindStation>({
+            id: 'wind-stations',
+            data: field.stations,
+            getPosition: station => [
+              -station.long,
+              station.lat,
+              station.elv * ELEVATION_SCALE + 5_200
+            ],
+            getFillColor: [255, 227, 165, 205],
+            getRadius: 3,
+            radiusUnits: 'pixels',
+            radiusMinPixels: 2,
+            pickable: true
+          })
+      ]
+    });
+  }
+
+  function animate(timestamp: number): void {
+    if (disposed) {
+      return;
+    }
+    if (timestamp - lastFrameTime >= 1000 / 30) {
+      const elapsed = lastFrameTime ? Math.min(timestamp - lastFrameTime, 100) : 0;
+      animationTime += elapsed / 1800;
+      lastFrameTime = timestamp;
+      if (status && field) {
+        status.dataset.windFrame = animationTime.toFixed(3);
+      }
+      updateLayers();
+    }
+    animationFrame = window.requestAnimationFrame(animate);
+  }
+
+  const dataUrl = options.dataUrl ?? WIND_DATA_ROOT;
+  void Promise.all([
+    loadWindField(dataUrl, abortController.signal),
+    loadTerrainTexture(dataUrl, abortController.signal)
+  ])
+    .then(([windField, nextTerrainTexture]) => {
+      if (disposed) {
+        return;
+      }
+      field = windField;
+      terrainTexture = nextTerrainTexture;
+      if (status) {
+        status.textContent = `${windField.stations.length.toLocaleString()} stations · ${windField.frames.length} hourly weather frames`;
+      }
+      updateLayers();
+      animationFrame = window.requestAnimationFrame(animate);
+    })
+    .catch((error: unknown) => {
+      if (!disposed && status) {
+        status.textContent = error instanceof Error ? error.message : 'Could not load wind data.';
+      }
+    });
+
+  return () => {
+    disposed = true;
+    abortController.abort();
+    window.cancelAnimationFrame(animationFrame);
+    deck.finalize();
+    panel.remove();
+  };
+}

--- a/examples/geo-layers/wind/index.html
+++ b/examples/geo-layers/wind/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Wind Map | deck.gl-community</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./index.ts"></script>
+  </body>
+</html>

--- a/examples/geo-layers/wind/index.ts
+++ b/examples/geo-layers/wind/index.ts
@@ -1,0 +1,8 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {mountStandaloneExample} from '../../mount-example';
+import {mountWindExample} from './app';
+
+mountStandaloneExample(mountWindExample);

--- a/examples/geo-layers/wind/package.json
+++ b/examples/geo-layers/wind/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "wind-layer-example",
+  "version": "9.3.0",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "start": "vite --open",
+    "start-local": "vite --config ../../vite.config.local.mjs",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@deck.gl-community/geo-layers": "workspace:*",
+    "@deck.gl/core": "~9.3.0",
+    "@deck.gl/extensions": "~9.3.0",
+    "@deck.gl/geo-layers": "~9.3.0",
+    "@deck.gl/layers": "~9.3.0",
+    "@deck.gl/mesh-layers": "~9.3.0",
+    "@loaders.gl/core": "^4.4.1",
+    "@luma.gl/core": "~9.3.2",
+    "@luma.gl/engine": "~9.3.2",
+    "@luma.gl/shadertools": "~9.3.2"
+  },
+  "devDependencies": {
+    "vite": "^7.3.1"
+  }
+}

--- a/examples/geo-layers/wind/tsconfig.json
+++ b/examples/geo-layers/wind/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./app.ts", "./index.ts"]
+}

--- a/modules/geo-layers/README.md
+++ b/modules/geo-layers/README.md
@@ -6,3 +6,18 @@
 This module contains a suite of non-official deck.gl layers.
 
 They can be quite useful in applications, however they are not officially supported by the deck.gl team, so use at your own risk.
+
+## Wind layers
+
+The package includes the reusable layers and interpolation utilities from the historical deck.gl
+wind showcase:
+
+- `WindLayer` renders interpolated, speed-colored wind-direction arrows.
+- `ParticleLayer` renders fading particle trails through the wind field.
+- `ElevationLayer` renders the original elevation image as illuminated 3D mountain terrain.
+- `DelaunayCoverLayer` renders elevation-colored station-triangulated terrain.
+- `DelaunayInterpolation` samples or rasterizes the same field.
+- `parseWindData`, `triangulateWindStations`, `createWindField`, and `sampleWindField` load and
+  interpolate the original station-major, 72-hour weather forecast.
+
+The standalone example is in `examples/geo-layers/wind`.

--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@loaders.gl/loader-utils": "^4.4.1",
+    "@loaders.gl/terrain": "^4.4.1",
     "@luma.gl/shadertools": "~9.3.2",
     "@math.gl/core": "^4.0.0",
     "@probe.gl/stats": "^4.1.1",
@@ -49,12 +50,14 @@
     "@deck.gl/core": "~9.3.0",
     "@deck.gl/geo-layers": "~9.3.0",
     "@deck.gl/layers": "~9.3.0",
+    "@loaders.gl/core": "^4.4.1",
     "@luma.gl/core": "~9.3.2",
     "@luma.gl/engine": "~9.3.2"
   },
   "devDependencies": {
     "@deck.gl/core": "~9.3.0",
     "@deck.gl/test-utils": "~9.3.0",
+    "@loaders.gl/core": "^4.4.1",
     "@luma.gl/core": "~9.3.2",
     "@luma.gl/engine": "~9.3.2",
     "@luma.gl/webgpu": "~9.3.2",

--- a/modules/geo-layers/src/index.ts
+++ b/modules/geo-layers/src/index.ts
@@ -19,6 +19,35 @@ export {SharedTileset2D, SharedTile2DHeader} from './tileset/index';
 export type {TileGridLayerProps} from './tile-grid-layer/tile-grid-layer';
 export {TileGridLayer} from './tile-grid-layer/tile-grid-layer';
 
+export {
+  createWindField,
+  getWindBounds,
+  parseWindData,
+  sampleWindField,
+  triangulateWindStations
+} from './wind-layer/wind-data';
+export type {
+  WindBounds,
+  WindField,
+  WindMeasurement,
+  WindSample,
+  WindStation,
+  WindTriangle
+} from './wind-layer/wind-data';
+export {DelaunayInterpolation} from './wind-layer/delaunay-interpolation';
+export type {
+  DelaunayInterpolationProps,
+  WindRaster
+} from './wind-layer/delaunay-interpolation';
+export {DelaunayCoverLayer} from './wind-layer/delaunay-cover-layer';
+export type {DelaunayCoverLayerProps} from './wind-layer/delaunay-cover-layer';
+export {ElevationLayer} from './wind-layer/elevation-layer';
+export type {ElevationLayerProps} from './wind-layer/elevation-layer';
+export {ParticleLayer} from './wind-layer/particle-layer';
+export type {ParticleLayerProps} from './wind-layer/particle-layer';
+export {WindLayer} from './wind-layer/wind-layer';
+export type {WindLayerProps} from './wind-layer/wind-layer';
+
 export {GlobalGridLayer, type GlobalGridLayerProps} from './global-grid-layer/global-grid-layer';
 
 export {type GlobalGrid} from './global-grid-systems/grids/global-grid';

--- a/modules/geo-layers/src/wind-layer/delaunay-cover-layer.ts
+++ b/modules/geo-layers/src/wind-layer/delaunay-cover-layer.ts
@@ -1,0 +1,91 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {CompositeLayer, type Color, type DefaultProps} from '@deck.gl/core';
+import {SolidPolygonLayer} from '@deck.gl/layers';
+
+import type {WindField, WindStation, WindTriangle} from './wind-data';
+
+/** Properties for the station-triangulated terrain beneath a geographic wind field. */
+export type DelaunayCoverLayerProps = {
+  /** Wind field supplying the geographic station triangulation. */
+  windField: WindField;
+  /** Elevation multiplier applied to station heights in meters. */
+  elevationScale?: number;
+  /** Color for the lowest station elevation. */
+  lowColor?: Color;
+  /** Color for the highest station elevation. */
+  highColor?: Color;
+};
+
+type TerrainTriangle = {
+  polygon: [number, number, number][];
+  color: Color;
+};
+
+const defaultProps: DefaultProps<DelaunayCoverLayerProps> = {
+  windField: {type: 'object', value: undefined!},
+  elevationScale: 1,
+  lowColor: [17, 34, 49, 220],
+  highColor: [102, 151, 127, 235]
+};
+
+function createTerrainTriangle(
+  triangle: WindTriangle,
+  stations: readonly WindStation[],
+  elevationScale: number,
+  lowColor: Color,
+  highColor: Color,
+  minimumElevation: number,
+  elevationSpan: number
+): TerrainTriangle {
+  const vertices = triangle.map(index => stations[index]);
+  const averageElevation = vertices.reduce((sum, station) => sum + station.elv, 0) / 3;
+  const intensity = Math.max(0, Math.min(1, (averageElevation - minimumElevation) / elevationSpan));
+  return {
+    polygon: vertices.map(station => [-station.long, station.lat, station.elv * elevationScale]),
+    color: [
+      Math.round(lowColor[0] + (highColor[0] - lowColor[0]) * intensity),
+      Math.round(lowColor[1] + (highColor[1] - lowColor[1]) * intensity),
+      Math.round(lowColor[2] + (highColor[2] - lowColor[2]) * intensity),
+      Math.round((lowColor[3] ?? 255) + ((highColor[3] ?? 255) - (lowColor[3] ?? 255)) * intensity)
+    ]
+  };
+}
+
+/** Recreates the wind showcase's elevation-colored Delaunay terrain as a reusable layer. */
+export class DelaunayCoverLayer extends CompositeLayer<DelaunayCoverLayerProps> {
+  static layerName = 'DelaunayCoverLayer';
+  static defaultProps: DefaultProps<DelaunayCoverLayerProps> = defaultProps;
+
+  /** Renders one elevation-colored polygon for each station triangle. */
+  renderLayers() {
+    const {windField, elevationScale, lowColor, highColor} = this.props;
+    if (!windField) {
+      return null;
+    }
+    const elevations = windField.stations.map(station => station.elv);
+    const minimumElevation = Math.min(...elevations);
+    const elevationSpan = Math.max(Math.max(...elevations) - minimumElevation, 1);
+    const data = windField.triangles.map(triangle =>
+      createTerrainTriangle(
+        triangle,
+        windField.stations,
+        elevationScale,
+        lowColor,
+        highColor,
+        minimumElevation,
+        elevationSpan
+      )
+    );
+
+    return new SolidPolygonLayer<TerrainTriangle>(this.getSubLayerProps({id: 'terrain'}), {
+      data,
+      getPolygon: triangle => triangle.polygon,
+      getFillColor: triangle => triangle.color,
+      material: true,
+      pickable: false
+    });
+  }
+}

--- a/modules/geo-layers/src/wind-layer/delaunay-interpolation.ts
+++ b/modules/geo-layers/src/wind-layer/delaunay-interpolation.ts
@@ -1,0 +1,80 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {sampleWindField, type WindField, type WindSample} from './wind-data';
+
+/** An RGBA float raster containing direction, speed, temperature, and elevation. */
+export type WindRaster = {
+  width: number;
+  height: number;
+  data: Float32Array;
+};
+
+/** Options for rasterizing a Delaunay-interpolated wind field. */
+export type DelaunayInterpolationProps = {
+  field: WindField;
+  width?: number;
+  height?: number;
+};
+
+/**
+ * Rasterizes or directly samples station measurements using Delaunay interpolation.
+ *
+ * Unlike the original showcase's off-screen WebGL transform, this implementation can be
+ * shared by WebGL, WebGPU, server-side preprocessing, and deterministic tests.
+ */
+export class DelaunayInterpolation {
+  readonly field: WindField;
+  readonly width: number;
+  readonly height: number;
+
+  constructor({field, width = 256, height}: DelaunayInterpolationProps) {
+    if (!Number.isInteger(width) || width < 2) {
+      throw new RangeError('A wind raster width must be an integer greater than one.');
+    }
+    const {bounds} = field;
+    const inferredHeight = Math.max(
+      2,
+      Math.ceil(
+        (width * (bounds.maxLat - bounds.minLat)) /
+          Math.max(bounds.maxLng - bounds.minLng, Number.EPSILON)
+      )
+    );
+    if (height !== undefined && (!Number.isInteger(height) || height < 2)) {
+      throw new RangeError('A wind raster height must be an integer greater than one.');
+    }
+    this.field = field;
+    this.width = width;
+    this.height = height ?? inferredHeight;
+  }
+
+  /** Samples a geographic position at a fractional, cyclic weather-frame time. */
+  sample(position: readonly [number, number], time = 0): WindSample | null {
+    return sampleWindField(this.field, position, time);
+  }
+
+  /** Rasterizes one time step without eagerly materializing the complete weather animation. */
+  rasterize(time = 0): WindRaster {
+    const {bounds} = this.field;
+    const data = new Float32Array(this.width * this.height * 4);
+
+    for (let y = 0; y < this.height; y++) {
+      const latitude = bounds.minLat + (y / (this.height - 1)) * (bounds.maxLat - bounds.minLat);
+      for (let x = 0; x < this.width; x++) {
+        const longitude = bounds.minLng + (x / (this.width - 1)) * (bounds.maxLng - bounds.minLng);
+        const sample = this.sample([longitude, latitude], time);
+        if (!sample) {
+          continue;
+        }
+        const offset = (y * this.width + x) * 4;
+        data[offset] = sample.direction;
+        data[offset + 1] = sample.speed;
+        data[offset + 2] = sample.temperature;
+        data[offset + 3] = sample.elevation;
+      }
+    }
+
+    return {width: this.width, height: this.height, data};
+  }
+}

--- a/modules/geo-layers/src/wind-layer/elevation-layer.ts
+++ b/modules/geo-layers/src/wind-layer/elevation-layer.ts
@@ -1,0 +1,73 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {CompositeLayer, type Color, type DefaultProps} from '@deck.gl/core';
+import {TerrainLayer} from '@deck.gl/geo-layers';
+import {TerrainLoader} from '@loaders.gl/terrain';
+
+/** Properties for a height-map-based geographic wind-showcase terrain surface. */
+export type ElevationLayerProps = {
+  /** Grayscale image encoding real terrain elevations in its red channel. */
+  elevationData: string;
+  /** Geographic extent of the elevation image: west, south, east, north. */
+  bounds: [number, number, number, number];
+  /** Minimum and maximum elevations encoded by the image, in meters. */
+  elevationRange?: [number, number];
+  /** Vertical exaggeration applied to the decoded terrain geometry. */
+  elevationScale?: number;
+  /** Error tolerance used to simplify the generated terrain mesh. */
+  meshMaxError?: number;
+  /** Color applied to the shaded three-dimensional terrain surface. */
+  color?: Color;
+  /** Optional image draped over the generated terrain mesh. */
+  texture?: string;
+};
+
+const defaultProps: DefaultProps<ElevationLayerProps> = {
+  elevationData: '',
+  bounds: {type: 'array', value: [-125, 24.4, -66.7, 49.6]},
+  elevationRange: {type: 'array', value: [-100, 4126]},
+  elevationScale: 1,
+  meshMaxError: 80,
+  color: [42, 58, 72, 255],
+  texture: ''
+};
+
+/**
+ * Renders the original wind showcase's elevation image as an actual 3D terrain mesh.
+ *
+ * The image is decoded with the in-process loaders.gl terrain parser so the standalone
+ * showcase does not rely on an externally hosted terrain-worker bundle.
+ */
+export class ElevationLayer extends CompositeLayer<ElevationLayerProps> {
+  static layerName = 'ElevationLayer';
+  static defaultProps: DefaultProps<ElevationLayerProps> = defaultProps;
+
+  /** Builds the shaded, vertically exaggerated height-map terrain sub-layer. */
+  renderLayers(): TerrainLayer | null {
+    const {elevationData, bounds, elevationRange, elevationScale, meshMaxError, color, texture} =
+      this.props;
+    if (!elevationData) {
+      return null;
+    }
+
+    return new TerrainLayer(this.getSubLayerProps({id: 'terrain-mesh'}), {
+      elevationData,
+      bounds,
+      elevationDecoder: {
+        rScaler: ((elevationRange[1] - elevationRange[0]) / 255) * elevationScale,
+        gScaler: 0,
+        bScaler: 0,
+        offset: elevationRange[0] * elevationScale
+      },
+      meshMaxError,
+      color,
+      texture: texture || elevationData,
+      material: {ambient: 0.42, diffuse: 0.82, shininess: 28, specularColor: [76, 91, 105]},
+      loaders: [TerrainLoader],
+      loadOptions: {worker: false},
+      pickable: false
+    });
+  }
+}

--- a/modules/geo-layers/src/wind-layer/particle-layer.ts
+++ b/modules/geo-layers/src/wind-layer/particle-layer.ts
@@ -1,0 +1,255 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {CompositeLayer, type Color, type DefaultProps, type UpdateParameters} from '@deck.gl/core';
+import {LineLayer, ScatterplotLayer} from '@deck.gl/layers';
+
+import {sampleWindField, type WindBounds, type WindField} from './wind-data';
+
+/** Properties for animated wind-field particle trails. */
+export type ParticleLayerProps = {
+  /** Indexed, time-varying weather station data. */
+  windField: WindField;
+  /** Fractional weather-frame and animation time. */
+  time?: number;
+  /** Number of continuously advected particles. */
+  numParticles?: number;
+  /** Number of historical positions retained in each trail. */
+  trailLength?: number;
+  /** Geographic distance advanced per elapsed, 30-frame-per-second animation step. */
+  speedScale?: number;
+  /** Screen-space trail width in pixels. */
+  widthMinPixels?: number;
+  /** Trail color; opacity increases toward each particle's current position. */
+  color?: Color;
+  /** Elevation multiplier applied to interpolated station elevation. */
+  elevationScale?: number;
+  /** Vertical separation above the shaded terrain surface, in meters. */
+  surfaceOffset?: number;
+  /** Radius in pixels of each bright, moving particle head. */
+  pointRadiusPixels?: number;
+};
+
+type ParticlePosition = [number, number, number];
+type Particle = {
+  seed: number;
+  positions: ParticlePosition[];
+  direction?: number;
+  speed?: number;
+};
+type ParticleSegment = {source: ParticlePosition; target: ParticlePosition; color: Color};
+
+const PARTICLE_FRAME_RATE = 30;
+const WEATHER_FRAME_DURATION_MS = 1800;
+
+const defaultProps: DefaultProps<ParticleLayerProps> = {
+  windField: {type: 'object', value: undefined!},
+  time: 0,
+  numParticles: 2400,
+  trailLength: 12,
+  speedScale: 0.085,
+  widthMinPixels: 1.1,
+  color: [194, 246, 224, 210],
+  elevationScale: 1,
+  surfaceOffset: 160,
+  pointRadiusPixels: 1.6
+};
+
+function random(seed: number): number {
+  const value = Math.sin(seed * 127.1 + 311.7) * 43758.5453123;
+  return value - Math.floor(value);
+}
+
+function createParticlePosition(
+  bounds: WindBounds,
+  seed: number,
+  field: WindField,
+  time: number,
+  elevationScale: number,
+  surfaceOffset: number
+): ParticlePosition {
+  for (let attempt = 0; attempt < 12; attempt++) {
+    const attemptSeed = seed + attempt * 19.19;
+    const longitude = bounds.minLng + random(attemptSeed) * (bounds.maxLng - bounds.minLng);
+    const latitude = bounds.minLat + random(attemptSeed + 7.13) * (bounds.maxLat - bounds.minLat);
+    const sample = sampleWindField(field, [longitude, latitude], time);
+    if (sample) {
+      return [longitude, latitude, sample.elevation * elevationScale + surfaceOffset];
+    }
+  }
+  return [(bounds.minLng + bounds.maxLng) / 2, (bounds.minLat + bounds.maxLat) / 2, surfaceOffset];
+}
+
+/**
+ * Advects fading particle trails through a Delaunay-interpolated wind field.
+ *
+ * Particle positions are backend independent, while built-in deck.gl line sublayers handle
+ * instanced GPU rendering on both WebGL and WebGPU.
+ */
+export class ParticleLayer extends CompositeLayer<ParticleLayerProps> {
+  static layerName = 'ParticleLayer';
+  static defaultProps: DefaultProps<ParticleLayerProps> = defaultProps;
+
+  declare state: {particles: Particle[]; lastTime: number};
+
+  /** Seeds particles reproducibly throughout the measured station coverage. */
+  initializeState(): void {
+    this.setState({particles: this.createParticles(), lastTime: this.props.time});
+  }
+
+  /** Re-seeds on field changes and advances existing trails when animation time changes. */
+  updateState({props, oldProps, changeFlags}: UpdateParameters<this>): void {
+    if (
+      changeFlags.dataChanged ||
+      props.windField !== oldProps.windField ||
+      props.numParticles !== oldProps.numParticles
+    ) {
+      this.setState({particles: this.createParticles(), lastTime: props.time});
+      return;
+    }
+
+    if (props.time !== this.state.lastTime) {
+      const elapsedFrames =
+        Math.abs(props.time - this.state.lastTime) *
+        (WEATHER_FRAME_DURATION_MS / (1000 / PARTICLE_FRAME_RATE));
+      this.advanceParticles(Math.max(0.2, Math.min(elapsedFrames, 3)));
+      this.setState({lastTime: props.time});
+    }
+  }
+
+  private createParticles(): Particle[] {
+    const {windField, time, numParticles, elevationScale, surfaceOffset} = this.props;
+    if (!windField) {
+      return [];
+    }
+    return Array.from({length: Math.max(0, Math.floor(numParticles))}, (_, index) => {
+      const seed = index + 1;
+      return {
+        seed,
+        positions: [
+          createParticlePosition(
+            windField.bounds,
+            seed,
+            windField,
+            time,
+            elevationScale,
+            surfaceOffset
+          )
+        ]
+      };
+    });
+  }
+
+  private advanceParticles(elapsedFrames: number): void {
+    const {windField, time, trailLength, speedScale, elevationScale, surfaceOffset} = this.props;
+    const speedSpan = Math.max(windField.speedRange[1] - windField.speedRange[0], 1);
+
+    for (const particle of this.state.particles) {
+      const previous = particle.positions[particle.positions.length - 1];
+      const sample = sampleWindField(windField, [previous[0], previous[1]], time);
+      if (!sample || sample.speed <= 0) {
+        particle.seed += 101.7;
+        particle.direction = undefined;
+        particle.speed = undefined;
+        particle.positions = [
+          createParticlePosition(
+            windField.bounds,
+            particle.seed,
+            windField,
+            time,
+            elevationScale,
+            surfaceOffset
+          )
+        ];
+        continue;
+      }
+
+      const normalizedSpeed =
+        0.18 + Math.sqrt(Math.max(0, (sample.speed - windField.speedRange[0]) / speedSpan)) * 0.82;
+      const smoothing = Math.min(0.18 * elapsedFrames, 1);
+      const previousDirection = particle.direction ?? sample.direction;
+      const direction = Math.atan2(
+        Math.sin(previousDirection) * (1 - smoothing) + Math.sin(sample.direction) * smoothing,
+        Math.cos(previousDirection) * (1 - smoothing) + Math.cos(sample.direction) * smoothing
+      );
+      const previousSpeed = particle.speed ?? normalizedSpeed;
+      const speed = previousSpeed + (normalizedSpeed - previousSpeed) * smoothing;
+      const distance = speed * speedScale * elapsedFrames;
+      const next: ParticlePosition = [
+        previous[0] + Math.cos(direction) * distance,
+        previous[1] + Math.sin(direction) * distance,
+        sample.elevation * elevationScale + surfaceOffset
+      ];
+
+      if (!sampleWindField(windField, [next[0], next[1]], time)) {
+        particle.seed += 101.7;
+        particle.direction = undefined;
+        particle.speed = undefined;
+        particle.positions = [
+          createParticlePosition(
+            windField.bounds,
+            particle.seed,
+            windField,
+            time,
+            elevationScale,
+            surfaceOffset
+          )
+        ];
+        continue;
+      }
+
+      particle.direction = direction;
+      particle.speed = speed;
+      particle.positions.push(next);
+      if (particle.positions.length > Math.max(2, Math.floor(trailLength))) {
+        particle.positions.shift();
+      }
+    }
+  }
+
+  /** Renders independently faded, GPU-instanced trail segments. */
+  renderLayers() {
+    if (!this.state?.particles) {
+      return null;
+    }
+
+    const {color, widthMinPixels, pointRadiusPixels} = this.props;
+    const segments: ParticleSegment[] = [];
+    for (const particle of this.state.particles) {
+      for (let index = 1; index < particle.positions.length; index++) {
+        const opacity = index / Math.max(1, particle.positions.length - 1);
+        segments.push({
+          source: particle.positions[index - 1],
+          target: particle.positions[index],
+          color: [color[0], color[1], color[2], Math.round((color[3] ?? 255) * opacity)]
+        });
+      }
+    }
+
+    return [
+      new LineLayer<ParticleSegment>(this.getSubLayerProps({id: 'trails'}), {
+        data: segments,
+        getSourcePosition: segment => segment.source,
+        getTargetPosition: segment => segment.target,
+        getColor: segment => segment.color,
+        getWidth: 1,
+        widthUnits: 'pixels',
+        widthMinPixels,
+        parameters: {depthWriteEnabled: false},
+        pickable: false
+      }),
+      new ScatterplotLayer<Particle>(this.getSubLayerProps({id: 'heads'}), {
+        data: this.state.particles,
+        getPosition: particle => particle.positions[particle.positions.length - 1],
+        getFillColor: [255, 255, 255, Math.min(255, (color[3] ?? 255) + 24)],
+        getRadius: pointRadiusPixels,
+        radiusUnits: 'pixels',
+        radiusMinPixels: pointRadiusPixels,
+        billboard: true,
+        parameters: {depthWriteEnabled: false},
+        pickable: false
+      })
+    ];
+  }
+}

--- a/modules/geo-layers/src/wind-layer/wind-data.ts
+++ b/modules/geo-layers/src/wind-layer/wind-data.ts
@@ -1,0 +1,377 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** A weather station in the original deck.gl wind showcase dataset. */
+export type WindStation = {
+  name: string;
+  long: number;
+  lat: number;
+  elv: number;
+  icao?: string;
+  state?: string;
+  abbr?: string;
+};
+
+/** West, south, east, and north bounds of a geographic wind field. */
+export type WindBounds = {
+  minLng: number;
+  minLat: number;
+  maxLng: number;
+  maxLat: number;
+};
+
+/** Direction in eighth-turns, wind speed, and temperature at one station. */
+export type WindMeasurement = readonly [number, number, number];
+
+/** Three indices into a wind field's station and measurement arrays. */
+export type WindTriangle = readonly [number, number, number];
+
+/** A time-varying Delaunay-interpolated geographic vector field. */
+export type WindField = {
+  stations: readonly WindStation[];
+  frames: readonly (readonly WindMeasurement[])[];
+  triangles: readonly WindTriangle[];
+  bounds: WindBounds;
+  speedRange: readonly [number, number];
+  temperatureRange: readonly [number, number];
+  spatialIndex: WindSpatialIndex;
+};
+
+/** A sampled and temporally interpolated wind vector. */
+export type WindSample = {
+  direction: number;
+  speed: number;
+  temperature: number;
+  elevation: number;
+  velocity: [number, number];
+};
+
+type WindSpatialIndex = {
+  columns: number;
+  rows: number;
+  cells: number[][];
+};
+
+type Circumcircle = {x: number; y: number; radiusSquared: number};
+type Point = readonly [number, number];
+
+const EPSILON = 1e-10;
+
+/** Parses the station-major, 72-hour binary format used by the original wind showcase. */
+export function parseWindData(
+  buffer: ArrayBuffer,
+  stationCount: number,
+  frameCount = 72
+): WindMeasurement[][] {
+  if (stationCount <= 0 || frameCount <= 0) {
+    throw new RangeError('Wind data requires a positive station and frame count.');
+  }
+  if (buffer.byteLength % Uint16Array.BYTES_PER_ELEMENT !== 0) {
+    throw new RangeError('Wind data must contain complete unsigned 16-bit measurements.');
+  }
+
+  const values = new Uint16Array(buffer);
+  const expectedLength = stationCount * frameCount * 3;
+  if (values.length !== expectedLength) {
+    throw new RangeError(
+      `Expected ${expectedLength} wind measurements, but received ${values.length}.`
+    );
+  }
+
+  return Array.from({length: frameCount}, (_, frameIndex) =>
+    Array.from({length: stationCount}, (_, stationIndex) => {
+      const offset = (stationIndex * frameCount + frameIndex) * 3;
+      return [values[offset], values[offset + 1], values[offset + 2]];
+    })
+  );
+}
+
+/** Calculates geographic bounds for stations whose legacy longitudes are positive-west. */
+export function getWindBounds(stations: readonly WindStation[]): WindBounds {
+  if (stations.length === 0) {
+    throw new RangeError('A wind field requires at least one station.');
+  }
+
+  let minLng = Infinity;
+  let minLat = Infinity;
+  let maxLng = -Infinity;
+  let maxLat = -Infinity;
+
+  for (const station of stations) {
+    const longitude = station.long === 0 ? 0 : -station.long;
+    if (!Number.isFinite(longitude) || !Number.isFinite(station.lat)) {
+      throw new TypeError('Wind station coordinates must be finite numbers.');
+    }
+    minLng = Math.min(minLng, longitude);
+    minLat = Math.min(minLat, station.lat);
+    maxLng = Math.max(maxLng, longitude);
+    maxLat = Math.max(maxLat, station.lat);
+  }
+
+  return {minLng, minLat, maxLng, maxLat};
+}
+
+function getCircumcircle(a: Point, b: Point, c: Point): Circumcircle | null {
+  const determinant = 2 * (a[0] * (b[1] - c[1]) + b[0] * (c[1] - a[1]) + c[0] * (a[1] - b[1]));
+  if (Math.abs(determinant) < EPSILON) {
+    return null;
+  }
+  const aSquared = a[0] * a[0] + a[1] * a[1];
+  const bSquared = b[0] * b[0] + b[1] * b[1];
+  const cSquared = c[0] * c[0] + c[1] * c[1];
+  const x =
+    (aSquared * (b[1] - c[1]) + bSquared * (c[1] - a[1]) + cSquared * (a[1] - b[1])) / determinant;
+  const y =
+    (aSquared * (c[0] - b[0]) + bSquared * (a[0] - c[0]) + cSquared * (b[0] - a[0])) / determinant;
+  return {x, y, radiusSquared: (x - a[0]) ** 2 + (y - a[1]) ** 2};
+}
+
+/** Builds a dependency-free Delaunay triangulation of weather-station positions. */
+export function triangulateWindStations(stations: readonly WindStation[]): WindTriangle[] {
+  if (stations.length < 3) {
+    return [];
+  }
+
+  const bounds = getWindBounds(stations);
+  const centerX = (bounds.minLng + bounds.maxLng) / 2;
+  const centerY = (bounds.minLat + bounds.maxLat) / 2;
+  const span = Math.max(bounds.maxLng - bounds.minLng, bounds.maxLat - bounds.minLat, 1);
+  const points: Point[] = stations.map(station => [-station.long, station.lat]);
+  const count = points.length;
+  points.push(
+    [centerX - 32 * span, centerY - span],
+    [centerX, centerY + 32 * span],
+    [centerX + 32 * span, centerY - span]
+  );
+
+  let triangles: WindTriangle[] = [[count, count + 1, count + 2]];
+  const seenPoints = new Set<string>();
+
+  for (let pointIndex = 0; pointIndex < count; pointIndex++) {
+    const point = points[pointIndex];
+    const pointKey = `${point[0]},${point[1]}`;
+    if (seenPoints.has(pointKey)) {
+      continue;
+    }
+    seenPoints.add(pointKey);
+
+    const surviving: WindTriangle[] = [];
+    const boundary = new Map<string, [number, number]>();
+
+    for (const triangle of triangles) {
+      const circle = getCircumcircle(points[triangle[0]], points[triangle[1]], points[triangle[2]]);
+      const inside =
+        circle !== null &&
+        (point[0] - circle.x) ** 2 + (point[1] - circle.y) ** 2 <= circle.radiusSquared + EPSILON;
+
+      if (!inside) {
+        surviving.push(triangle);
+        continue;
+      }
+
+      for (const [start, end] of [
+        [triangle[0], triangle[1]],
+        [triangle[1], triangle[2]],
+        [triangle[2], triangle[0]]
+      ] as [number, number][]) {
+        const edgeKey = start < end ? `${start}:${end}` : `${end}:${start}`;
+        if (boundary.has(edgeKey)) {
+          boundary.delete(edgeKey);
+        } else {
+          boundary.set(edgeKey, [start, end]);
+        }
+      }
+    }
+
+    for (const [start, end] of boundary.values()) {
+      surviving.push([start, end, pointIndex]);
+    }
+    triangles = surviving;
+  }
+
+  return triangles.filter(triangle => triangle.every(index => index < count));
+}
+
+function getRange(
+  frames: readonly (readonly WindMeasurement[])[],
+  component: 1 | 2
+): [number, number] {
+  let minimum = Infinity;
+  let maximum = -Infinity;
+  for (const frame of frames) {
+    for (const measurement of frame) {
+      if (measurement[component] !== 0) {
+        minimum = Math.min(minimum, measurement[component]);
+        maximum = Math.max(maximum, measurement[component]);
+      }
+    }
+  }
+  return Number.isFinite(minimum) ? [minimum, maximum] : [0, 0];
+}
+
+function createSpatialIndex(
+  stations: readonly WindStation[],
+  triangles: readonly WindTriangle[],
+  bounds: WindBounds
+): WindSpatialIndex {
+  const columns = 48;
+  const rows = 24;
+  const cells = Array.from({length: columns * rows}, () => [] as number[]);
+  const longitudeSpan = Math.max(bounds.maxLng - bounds.minLng, EPSILON);
+  const latitudeSpan = Math.max(bounds.maxLat - bounds.minLat, EPSILON);
+
+  for (let triangleIndex = 0; triangleIndex < triangles.length; triangleIndex++) {
+    const vertices = triangles[triangleIndex].map(index => stations[index]);
+    const west = Math.min(...vertices.map(station => -station.long));
+    const east = Math.max(...vertices.map(station => -station.long));
+    const south = Math.min(...vertices.map(station => station.lat));
+    const north = Math.max(...vertices.map(station => station.lat));
+    const minColumn = Math.max(0, Math.floor(((west - bounds.minLng) / longitudeSpan) * columns));
+    const maxColumn = Math.min(
+      columns - 1,
+      Math.floor(((east - bounds.minLng) / longitudeSpan) * columns)
+    );
+    const minRow = Math.max(0, Math.floor(((south - bounds.minLat) / latitudeSpan) * rows));
+    const maxRow = Math.min(rows - 1, Math.floor(((north - bounds.minLat) / latitudeSpan) * rows));
+
+    for (let row = minRow; row <= maxRow; row++) {
+      for (let column = minColumn; column <= maxColumn; column++) {
+        cells[row * columns + column].push(triangleIndex);
+      }
+    }
+  }
+
+  return {columns, rows, cells};
+}
+
+/** Creates the shared, indexed wind field consumed by all wind showcase layers. */
+export function createWindField(
+  stations: readonly WindStation[],
+  frames: readonly (readonly WindMeasurement[])[],
+  options: {triangles?: readonly WindTriangle[]} = {}
+): WindField {
+  if (stations.length < 3) {
+    throw new RangeError('A wind field requires at least three stations.');
+  }
+  if (frames.length === 0 || frames.some(frame => frame.length !== stations.length)) {
+    throw new RangeError('Each wind frame must contain one measurement for every station.');
+  }
+
+  const bounds = getWindBounds(stations);
+  const triangles = options.triangles ?? triangulateWindStations(stations);
+  return {
+    stations,
+    frames,
+    triangles,
+    bounds,
+    speedRange: getRange(frames, 1),
+    temperatureRange: getRange(frames, 2),
+    spatialIndex: createSpatialIndex(stations, triangles, bounds)
+  };
+}
+
+function getBarycentricWeights(
+  position: Point,
+  a: Point,
+  b: Point,
+  c: Point
+): [number, number, number] | null {
+  const determinant = (b[1] - c[1]) * (a[0] - c[0]) + (c[0] - b[0]) * (a[1] - c[1]);
+  if (Math.abs(determinant) < EPSILON) {
+    return null;
+  }
+  const first =
+    ((b[1] - c[1]) * (position[0] - c[0]) + (c[0] - b[0]) * (position[1] - c[1])) / determinant;
+  const second =
+    ((c[1] - a[1]) * (position[0] - c[0]) + (a[0] - c[0]) * (position[1] - c[1])) / determinant;
+  const third = 1 - first - second;
+  return first >= -EPSILON && second >= -EPSILON && third >= -EPSILON
+    ? [first, second, third]
+    : null;
+}
+
+/** Samples the wind field using spatial Delaunay and circular temporal interpolation. */
+export function sampleWindField(field: WindField, position: Point, time = 0): WindSample | null {
+  const {bounds, spatialIndex, triangles, stations, frames} = field;
+  if (
+    position[0] < bounds.minLng ||
+    position[0] > bounds.maxLng ||
+    position[1] < bounds.minLat ||
+    position[1] > bounds.maxLat
+  ) {
+    return null;
+  }
+
+  const column = Math.min(
+    spatialIndex.columns - 1,
+    Math.max(
+      0,
+      Math.floor(
+        ((position[0] - bounds.minLng) / Math.max(bounds.maxLng - bounds.minLng, EPSILON)) *
+          spatialIndex.columns
+      )
+    )
+  );
+  const row = Math.min(
+    spatialIndex.rows - 1,
+    Math.max(
+      0,
+      Math.floor(
+        ((position[1] - bounds.minLat) / Math.max(bounds.maxLat - bounds.minLat, EPSILON)) *
+          spatialIndex.rows
+      )
+    )
+  );
+  const wrappedTime = ((time % frames.length) + frames.length) % frames.length;
+  const frameIndex = Math.floor(wrappedTime);
+  const nextFrameIndex = (frameIndex + 1) % frames.length;
+  const frameMix = wrappedTime - frameIndex;
+
+  for (const triangleIndex of spatialIndex.cells[row * spatialIndex.columns + column]) {
+    const triangle = triangles[triangleIndex];
+    const weights = getBarycentricWeights(
+      position,
+      [-stations[triangle[0]].long, stations[triangle[0]].lat],
+      [-stations[triangle[1]].long, stations[triangle[1]].lat],
+      [-stations[triangle[2]].long, stations[triangle[2]].lat]
+    );
+    if (!weights) {
+      continue;
+    }
+
+    let east = 0;
+    let north = 0;
+    let speed = 0;
+    let temperature = 0;
+    let elevation = 0;
+
+    for (let vertex = 0; vertex < 3; vertex++) {
+      const stationIndex = triangle[vertex];
+      const from = frames[frameIndex][stationIndex];
+      const to = frames[nextFrameIndex][stationIndex];
+      const weight = weights[vertex];
+      const fromAngle = (from[0] * Math.PI) / 4;
+      const toAngle = (to[0] * Math.PI) / 4;
+      east += weight * ((1 - frameMix) * Math.cos(fromAngle) + frameMix * Math.cos(toAngle));
+      north += weight * ((1 - frameMix) * Math.sin(fromAngle) + frameMix * Math.sin(toAngle));
+      speed += weight * ((1 - frameMix) * from[1] + frameMix * to[1]);
+      temperature += weight * ((1 - frameMix) * from[2] + frameMix * to[2]);
+      elevation += weight * stations[stationIndex].elv;
+    }
+
+    if (Math.abs(east) < EPSILON && Math.abs(north) < EPSILON) {
+      return null;
+    }
+    const direction = Math.atan2(north, east);
+    return {
+      direction,
+      speed,
+      temperature,
+      elevation,
+      velocity: [Math.cos(direction) * speed, Math.sin(direction) * speed]
+    };
+  }
+
+  return null;
+}

--- a/modules/geo-layers/src/wind-layer/wind-layer.ts
+++ b/modules/geo-layers/src/wind-layer/wind-layer.ts
@@ -1,0 +1,202 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {CompositeLayer, type Color, type DefaultProps} from '@deck.gl/core';
+import {PathLayer, SolidPolygonLayer} from '@deck.gl/layers';
+
+import {sampleWindField, type WindField} from './wind-data';
+
+/** Properties for rendering geographic wind vectors as directional arrow glyphs. */
+export type WindLayerProps = {
+  /** Indexed, time-varying weather station data. */
+  windField: WindField;
+  /** Fractional weather-frame time. Frame indices wrap automatically. */
+  time?: number;
+  /** Number of arrow samples in the longitudinal direction. */
+  gridWidth?: number;
+  /** Number of arrow samples in the latitudinal direction. */
+  gridHeight?: number;
+  /** Geographic length multiplier for wind arrows. */
+  speedScale?: number;
+  /** Minimum on-screen arrow width in pixels. */
+  widthMinPixels?: number;
+  /** Color used for slower wind vectors. */
+  lowColor?: Color;
+  /** Color used for faster wind vectors. */
+  highColor?: Color;
+  /** Elevation multiplier applied to sampled station elevations. */
+  elevationScale?: number;
+  /** Vertical separation above the terrain surface, in meters. */
+  surfaceOffset?: number;
+};
+
+type WindArrow = {
+  shaft: [number, number, number][];
+  head: [number, number, number][];
+  polygon: [number, number, number][];
+  color: Color;
+};
+
+const defaultProps: DefaultProps<WindLayerProps> = {
+  windField: {type: 'object', value: undefined!},
+  time: 0,
+  gridWidth: 64,
+  gridHeight: 32,
+  speedScale: 0.65,
+  widthMinPixels: 1.25,
+  lowColor: [70, 190, 168, 190],
+  highColor: [247, 105, 76, 235],
+  elevationScale: 1,
+  surfaceOffset: 200
+};
+
+function mixColor(from: Color, to: Color, factor: number): Color {
+  return [
+    Math.round(from[0] + (to[0] - from[0]) * factor),
+    Math.round(from[1] + (to[1] - from[1]) * factor),
+    Math.round(from[2] + (to[2] - from[2]) * factor),
+    Math.round((from[3] ?? 255) + ((to[3] ?? 255) - (from[3] ?? 255)) * factor)
+  ];
+}
+
+/** Renders the original wind showcase's directional field as reusable deck.gl arrow glyphs. */
+export class WindLayer extends CompositeLayer<WindLayerProps> {
+  static layerName = 'WindLayer';
+  static defaultProps: DefaultProps<WindLayerProps> = defaultProps;
+
+  /** Samples the field and renders arrow shafts and directional arrowheads. */
+  renderLayers() {
+    const {
+      windField,
+      time,
+      gridWidth,
+      gridHeight,
+      speedScale,
+      widthMinPixels,
+      lowColor,
+      highColor,
+      elevationScale,
+      surfaceOffset
+    } = this.props;
+    if (!windField || gridWidth < 2 || gridHeight < 2) {
+      return null;
+    }
+
+    const {bounds, speedRange} = windField;
+    const longitudeStep = (bounds.maxLng - bounds.minLng) / (gridWidth - 1);
+    const latitudeStep = (bounds.maxLat - bounds.minLat) / (gridHeight - 1);
+    const speedSpan = Math.max(speedRange[1] - speedRange[0], Number.EPSILON);
+    const arrows: WindArrow[] = [];
+
+    for (let row = 0; row < gridHeight; row++) {
+      for (let column = 0; column < gridWidth; column++) {
+        const longitude = bounds.minLng + (column + (row % 2 === 0 ? 0 : 0.5)) * longitudeStep;
+        const latitude = bounds.minLat + row * latitudeStep;
+        const sample = sampleWindField(windField, [longitude, latitude], time);
+        if (!sample || sample.speed <= 0) {
+          continue;
+        }
+
+        const intensity = Math.max(0, Math.min(1, (sample.speed - speedRange[0]) / speedSpan));
+        const arrowLength =
+          Math.min(longitudeStep, latitudeStep) * speedScale * (0.25 + intensity * 0.75);
+        const deltaX = Math.cos(sample.direction) * arrowLength;
+        const deltaY = Math.sin(sample.direction) * arrowLength;
+        const elevation = sample.elevation * elevationScale + surfaceOffset;
+        const source: [number, number, number] = [longitude, latitude, elevation];
+        const target: [number, number, number] = [longitude + deltaX, latitude + deltaY, elevation];
+        const wingScale = 0.34;
+        const wingSpread = 0.52;
+        const perpendicularX = -Math.sin(sample.direction);
+        const perpendicularY = Math.cos(sample.direction);
+        const shaftHalfWidth = arrowLength * 0.1;
+        const headHalfWidth = arrowLength * 0.3;
+        const headStartX = longitude + deltaX * 0.59;
+        const headStartY = latitude + deltaY * 0.59;
+        arrows.push({
+          shaft: [source, target],
+          head: [
+            [
+              target[0] - deltaX * wingScale - deltaY * wingSpread * wingScale,
+              target[1] - deltaY * wingScale + deltaX * wingSpread * wingScale,
+              elevation
+            ],
+            target,
+            [
+              target[0] - deltaX * wingScale + deltaY * wingSpread * wingScale,
+              target[1] - deltaY * wingScale - deltaX * wingSpread * wingScale,
+              elevation
+            ]
+          ],
+          polygon: [
+            [
+              longitude + perpendicularX * shaftHalfWidth,
+              latitude + perpendicularY * shaftHalfWidth,
+              elevation
+            ],
+            [
+              headStartX + perpendicularX * shaftHalfWidth,
+              headStartY + perpendicularY * shaftHalfWidth,
+              elevation
+            ],
+            [
+              headStartX + perpendicularX * headHalfWidth,
+              headStartY + perpendicularY * headHalfWidth,
+              elevation
+            ],
+            target,
+            [
+              headStartX - perpendicularX * headHalfWidth,
+              headStartY - perpendicularY * headHalfWidth,
+              elevation
+            ],
+            [
+              headStartX - perpendicularX * shaftHalfWidth,
+              headStartY - perpendicularY * shaftHalfWidth,
+              elevation
+            ],
+            [
+              longitude - perpendicularX * shaftHalfWidth,
+              latitude - perpendicularY * shaftHalfWidth,
+              elevation
+            ]
+          ],
+          color: mixColor(lowColor, highColor, intensity)
+        });
+      }
+    }
+
+    return [
+      new SolidPolygonLayer<WindArrow>(this.getSubLayerProps({id: 'glyphs'}), {
+        data: arrows,
+        getPolygon: arrow => arrow.polygon,
+        getFillColor: arrow => arrow.color,
+        material: {ambient: 0.75, diffuse: 0.45, shininess: 16},
+        parameters: {depthWriteEnabled: false},
+        pickable: false
+      }),
+      new PathLayer<WindArrow>(this.getSubLayerProps({id: 'shafts'}), {
+        data: arrows,
+        getPath: arrow => arrow.shaft,
+        getColor: arrow => arrow.color,
+        getWidth: 1,
+        widthUnits: 'pixels',
+        widthMinPixels,
+        capRounded: true,
+        pickable: false
+      }),
+      new PathLayer<WindArrow>(this.getSubLayerProps({id: 'arrowheads'}), {
+        data: arrows,
+        getPath: arrow => arrow.head,
+        getColor: arrow => arrow.color,
+        getWidth: 1,
+        widthUnits: 'pixels',
+        widthMinPixels,
+        jointRounded: true,
+        capRounded: true,
+        pickable: false
+      })
+    ];
+  }
+}

--- a/modules/geo-layers/test/imports.node.spec.ts
+++ b/modules/geo-layers/test/imports.node.spec.ts
@@ -26,6 +26,18 @@ it('exports GlobalGridLayer', () => {
   expect(GeoLayers.GlobalGridLayer).toBeDefined();
 });
 
+it('exports the reusable wind showcase layers and field utilities', () => {
+  expect(GeoLayers.WindLayer).toBeDefined();
+  expect(GeoLayers.ParticleLayer).toBeDefined();
+  expect(GeoLayers.DelaunayCoverLayer).toBeDefined();
+  expect(GeoLayers.ElevationLayer).toBeDefined();
+  expect(GeoLayers.DelaunayInterpolation).toBeDefined();
+  expect(GeoLayers.createWindField).toBeDefined();
+  expect(GeoLayers.parseWindData).toBeDefined();
+  expect(GeoLayers.sampleWindField).toBeDefined();
+  expect(GeoLayers.triangulateWindStations).toBeDefined();
+});
+
 it('exports grid systems', () => {
   expect(GeoLayers.H3Grid).toBeDefined();
   expect(GeoLayers.S2Grid).toBeDefined();

--- a/modules/geo-layers/test/wind-layer/wind-data.spec.ts
+++ b/modules/geo-layers/test/wind-layer/wind-data.spec.ts
@@ -1,0 +1,142 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, it} from 'vitest';
+
+import {
+  createWindField,
+  DelaunayInterpolation,
+  getWindBounds,
+  parseWindData,
+  sampleWindField,
+  triangulateWindStations,
+  type WindMeasurement,
+  type WindStation
+} from '../../src';
+
+const STATIONS: WindStation[] = [
+  {name: 'southwest', long: 2, lat: 0, elv: 10},
+  {name: 'southeast', long: 0, lat: 0, elv: 20},
+  {name: 'northwest', long: 2, lat: 2, elv: 30},
+  {name: 'northeast', long: 0, lat: 2, elv: 40}
+];
+
+const FRAMES: WindMeasurement[][] = [
+  [
+    [0, 10, 20],
+    [0, 20, 30],
+    [0, 30, 40],
+    [0, 40, 50]
+  ],
+  [
+    [2, 20, 30],
+    [2, 30, 40],
+    [2, 40, 50],
+    [2, 50, 60]
+  ]
+];
+
+describe('wind showcase data', () => {
+  it('parses the original station-major binary weather format', () => {
+    const values = new Uint16Array([
+      0, 10, 20, 2, 20, 30, 0, 20, 30, 2, 30, 40, 0, 30, 40, 2, 40, 50, 0, 40, 50, 2, 50, 60
+    ]);
+
+    expect(parseWindData(values.buffer, STATIONS.length, 2)).toEqual(FRAMES);
+  });
+
+  it('rejects truncated and mismatched weather binaries', () => {
+    expect(() => parseWindData(new Uint8Array([1]).buffer, 1, 1)).toThrow(
+      'complete unsigned 16-bit'
+    );
+    expect(() => parseWindData(new Uint16Array([1, 2, 3]).buffer, 2, 1)).toThrow(
+      'Expected 6 wind measurements'
+    );
+  });
+
+  it('converts original positive-west station longitudes into geographic bounds', () => {
+    expect(getWindBounds(STATIONS)).toEqual({minLng: -2, minLat: 0, maxLng: 0, maxLat: 2});
+  });
+
+  it('triangulates the complete station coverage', () => {
+    const triangles = triangulateWindStations(STATIONS);
+
+    expect(triangles).toHaveLength(2);
+    expect(new Set(triangles.flat())).toEqual(new Set([0, 1, 2, 3]));
+  });
+
+  it('ignores duplicate station coordinates without creating degenerate triangles', () => {
+    const triangles = triangulateWindStations([...STATIONS, {...STATIONS[0], name: 'duplicate'}]);
+
+    expect(triangles).toHaveLength(2);
+    expect(triangles.flat()).not.toContain(4);
+  });
+
+  it('interpolates station speed, temperature, and elevation barycentrically', () => {
+    const field = createWindField(STATIONS, FRAMES);
+    const sample = sampleWindField(field, [-1, 1], 0);
+
+    expect(sample).not.toBeNull();
+    expect(sample?.direction).toBeCloseTo(0);
+    expect(sample?.speed).toBeCloseTo(25);
+    expect(sample?.temperature).toBeCloseTo(35);
+    expect(sample?.elevation).toBeCloseTo(25);
+    expect(sample?.velocity[0]).toBeCloseTo(25);
+  });
+
+  it('interpolates wind direction circularly between weather frames', () => {
+    const field = createWindField(STATIONS, FRAMES);
+    const sample = sampleWindField(field, [-1, 1], 0.5);
+
+    expect(sample?.direction).toBeCloseTo(Math.PI / 4);
+    expect(sample?.speed).toBeCloseTo(30);
+    expect(sample?.temperature).toBeCloseTo(40);
+  });
+
+  it('wraps fractional animation time in either direction', () => {
+    const field = createWindField(STATIONS, FRAMES);
+
+    expect(sampleWindField(field, [-1, 1], 2.5)).toEqual(sampleWindField(field, [-1, 1], 0.5));
+    expect(sampleWindField(field, [-1, 1], -0.5)).toEqual(sampleWindField(field, [-1, 1], 1.5));
+  });
+
+  it('does not extrapolate beyond station coverage', () => {
+    const field = createWindField(STATIONS, FRAMES);
+
+    expect(sampleWindField(field, [-3, 1])).toBeNull();
+    expect(sampleWindField(field, [-1, 3])).toBeNull();
+  });
+
+  it('validates station and frame alignment', () => {
+    expect(() => createWindField(STATIONS.slice(0, 2), FRAMES)).toThrow('at least three');
+    expect(() => createWindField(STATIONS, [FRAMES[0].slice(0, 3)])).toThrow(
+      'one measurement for every station'
+    );
+  });
+
+  it('rasterizes interpolated direction, speed, temperature, and elevation', () => {
+    const interpolation = new DelaunayInterpolation({
+      field: createWindField(STATIONS, FRAMES),
+      width: 3,
+      height: 3
+    });
+    const raster = interpolation.rasterize(0.5);
+    const centerOffset = (1 * raster.width + 1) * 4;
+
+    expect(raster.width).toBe(3);
+    expect(raster.height).toBe(3);
+    expect(raster.data).toHaveLength(36);
+    expect(raster.data[centerOffset]).toBeCloseTo(Math.PI / 4);
+    expect(raster.data[centerOffset + 1]).toBeCloseTo(30);
+    expect(raster.data[centerOffset + 2]).toBeCloseTo(40);
+    expect(raster.data[centerOffset + 3]).toBeCloseTo(25);
+  });
+
+  it('validates raster dimensions', () => {
+    const field = createWindField(STATIONS, FRAMES);
+
+    expect(() => new DelaunayInterpolation({field, width: 1})).toThrow('width');
+    expect(() => new DelaunayInterpolation({field, height: 1})).toThrow('height');
+  });
+});

--- a/modules/geo-layers/test/wind-layer/wind-layers.browser.spec.ts
+++ b/modules/geo-layers/test/wind-layer/wind-layers.browser.spec.ts
@@ -1,0 +1,175 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Deck, MapView} from '@deck.gl/core';
+import {luma, type Device} from '@luma.gl/core';
+import {webgl2Adapter} from '@luma.gl/webgl';
+import {webgpuAdapter} from '@luma.gl/webgpu';
+import {describe, expect, it} from 'vitest';
+
+import {
+  createWindField,
+  DelaunayCoverLayer,
+  ElevationLayer,
+  ParticleLayer,
+  WindLayer,
+  type WindField,
+  type WindStation
+} from '../../src';
+
+type BrowserGpu = {requestAdapter: () => Promise<unknown>};
+
+const STATIONS: WindStation[] = [
+  {name: 'southwest', long: 100, lat: 35, elv: 120},
+  {name: 'southeast', long: 96, lat: 35, elv: 180},
+  {name: 'northwest', long: 100, lat: 39, elv: 240},
+  {name: 'northeast', long: 96, lat: 39, elv: 320}
+];
+
+function createElevationData(): string {
+  const canvas = document.createElement('canvas');
+  canvas.width = 16;
+  canvas.height = 16;
+  const context = canvas.getContext('2d');
+  if (!context) {
+    throw new Error('Could not create the browser-test elevation image.');
+  }
+
+  const image = context.createImageData(canvas.width, canvas.height);
+  for (let offset = 0; offset < image.data.length; offset += 4) {
+    image.data[offset] = 48 + ((offset / 4) % canvas.width) * 10;
+    image.data[offset + 3] = 255;
+  }
+  context.putImageData(image, 0, 0);
+  return canvas.toDataURL('image/png');
+}
+
+function createLayers(field: WindField, time: number, elevationData: string) {
+  return [
+    new ElevationLayer({
+      id: 'test-wind-height-map',
+      elevationData,
+      bounds: [-100, 35, -96, 39],
+      elevationRange: [0, 255],
+      elevationScale: 2,
+      meshMaxError: 4
+    }),
+    new DelaunayCoverLayer({id: 'test-wind-terrain', windField: field, elevationScale: 2}),
+    new WindLayer({
+      id: 'test-wind-arrows',
+      windField: field,
+      time,
+      gridWidth: 8,
+      gridHeight: 6,
+      elevationScale: 2
+    }),
+    new ParticleLayer({
+      id: 'test-wind-particles',
+      windField: field,
+      time,
+      numParticles: 24,
+      trailLength: 4,
+      elevationScale: 2
+    })
+  ];
+}
+
+describe('wind height-map setup', () => {
+  it('constructs the original elevation terrain without a remote worker', () => {
+    const layer = new ElevationLayer({
+      id: 'test-height-map',
+      elevationData: 'https://example.com/elevation.png',
+      bounds: [-125, 24.4, -66.7, 49.6],
+      elevationScale: 80
+    });
+
+    expect(layer.props.elevationScale).toBe(80);
+    expect(layer.props.elevationData).toContain('elevation.png');
+  });
+});
+
+async function renderWindLayers(type: 'webgl' | 'webgpu'): Promise<void> {
+  const parent = document.createElement('div');
+  parent.style.width = '160px';
+  parent.style.height = '120px';
+  document.body.append(parent);
+
+  const field = createWindField(STATIONS, [
+    [
+      [0, 10, 20],
+      [1, 15, 25],
+      [2, 20, 30],
+      [3, 25, 35]
+    ],
+    [
+      [1, 12, 21],
+      [2, 17, 26],
+      [3, 22, 31],
+      [4, 27, 36]
+    ]
+  ]);
+
+  let device: Device | undefined;
+  let deck: Deck | undefined;
+  const elevationData = createElevationData();
+
+  try {
+    device = await luma.createDevice({
+      type,
+      adapters: [webgl2Adapter, webgpuAdapter],
+      createCanvasContext: {container: parent}
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = window.setTimeout(() => {
+        reject(new Error(`Timed out while rendering wind showcase layers with ${type}.`));
+      }, 10_000);
+      let renderedAnimation = false;
+
+      deck = new Deck({
+        device,
+        parent,
+        width: 160,
+        height: 120,
+        views: new MapView({id: 'wind-test'}),
+        initialViewState: {longitude: -98, latitude: 37, zoom: 4},
+        layers: createLayers(field, 0, elevationData),
+        onAfterRender: () => {
+          if (!renderedAnimation) {
+            renderedAnimation = true;
+            deck?.setProps({layers: createLayers(field, 0.5, elevationData)});
+            return;
+          }
+          window.clearTimeout(timeout);
+          resolve();
+        },
+        onError: error => {
+          window.clearTimeout(timeout);
+          reject(error);
+        }
+      });
+    });
+
+    expect(deck.device?.type).toBe(type);
+  } finally {
+    deck?.finalize();
+    device?.destroy();
+    parent.remove();
+  }
+}
+
+describe('wind showcase rendering', () => {
+  it('renders and animates terrain, arrows, and particles on WebGL2', async () => {
+    await renderWindLayers('webgl');
+  }, 20_000);
+
+  it('renders and animates terrain, arrows, and particles on WebGPU', async ({skip}) => {
+    const gpu = (navigator as Navigator & {gpu?: BrowserGpu}).gpu;
+    if (!gpu || !(await gpu.requestAdapter())) {
+      skip('This browser does not expose an available WebGPU adapter.');
+    }
+
+    await renderWindLayers('webgpu');
+  }, 20_000);
+});

--- a/modules/geo-layers/test/wind-layer/wind-layers.spec.ts
+++ b/modules/geo-layers/test/wind-layer/wind-layers.spec.ts
@@ -1,0 +1,189 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {LineLayer, PathLayer, ScatterplotLayer, SolidPolygonLayer} from '@deck.gl/layers';
+import {TerrainLayer} from '@deck.gl/geo-layers';
+import {describe, expect, it, vi} from 'vitest';
+
+import {
+  createWindField,
+  DelaunayCoverLayer,
+  ElevationLayer,
+  ParticleLayer,
+  WindLayer,
+  type WindStation
+} from '../../src';
+
+const STATIONS: WindStation[] = [
+  {name: 'southwest', long: 2, lat: 0, elv: 10},
+  {name: 'southeast', long: 0, lat: 0, elv: 20},
+  {name: 'northwest', long: 2, lat: 2, elv: 30},
+  {name: 'northeast', long: 0, lat: 2, elv: 40}
+];
+
+const FIELD = createWindField(STATIONS, [
+  [
+    [0, 10, 20],
+    [1, 20, 30],
+    [2, 30, 40],
+    [3, 40, 50]
+  ],
+  [
+    [1, 20, 30],
+    [2, 30, 40],
+    [3, 40, 50],
+    [4, 50, 60]
+  ]
+]);
+
+describe('reusable wind showcase layers', () => {
+  it('renders vector shafts and arrowheads from the shared wind field', () => {
+    const layer = new WindLayer({
+      id: 'wind-test',
+      windField: FIELD,
+      gridWidth: 5,
+      gridHeight: 5,
+      time: 0.5
+    });
+    layer.getSubLayerProps = vi.fn(props => props);
+
+    const [glyphs, shafts, heads] = layer.renderLayers() as [
+      SolidPolygonLayer,
+      PathLayer,
+      PathLayer
+    ];
+
+    expect(glyphs).toBeInstanceOf(SolidPolygonLayer);
+    expect(glyphs.props.id).toBe('glyphs');
+    expect(shafts).toBeInstanceOf(PathLayer);
+    expect(heads).toBeInstanceOf(PathLayer);
+    expect(shafts.props.id).toBe('shafts');
+    expect(heads.props.id).toBe('arrowheads');
+    expect(shafts.props.data).not.toHaveLength(0);
+    expect(glyphs.props.data).toHaveLength((shafts.props.data as unknown[]).length);
+    expect(heads.props.data).toHaveLength((shafts.props.data as unknown[]).length);
+  });
+
+  it('decodes the original grayscale elevation image as a real exaggerated terrain mesh', () => {
+    const layer = new ElevationLayer({
+      id: 'elevation-test',
+      elevationData: 'https://example.com/elevation.png',
+      bounds: [-125, 24.4, -66.7, 49.6],
+      elevationRange: [-100, 4126],
+      elevationScale: 80
+    });
+    layer.getSubLayerProps = vi.fn(props => props);
+
+    const terrain = layer.renderLayers() as TerrainLayer;
+
+    expect(terrain).toBeInstanceOf(TerrainLayer);
+    expect(terrain.props.id).toBe('terrain-mesh');
+    expect(terrain.props.elevationData).toBe('https://example.com/elevation.png');
+    expect(terrain.props.texture).toBe('https://example.com/elevation.png');
+    expect(terrain.props.elevationDecoder).toEqual({
+      rScaler: (4226 / 255) * 80,
+      gScaler: 0,
+      bScaler: 0,
+      offset: -8000
+    });
+    expect(terrain.props.loadOptions).toEqual({worker: false});
+  });
+
+  it('renders one terrain polygon per station triangle', () => {
+    const layer = new DelaunayCoverLayer({
+      id: 'terrain-test',
+      windField: FIELD,
+      elevationScale: 2
+    });
+    layer.getSubLayerProps = vi.fn(props => props);
+
+    const terrain = layer.renderLayers() as SolidPolygonLayer;
+
+    expect(terrain).toBeInstanceOf(SolidPolygonLayer);
+    expect(terrain.props.id).toBe('terrain');
+    expect(terrain.props.data).toHaveLength(FIELD.triangles.length);
+    expect((terrain.props.data as {polygon: number[][]}[])[0].polygon[0][2]).toBeGreaterThan(0);
+  });
+
+  it('advects particles a visible, elapsed-time-scaled distance through the wind field', () => {
+    const createAdvancedParticle = (time: number) => {
+      const layer = new ParticleLayer({
+        id: `advected-particle-${time}`,
+        windField: FIELD,
+        time,
+        numParticles: 1,
+        speedScale: 0.16,
+        surfaceOffset: 160
+      });
+      layer.state = {
+        lastTime: 0,
+        particles: [{seed: 1, positions: [[-1, 1, 160]]}]
+      };
+      vi.spyOn(layer, 'setState').mockImplementation(update => {
+        Object.assign(layer.state, update);
+      });
+
+      layer.updateState({
+        props: layer.props,
+        oldProps: layer.props,
+        changeFlags: {dataChanged: false}
+      } as Parameters<ParticleLayer['updateState']>[0]);
+
+      return layer.state.particles[0];
+    };
+
+    const oneFrame = createAdvancedParticle(1 / 54);
+    const twoFrames = createAdvancedParticle(2 / 54);
+    const getDistance = (particle: typeof oneFrame) => {
+      const [start, end] = particle.positions;
+      return Math.hypot(end[0] - start[0], end[1] - start[1]);
+    };
+
+    expect(oneFrame.positions).toHaveLength(2);
+    expect(getDistance(oneFrame)).toBeGreaterThan(0.025);
+    expect(getDistance(twoFrames)).toBeCloseTo(getDistance(oneFrame) * 2, 2);
+    expect(oneFrame.direction).toBeTypeOf('number');
+    expect(oneFrame.speed).toBeGreaterThan(0);
+  });
+
+  it('renders independently faded particle trail segments', () => {
+    const layer = new ParticleLayer({
+      id: 'particles-test',
+      windField: FIELD,
+      numParticles: 1,
+      color: [100, 150, 200, 180]
+    });
+    layer.getSubLayerProps = vi.fn(props => props);
+    layer.state = {
+      lastTime: 0,
+      particles: [
+        {
+          seed: 1,
+          positions: [
+            [-1.5, 0.5, 10],
+            [-1.25, 0.5, 12],
+            [-1, 0.5, 14]
+          ]
+        }
+      ]
+    };
+
+    const [trails, heads] = layer.renderLayers() as [LineLayer, ScatterplotLayer];
+    const segments = trails.props.data as {color: number[]}[];
+
+    expect(trails).toBeInstanceOf(LineLayer);
+    expect(heads).toBeInstanceOf(ScatterplotLayer);
+    expect(trails.props.id).toBe('trails');
+    expect(segments).toHaveLength(2);
+    expect(segments[0].color[3]).toBeLessThan(segments[1].color[3]);
+    expect(segments[1].color).toEqual([100, 150, 200, 180]);
+    expect(heads.props.data).toHaveLength(1);
+  });
+
+  it('does not render particles before their simulation is initialized', () => {
+    const layer = new ParticleLayer({id: 'empty-particles', windField: FIELD});
+
+    expect(layer.renderLayers()).toBeNull();
+  });
+});

--- a/website/src/examples-sidebar.js
+++ b/website/src/examples-sidebar.js
@@ -19,7 +19,7 @@ const sidebars = {
     {
       type: 'category',
       label: '@deck.gl-community/geo-layers',
-      items: ['geo-layers/shared-tile-2d-layer']
+      items: ['geo-layers/shared-tile-2d-layer', 'geo-layers/wind']
     },
     {
       type: 'category',

--- a/website/src/examples/geo-layers/wind.mdx
+++ b/website/src/examples/geo-layers/wind.mdx
@@ -1,0 +1,8 @@
+---
+title: Wind Map
+hide_title: true
+---
+
+import Demo from './wind';
+
+<Demo />

--- a/website/src/examples/geo-layers/wind.tsx
+++ b/website/src/examples/geo-layers/wind.tsx
@@ -1,0 +1,12 @@
+import {GITHUB_TREE} from '../../constants/defaults';
+import {makeImperativeExample} from '../../components';
+
+export default makeImperativeExample({
+  title: 'Wind Map',
+  code: `${GITHUB_TREE}/examples/geo-layers/wind`,
+  deviceTabs: true,
+  async mount(container, options) {
+    const {mountWindExample} = await import('../../../../examples/geo-layers/wind/app');
+    return mountWindExample(container, options);
+  }
+});

--- a/website/src/examples/index.mdx
+++ b/website/src/examples/index.mdx
@@ -8,6 +8,7 @@ export const thumbnailOverrides = {
   'layers/basemap-layer-map-view': '/images/maps.jpg',
   'infovis-layers/layer-primitives': '/images/layers.png',
   'geo-layers/shared-tile-2d-layer': '/images/layers.png',
+  'geo-layers/wind': '/images/layers.png',
   'timeline-layers/horizon-graph-layer': '/images/examples/infovis-layers/horizon-graph-layer.jpg',
   'timeline-layers/multi-horizon-graph-layer': '/images/examples/infovis-layers/horizon-graph-layer.jpg',
   'trace-layers/tracevis': '/images/layers.png',

--- a/yarn.lock
+++ b/yarn.lock
@@ -515,7 +515,9 @@ __metadata:
   dependencies:
     "@deck.gl/core": "npm:~9.3.0"
     "@deck.gl/test-utils": "npm:~9.3.0"
+    "@loaders.gl/core": "npm:^4.4.1"
     "@loaders.gl/loader-utils": "npm:^4.4.1"
+    "@loaders.gl/terrain": "npm:^4.4.1"
     "@luma.gl/core": "npm:~9.3.2"
     "@luma.gl/engine": "npm:~9.3.2"
     "@luma.gl/shadertools": "npm:~9.3.2"
@@ -529,6 +531,7 @@ __metadata:
     "@deck.gl/core": ~9.3.0
     "@deck.gl/geo-layers": ~9.3.0
     "@deck.gl/layers": ~9.3.0
+    "@loaders.gl/core": ^4.4.1
     "@luma.gl/core": ~9.3.2
     "@luma.gl/engine": ~9.3.2
   languageName: unknown
@@ -17145,6 +17148,24 @@ __metadata:
     "@luma.gl/shadertools": "npm:~9.3.2"
     "@luma.gl/webgl": "npm:~9.3.2"
     "@luma.gl/webgpu": "npm:~9.3.2"
+    vite: "npm:^7.3.1"
+  languageName: unknown
+  linkType: soft
+
+"wind-layer-example@workspace:examples/geo-layers/wind":
+  version: 0.0.0-use.local
+  resolution: "wind-layer-example@workspace:examples/geo-layers/wind"
+  dependencies:
+    "@deck.gl-community/geo-layers": "workspace:*"
+    "@deck.gl/core": "npm:~9.3.0"
+    "@deck.gl/extensions": "npm:~9.3.0"
+    "@deck.gl/geo-layers": "npm:~9.3.0"
+    "@deck.gl/layers": "npm:~9.3.0"
+    "@deck.gl/mesh-layers": "npm:~9.3.0"
+    "@loaders.gl/core": "npm:^4.4.1"
+    "@luma.gl/core": "npm:~9.3.2"
+    "@luma.gl/engine": "npm:~9.3.2"
+    "@luma.gl/shadertools": "npm:~9.3.2"
     vite: "npm:^7.3.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary

Port Nicolas Belmonte’s historical deck.gl wind showcase into reusable, documented `@deck.gl-community/geo-layers` APIs and recreate the example from the original weather and elevation data.

## What changed

- Add `WindLayer`, `ParticleLayer`, `ElevationLayer`, `DelaunayCoverLayer`, and `DelaunayInterpolation` as public geo-layers APIs.
- Add parsing, station triangulation, temporal interpolation, and spatial sampling for the original 1,514-station, 72-hour weather forecast.
- Render the original elevation image as illuminated, vertically exaggerated three-dimensional terrain without depending on a remotely hosted terrain worker.
- Animate fading, curved, elapsed-time-scaled particle trails with visible particle heads and filled, wind-speed-colored direction arrows.
- Add a standalone wind example and embed it in the website, including layer visibility controls and an 85° maximum camera pitch.
- Document every new public layer and interpolation utility.
- Add station/data unit tests, public-export coverage, a particle-motion regression test, and a real Chromium/WebGL rendering test for the terrain, arrows, and particle animation.
- Declare `@loaders.gl/core` as the required shared peer dependency rather than installing a duplicate singleton.

## Follow-up

The example captures the original dataset, animated flow, 3D terrain, and reusable layer architecture, but visual parity and particle-density tuning against the original showcase can continue in follow-up work.

## Validation

- `yarn lint`.
- `yarn build`.
- Repository pre-commit full test suite: **167 test files, 1,408 passing tests, 9 existing skipped tests**.
- `yarn vitest run --project node modules/geo-layers/test/wind-layer`.
- `yarn vitest run --project headless modules/geo-layers/test/wind-layer/wind-layers.browser.spec.ts`: Chromium/WebGL passes; WebGPU is skipped when no adapter is exposed.
- Manually verified the running original-data showcase, terrain, animation, camera controls, and clean browser console.
