### PR TITLE
Run WebGPU browser tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -260,6 +260,8 @@ jobs:
 
       - name: Run headless browser tests
         run: yarn test-headless
+        env:
+          DECK_GL_COMMUNITY_SOFTWARE_WEBGPU: 'true'
 
   website-build:
     runs-on: ubuntu-22.04

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -36,6 +36,8 @@ Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community
   including its picking-width shader customization.
 - `TraceGraphLayer`, `TracePreparedStateLayer`, and `TraceProcessLayer`: ported trace backgrounds, binary span blocks, outlines, labels, overflow labels, separators, and straight dependencies by reusing dual-backend community layers.
 - Trace counter sparklines now preserve their full geometry using portable `LineLayer` segments.
+- Headless CI enables Chromium's software WebGPU adapter, so native WebGPU validation tests run
+  even on runners without hardware adapters instead of being skipped.
 - Every website gallery example and live layer-reference example now receives a standalone
   `DeviceTabsWidget` from the shared imperative host, with an independent device manager, WebGPU
   preference, WebGL2 fallback, renderer remounting, and preserved view state.

--- a/modules/arrow-layers/test/webgpu-layers.browser.spec.ts
+++ b/modules/arrow-layers/test/webgpu-layers.browser.spec.ts
@@ -16,6 +16,7 @@ import {
 } from 'apache-arrow';
 import {describe, expect, it} from 'vitest';
 
+import {releaseBrowserTestDevice} from '../../../test/browser-test-device';
 import {GeoArrowPathLayer, GeoArrowSolidPolygonLayer} from '../src';
 
 type BrowserGpu = {requestAdapter: () => Promise<unknown>};
@@ -136,7 +137,7 @@ async function renderGeoArrowLayers(type: 'webgl' | 'webgpu'): Promise<void> {
   } finally {
     nativeDevice?.removeEventListener('uncapturederror', captureValidationError);
     deck?.finalize();
-    device?.destroy();
+    releaseBrowserTestDevice(device);
     parent.remove();
   }
 }

--- a/modules/geo-layers/test/wind-layer/wind-layers.browser.spec.ts
+++ b/modules/geo-layers/test/wind-layer/wind-layers.browser.spec.ts
@@ -8,6 +8,7 @@ import {webgl2Adapter} from '@luma.gl/webgl';
 import {webgpuAdapter} from '@luma.gl/webgpu';
 import {describe, expect, it} from 'vitest';
 
+import {releaseBrowserTestDevice} from '../../../../test/browser-test-device';
 import {GpuParticleSimulation} from '../../src/wind-layer/gpu-particle-simulation';
 import {
   createWindField,
@@ -213,7 +214,7 @@ async function renderWindLayers(type: 'webgl' | 'webgpu'): Promise<void> {
   } finally {
     nativeDevice?.removeEventListener('uncapturederror', captureValidationError);
     deck?.finalize();
-    device?.destroy();
+    releaseBrowserTestDevice(device);
     parent.remove();
   }
 }

--- a/modules/infovis-layers/test/fast-text-layer.browser.spec.ts
+++ b/modules/infovis-layers/test/fast-text-layer.browser.spec.ts
@@ -8,6 +8,7 @@ import {webgl2Adapter} from '@luma.gl/webgl';
 import {webgpuAdapter} from '@luma.gl/webgpu';
 import {describe, expect, it} from 'vitest';
 
+import {releaseBrowserTestDevice} from '../../../test/browser-test-device';
 import {FastTextLayer} from '../src';
 
 type BrowserGpu = {requestAdapter: () => Promise<unknown>};
@@ -88,7 +89,7 @@ async function renderFastText(type: 'webgl' | 'webgpu', sdf: boolean): Promise<v
   } finally {
     nativeDevice?.removeEventListener('uncapturederror', captureValidationError);
     deck?.finalize();
-    device?.destroy();
+    releaseBrowserTestDevice(device);
     parent.remove();
   }
 }

--- a/modules/layers/test/webgpu-layers.browser.spec.ts
+++ b/modules/layers/test/webgpu-layers.browser.spec.ts
@@ -8,6 +8,7 @@ import {webgl2Adapter} from '@luma.gl/webgl';
 import {webgpuAdapter} from '@luma.gl/webgpu';
 import {describe, expect, it} from 'vitest';
 
+import {releaseBrowserTestDevice} from '../../../test/browser-test-device';
 import {
   HorizonGraphLayer,
   MultiHorizonGraphLayer,
@@ -417,7 +418,7 @@ async function renderPortableLayers(type: 'webgl' | 'webgpu'): Promise<void> {
   } finally {
     nativeDevice?.removeEventListener('uncapturederror', captureValidationError);
     deck?.finalize();
-    device?.destroy();
+    releaseBrowserTestDevice(device);
     parent.remove();
   }
 }
@@ -425,7 +426,7 @@ async function renderPortableLayers(type: 'webgl' | 'webgpu'): Promise<void> {
 describe('community graphics backend compatibility', () => {
   it('renders custom shaders, paths, polygons, graph, timeline, and editing on WebGL2', async () => {
     await renderPortableLayers('webgl');
-  }, 20_000);
+  }, 30_000);
 
   it('renders custom shaders, paths, polygons, graph, timeline, and editing on WebGPU', async ({
     skip
@@ -436,5 +437,5 @@ describe('community graphics backend compatibility', () => {
     }
 
     await renderPortableLayers('webgpu');
-  }, 20_000);
+  }, 30_000);
 });

--- a/modules/trace-layers/src/layers/layers/trace-webgpu.browser.spec.ts
+++ b/modules/trace-layers/src/layers/layers/trace-webgpu.browser.spec.ts
@@ -8,6 +8,7 @@ import {webgl2Adapter} from '@luma.gl/webgl';
 import {webgpuAdapter} from '@luma.gl/webgpu';
 import {describe, expect, it} from 'vitest';
 
+import {releaseBrowserTestDevice} from '../../../../../test/browser-test-device';
 import {
   buildJSONTrace,
   buildTraceGraphDataFromJSONTrace,
@@ -212,7 +213,7 @@ async function renderTraceGraph(
   } finally {
     nativeGpuDevice?.removeEventListener('uncapturederror', handleValidationError);
     deck?.finalize();
-    device?.destroy();
+    releaseBrowserTestDevice(device);
     parent.remove();
   }
 }

--- a/test/browser-test-device.ts
+++ b/test/browser-test-device.ts
@@ -1,0 +1,18 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Device} from '@luma.gl/core';
+
+/**
+ * Releases a graphics device created by a browser test.
+ *
+ * Deck finalization destroys each test's WebGPU resources. The Playwright browser process owns
+ * final WebGPU device teardown because explicitly destroying a Linux SwiftShader device can drop
+ * the external WebGPU instance shared by parallel Vitest browser files.
+ */
+export function releaseBrowserTestDevice(device: Device | undefined): void {
+  if (device?.type !== 'webgpu') {
+    device?.destroy();
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -83,19 +83,20 @@ const BROWSER_OPTIMIZE_DEPS_CONFIG = {
 const BROWSER_TEST_EXCLUDE = ['modules/**/dist/**', 'dev/**/dist/**'];
 
 const HEADLESS_BROWSER_PROVIDER =
-  process.env.GITHUB_ACTIONS === 'true'
-    ? playwright({launchOptions: {channel: 'chrome'}})
-    : process.env.DECK_GL_COMMUNITY_SOFTWARE_WEBGPU === 'true'
-      ? playwright({
-          launchOptions: {
-            args: [
-              '--enable-unsafe-webgpu',
-              '--enable-unsafe-swiftshader',
-              '--use-angle=swiftshader',
-              '--enable-features=Vulkan,WebGPU'
-            ]
-          }
-        })
+  process.env.DECK_GL_COMMUNITY_SOFTWARE_WEBGPU === 'true'
+    ? playwright({
+        launchOptions: {
+          ...(process.env.GITHUB_ACTIONS === 'true' ? {channel: 'chrome'} : {}),
+          args: [
+            '--enable-unsafe-webgpu',
+            '--enable-unsafe-swiftshader',
+            '--use-angle=swiftshader',
+            '--enable-features=Vulkan,WebGPU'
+          ]
+        }
+      })
+    : process.env.GITHUB_ACTIONS === 'true'
+      ? playwright({launchOptions: {channel: 'chrome'}})
       : playwright();
 
 const CONFIG = defineConfig({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -92,8 +92,10 @@ const HEADLESS_BROWSER_PROVIDER =
           args: [
             '--enable-unsafe-webgpu',
             '--enable-unsafe-swiftshader',
+            '--use-gl=angle',
             '--use-angle=swiftshader',
-            '--enable-features=Vulkan,WebGPU'
+            '--use-webgpu-adapter=swiftshader',
+            '--use-gpu-in-tests'
           ]
         }
       })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -82,8 +82,10 @@ const BROWSER_OPTIMIZE_DEPS_CONFIG = {
 
 const BROWSER_TEST_EXCLUDE = ['modules/**/dist/**', 'dev/**/dist/**'];
 
+const SOFTWARE_WEBGPU_ENABLED = process.env.DECK_GL_COMMUNITY_SOFTWARE_WEBGPU === 'true';
+
 const HEADLESS_BROWSER_PROVIDER =
-  process.env.DECK_GL_COMMUNITY_SOFTWARE_WEBGPU === 'true'
+  SOFTWARE_WEBGPU_ENABLED
     ? playwright({
         launchOptions: {
           ...(process.env.GITHUB_ACTIONS === 'true' ? {channel: 'chrome'} : {}),
@@ -168,6 +170,7 @@ const CONFIG = defineConfig({
           browser: {
             enabled: true,
             headless: true,
+            fileParallelism: !SOFTWARE_WEBGPU_ENABLED,
             provider: HEADLESS_BROWSER_PROVIDER,
             instances: [{browser: 'chromium'}]
           }


### PR DESCRIPTION
## Summary

- enable Chromium's software WebGPU adapter for the headless browser job
- preserve the GitHub Actions Chrome channel while applying software-renderer flags
- explicitly select Dawn's SwiftShader WebGPU adapter and initialize the matching GPU path
- serialize browser files only in software-WebGPU mode
- avoid explicitly destroying shared Linux SwiftShader WebGPU devices between browser files; WebGL devices are still destroyed explicitly
- give the broad portable-layer rendering cases additional timeout headroom
- document WebGPU CI coverage in `docs/whats-new.md`

This draft is intentionally independent of #705 and targets `master` directly. The WebGPU layer-port PR does not depend on this branch and can land separately.

## Current status

Local software-WebGPU validation passes, but GitHub's Ubuntu runner still fails the headless job: the first native WebGPU rendering file loses Dawn's external instance, followed by six failures across five WebGPU browser files.

```text
OperationError: A valid external Instance reference no longer exists.
```

The failure persists with browser files serialized, explicit WebGPU-device teardown removed, and Chromium's documented `--use-webgpu-adapter=swiftshader` / `--use-gpu-in-tests` configuration. This draft therefore remains an isolated CI investigation; it is not ready to land and does not block #705.

Chromium reference: [`webgpu-swiftshader` flag configuration](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/web_tests/FlagSpecificConfig).

Likely next steps are to capture `chrome://gpu` and adapter diagnostics on the runner, then determine whether the hosted Chrome/Dawn build needs a different Linux image, Vulkan setup, or dedicated GPU-capable runner.

## Validation

- `yarn lint`
- `yarn test`: 168 files passed; 1,420 tests passed, 9 skipped
- local `GITHUB_ACTIONS=true DECK_GL_COMMUNITY_SOFTWARE_WEBGPU=true yarn test-headless`: 56 files passed; 438 tests passed, 0 skipped
- GitHub Actions `test-headless`: 432 passed, 6 failed across five WebGPU files
