### PR TITLE
feat(three): render detailed palms

### DIFF
--- a/docs/modules/three/api-reference/tree-layer.md
+++ b/docs/modules/three/api-reference/tree-layer.md
@@ -23,7 +23,7 @@ new TreeLayer({
 
 ## Features
 
-- **5 tree species / silhouettes**: pine (tiered cones), oak (sphere), palm (flat crown), birch (narrow oval), cherry (round sphere)
+- **5 tree species / silhouettes**: pine (tiered cones), oak (sphere), date palm (ring-scarred trunk and pinnate fronds), birch (narrow oval), cherry (round sphere)
 - **Organic canopy geometry**: smooth low-frequency vertex jitter baked into each species mesh at init time — no runtime cost, no mesh gaps
 - **Per-tree variety**: position-derived random bearing and asymmetric XY scale give every instance a unique silhouette with zero extra draw calls
 - **Parametric geometry**: per-instance height, trunk-to-canopy ratio, trunk radius, canopy radius

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -103,10 +103,7 @@ Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community
 
 ### `@deck.gl-community/three`
 
-- `TreeLayer` now renders its `palm` silhouette as a recognizable date palm with a tapered,
-  ring-scarred trunk, a connected crown shaft, 20 mature arching fronds, 8 upright spear fronds,
-  and paired pinnate leaflets. The procedural crown remains one shared instanced mesh, and the
-  Wild Forest example includes a dedicated Date Palm Grove for visual inspection.
+- `TreeLayer`: improved `palm` silhouette with a detailed frond crown and ring-scarred trunk.
 
 ### `@deck.gl-community/widgets`
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -101,6 +101,13 @@ Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community
 
 - `<Panel />` - NEW React component for rendering reusable `@deck.gl-community/panels` definitions in React and MDX trees.
 
+### `@deck.gl-community/three`
+
+- `TreeLayer` now renders its `palm` silhouette as a recognizable date palm with a tapered,
+  ring-scarred trunk, a connected crown shaft, 20 mature arching fronds, 8 upright spear fronds,
+  and paired pinnate leaflets. The procedural crown remains one shared instanced mesh, and the
+  Wild Forest example includes a dedicated Date Palm Grove for visual inspection.
+
 ### `@deck.gl-community/widgets`
 
 - `PanelWidget` - NEW generic deck adapter for any panel-owned `PanelComponent`.

--- a/examples/three/wild-forest/app.tsx
+++ b/examples/three/wild-forest/app.tsx
@@ -104,7 +104,7 @@ const ZONES: ZoneInfo[] = [
   {label: 'Pine Forest (Summer)', color: '#006400'},
   {label: 'Oak Grove (Autumn)', color: '#b45314'},
   {label: 'Cherry Blossom (Spring)', color: '#ffb4c8'},
-  {label: 'Date Palm Grove (Summer)', color: '#14911e'},
+  {label: 'Palm Grove (Summer)', color: '#14911e'},
   {label: 'Birch Glade (Autumn)', color: '#e6b928'},
   {label: 'Oak Silhouettes (Winter)', color: 'rgba(100,80,80,0.4)'},
   {label: 'Birch Grove (Spring)', color: '#96d26e'},
@@ -369,7 +369,7 @@ function generateForest(): TreeDatum[] {
       trunkHeightFraction: 0.72 + palmRng() * 0.15,
       season: 'summer',
       branchLevels: 0,
-      label: 'Date Palm',
+      label: 'Palm',
       crop: null
     });
   }

--- a/examples/three/wild-forest/app.tsx
+++ b/examples/three/wild-forest/app.tsx
@@ -104,7 +104,7 @@ const ZONES: ZoneInfo[] = [
   {label: 'Pine Forest (Summer)', color: '#006400'},
   {label: 'Oak Grove (Autumn)', color: '#b45314'},
   {label: 'Cherry Blossom (Spring)', color: '#ffb4c8'},
-  {label: 'Palm Grove (Summer)', color: '#14911e'},
+  {label: 'Date Palm Grove (Summer)', color: '#14911e'},
   {label: 'Birch Glade (Autumn)', color: '#e6b928'},
   {label: 'Oak Silhouettes (Winter)', color: 'rgba(100,80,80,0.4)'},
   {label: 'Birch Grove (Spring)', color: '#96d26e'},
@@ -369,7 +369,7 @@ function generateForest(): TreeDatum[] {
       trunkHeightFraction: 0.72 + palmRng() * 0.15,
       season: 'summer',
       branchLevels: 0,
-      label: 'Palm',
+      label: 'Date Palm',
       crop: null
     });
   }

--- a/modules/three/README.md
+++ b/modules/three/README.md
@@ -21,7 +21,7 @@ Renders richly configurable 3D trees at geographic positions using procedural ge
 
 ### Features
 
-- **5 tree species / silhouettes**: pine (tiered cones), oak (sphere), date palm (ring-scarred trunk and pinnate fronds), birch (narrow oval), cherry (round sphere)
+- **5 tree species / silhouettes**: pine (tiered cones), oak (sphere), palm (ring-scarred trunk and pinnate fronds), birch (narrow oval), cherry (round sphere)
 - **Organic canopy geometry**: smooth low-frequency vertex jitter baked into each species mesh at init time — no runtime cost, no mesh gaps
 - **Per-tree variety**: position-derived random bearing and asymmetric XY scale give every instance a unique silhouette with zero extra draw calls
 - **Parametric geometry**: per-instance height, trunk-to-canopy ratio, trunk radius, canopy radius
@@ -184,7 +184,7 @@ type CropConfig = {
 
 ## Wild-Forest example
 
-A full demo with 9 forest zones (pines, oaks, date palms, birches, cherry blossoms, citrus orchards, almond groves) is available at `examples/three/wild-forest/`.
+A full demo with 9 forest zones (pines, oaks, palms, birches, cherry blossoms, citrus orchards, almond groves) is available at `examples/three/wild-forest/`.
 
 ```bash
 cd examples/three/wild-forest

--- a/modules/three/README.md
+++ b/modules/three/README.md
@@ -21,7 +21,7 @@ Renders richly configurable 3D trees at geographic positions using procedural ge
 
 ### Features
 
-- **5 tree species / silhouettes**: pine (tiered cones), oak (sphere), palm (flat crown), birch (narrow oval), cherry (round sphere)
+- **5 tree species / silhouettes**: pine (tiered cones), oak (sphere), date palm (ring-scarred trunk and pinnate fronds), birch (narrow oval), cherry (round sphere)
 - **Organic canopy geometry**: smooth low-frequency vertex jitter baked into each species mesh at init time — no runtime cost, no mesh gaps
 - **Per-tree variety**: position-derived random bearing and asymmetric XY scale give every instance a unique silhouette with zero extra draw calls
 - **Parametric geometry**: per-instance height, trunk-to-canopy ratio, trunk radius, canopy radius
@@ -184,7 +184,7 @@ type CropConfig = {
 
 ## Wild-Forest example
 
-A full demo with 9 forest zones (pines, oaks, palms, birches, cherry blossoms, citrus orchards, almond groves) is available at `examples/three/wild-forest/`.
+A full demo with 9 forest zones (pines, oaks, date palms, birches, cherry blossoms, citrus orchards, almond groves) is available at `examples/three/wild-forest/`.
 
 ```bash
 cd examples/three/wild-forest

--- a/modules/three/src/tree-layer/tree-geometry.ts
+++ b/modules/three/src/tree-layer/tree-geometry.ts
@@ -171,11 +171,11 @@ export function createTrunkMesh(segments = 8): TreeMesh {
 }
 
 /**
- * Unit date-palm trunk mesh with a slender taper and raised leaf-scar rings.
+ * Unit palm trunk mesh with a slender taper and raised leaf-scar rings.
  * Extends from z=0 (base) to z=1 (top).
  *
  * The shared trunk accessor still controls the overall radius and height. The
- * extra geometry is generated once and instanced for every date palm.
+ * extra geometry is generated once and instanced for every palm.
  */
 export function createDatePalmTrunkMesh(segments = 10, scarRings = 14): TreeMesh {
   const geos: BufferGeometry[] = [];
@@ -319,7 +319,7 @@ function appendPalmLeaflet(
   );
 }
 
-/** Build paired pinnate leaflets along one date-palm frond. */
+/** Build paired pinnate leaflets along one palm frond. */
 function appendPalmFrondLeaflets(
   positions: number[],
   indices: number[],
@@ -354,7 +354,7 @@ function appendPalmFrondLeaflets(
 }
 
 /**
- * Unit date-palm crown with radial, arching fronds and paired pinnate leaflets.
+ * Unit palm crown with radial, arching fronds and paired pinnate leaflets.
  * Extends approximately one unit in XY and from z=0.1 to z=1.
  *
  * Fronds are intentionally modeled as real mesh ribbons instead of a solid

--- a/modules/three/src/tree-layer/tree-geometry.ts
+++ b/modules/three/src/tree-layer/tree-geometry.ts
@@ -5,10 +5,14 @@
 import {
   BufferGeometry,
   BufferAttribute,
+  CubicBezierCurve3,
   CylinderGeometry,
   ConeGeometry,
   SphereGeometry,
-  Matrix4
+  Matrix4,
+  TorusGeometry,
+  TubeGeometry,
+  Vector3
 } from 'three';
 
 /**
@@ -167,6 +171,32 @@ export function createTrunkMesh(segments = 8): TreeMesh {
 }
 
 /**
+ * Unit date-palm trunk mesh with a slender taper and raised leaf-scar rings.
+ * Extends from z=0 (base) to z=1 (top).
+ *
+ * The shared trunk accessor still controls the overall radius and height. The
+ * extra geometry is generated once and instanced for every date palm.
+ */
+export function createDatePalmTrunkMesh(segments = 10, scarRings = 14): TreeMesh {
+  const geos: BufferGeometry[] = [];
+  const core = new CylinderGeometry(0.62, 1, 1, segments, scarRings);
+  core.applyMatrix4(Y_TO_Z_UP);
+  core.translate(0, 0, 0.5);
+  geos.push(core);
+
+  for (let i = 1; i <= scarRings; i++) {
+    const z = i / (scarRings + 1);
+    const trunkRadius = 1 - z * 0.38;
+    const scar = new TorusGeometry(trunkRadius * 0.96, 0.045, 3, segments);
+    scar.rotateZ((i % 2) * (Math.PI / segments));
+    scar.translate(0, 0, z);
+    geos.push(scar);
+  }
+
+  return extractMesh(mergeGeometries(geos));
+}
+
+/**
  * Unit pine canopy mesh: multiple tiered cones creating a Christmas tree silhouette.
  * Extends from z=0 (base of canopy) to z=1 (tip).
  *
@@ -249,19 +279,147 @@ export function createOakCanopyMesh(): TreeMesh {
   return extractMesh(geo);
 }
 
+/** Append a two-sided, tapered leaflet blade to a direct Z-up geometry buffer. */
+function appendPalmLeaflet(
+  positions: number[],
+  indices: number[],
+  base: Vector3,
+  direction: Vector3,
+  widthDirection: Vector3,
+  length: number,
+  width: number
+): void {
+  const tip = base.clone().addScaledVector(direction, length);
+  const middle = base.clone().lerp(tip, 0.52);
+  const left = middle.clone().addScaledVector(widthDirection, width);
+  const right = middle.clone().addScaledVector(widthDirection, -width);
+  const vertexBase = positions.length / 3;
+
+  // Duplicate the four vertices for the reverse winding. This keeps the thin
+  // blades visible from above and below without relying on material cull mode.
+  for (let side = 0; side < 2; side++) {
+    for (const point of [base, left, tip, right]) {
+      positions.push(point.x, point.y, point.z);
+    }
+  }
+
+  indices.push(
+    vertexBase,
+    vertexBase + 1,
+    vertexBase + 2,
+    vertexBase,
+    vertexBase + 2,
+    vertexBase + 3,
+    vertexBase + 4,
+    vertexBase + 6,
+    vertexBase + 5,
+    vertexBase + 4,
+    vertexBase + 7,
+    vertexBase + 6
+  );
+}
+
+/** Build paired pinnate leaflets along one date-palm frond. */
+function appendPalmFrondLeaflets(
+  positions: number[],
+  indices: number[],
+  curve: CubicBezierCurve3,
+  leafletPairs: number,
+  phase: number
+): void {
+  for (let i = 0; i < leafletPairs; i++) {
+    const t = 0.2 + (i / (leafletPairs - 1)) * 0.72;
+    const point = curve.getPoint(t);
+    const tangent = curve.getTangent(t).normalize();
+    const sideways = new Vector3(-tangent.y, tangent.x, 0).normalize();
+    const fullness = Math.sin(((i + 0.75) / leafletPairs) * Math.PI);
+    const length = 0.055 + fullness * 0.095;
+    const width = 0.007 + fullness * 0.008;
+
+    for (const side of [-1, 1]) {
+      const base = point.clone().addScaledVector(sideways, side * 0.008);
+      const direction = sideways
+        .clone()
+        .multiplyScalar(side)
+        .addScaledVector(tangent, 0.18 + Math.sin(phase + i * 0.7) * 0.06)
+        .add(new Vector3(0, 0, 0.12 - t * 0.2))
+        .normalize();
+      const widthDirection = tangent
+        .clone()
+        .add(new Vector3(0, 0, 0.08))
+        .normalize();
+      appendPalmLeaflet(positions, indices, base, direction, widthDirection, length, width);
+    }
+  }
+}
+
 /**
- * Unit palm canopy mesh: a flat, wide disk crown typical of palm trees.
- * Extends from z=0 to z=0.35, radius=1.
+ * Unit date-palm crown with radial, arching fronds and paired pinnate leaflets.
+ * Extends approximately one unit in XY and from z=0.1 to z=1.
+ *
+ * Fronds are intentionally modeled as real mesh ribbons instead of a solid
+ * canopy blob. This preserves the characteristic feathered silhouette from
+ * both aerial and pitched map views while remaining one shared instanced mesh.
  */
 export function createPalmCanopyMesh(): TreeMesh {
-  // Flattened sphere acting as a spread crown
-  const geo = new SphereGeometry(0.7, 12, 5);
-  jitterSmooth(geo, 0.1, 4);
-  const flatten = new Matrix4().makeScale(1.4, 0.35, 1.4);
-  geo.applyMatrix4(flatten);
-  geo.applyMatrix4(Y_TO_Z_UP);
-  geo.translate(0, 0, 0.18);
-  return extractMesh(geo);
+  const geos: BufferGeometry[] = [];
+  const leafletPositions: number[] = [];
+  const leafletIndices: number[] = [];
+  const frondCount = 20;
+
+  for (let i = 0; i < frondCount; i++) {
+    const angle = (i / frondCount) * Math.PI * 2 + Math.sin(i * 5.37) * 0.07;
+    const radial = new Vector3(Math.cos(angle), Math.sin(angle), 0);
+    const tier = i % 4;
+    const length = 0.84 + ((i * 7) % 9) * 0.018;
+    const start = radial
+      .clone()
+      .multiplyScalar(0.035)
+      .setZ(0.43 + tier * 0.012);
+    const controlA = radial
+      .clone()
+      .multiplyScalar(0.28)
+      .setZ(0.72 - tier * 0.025);
+    const controlB = radial
+      .clone()
+      .multiplyScalar(0.68)
+      .setZ(0.55 - tier * 0.045);
+    const end = radial
+      .clone()
+      .multiplyScalar(length)
+      .setZ(0.25 - tier * 0.035);
+    const curve = new CubicBezierCurve3(start, controlA, controlB, end);
+
+    geos.push(new TubeGeometry(curve, 10, 0.012, 4, false));
+    appendPalmFrondLeaflets(leafletPositions, leafletIndices, curve, 11, angle);
+  }
+
+  // Younger upright fronds close the crown and create the distinctive central spear.
+  const uprightFrondCount = 8;
+  for (let i = 0; i < uprightFrondCount; i++) {
+    const angle = ((i + 0.5) / uprightFrondCount) * Math.PI * 2;
+    const radial = new Vector3(Math.cos(angle), Math.sin(angle), 0);
+    const start = radial.clone().multiplyScalar(0.025).setZ(0.44);
+    const controlA = radial.clone().multiplyScalar(0.12).setZ(0.82);
+    const controlB = radial.clone().multiplyScalar(0.38).setZ(1.04);
+    const end = radial.clone().multiplyScalar(0.62).setZ(0.96);
+    const curve = new CubicBezierCurve3(start, controlA, controlB, end);
+
+    geos.push(new TubeGeometry(curve, 8, 0.011, 4, false));
+    appendPalmFrondLeaflets(leafletPositions, leafletIndices, curve, 8, angle + 0.4);
+  }
+
+  const leaflets = new BufferGeometry();
+  leaflets.setAttribute('position', new BufferAttribute(new Float32Array(leafletPositions), 3));
+  leaflets.setIndex(new BufferAttribute(new Uint32Array(leafletIndices), 1));
+  geos.push(leaflets);
+
+  const crownHeart = new SphereGeometry(0.13, 8, 5);
+  crownHeart.scale(1, 1, 0.75);
+  crownHeart.translate(0, 0, 0.43);
+  geos.push(crownHeart);
+
+  return extractMesh(mergeGeometries(geos));
 }
 
 /**

--- a/modules/three/src/tree-layer/tree-layer.ts
+++ b/modules/three/src/tree-layer/tree-layer.ts
@@ -125,7 +125,7 @@ const ALL_TREE_TYPES: TreeType[] = ['pine', 'oak', 'palm', 'birch', 'cherry'];
 const CANOPY_TRUNK_OVERLAP = 0.22;
 
 /**
- * Extra date-palm shaft length, expressed as a fraction of canopy height.
+ * Extra palm shaft length, expressed as a fraction of canopy height.
  * The shaft terminates inside the crown heart so varying trunk/canopy ratios
  * cannot expose daylight between the two independently scaled meshes.
  */
@@ -288,7 +288,7 @@ type _TreeLayerProps<DataT> = {
    * Silhouette / species variant.
    * 'pine'   – layered conical tiers (evergreen)
    * 'oak'    – wide spherical canopy
-   * 'palm'   – ring-scarred date-palm trunk with arching pinnate fronds
+   * 'palm'   – ring-scarred palm trunk with arching pinnate fronds
    * 'birch'  – narrow oval canopy, pale bark
    * 'cherry' – round lush canopy, seasonal blossom
    * @default 'pine'
@@ -606,7 +606,7 @@ export class TreeLayer<DataT = unknown, ExtraPropsT extends {} = {}> extends Com
     const {grouped, pineMeshes, liveCropPoints, droppedCropPoints} = this.state;
 
     // -----------------------------------------------------------------------
-    // 1. Trunk layers — date palms use their ring-scarred trunk mesh while
+    // 1. Trunk layers — palms use their ring-scarred trunk mesh while
     //    all other species continue to share the simpler tapered cylinder.
     // -----------------------------------------------------------------------
     const nonPalmTrunkData = ALL_TREE_TYPES.filter(type => type !== 'palm').flatMap(

--- a/modules/three/src/tree-layer/tree-layer.ts
+++ b/modules/three/src/tree-layer/tree-layer.ts
@@ -7,6 +7,7 @@ import type {Color, DefaultProps, LayerProps, Position} from '@deck.gl/core';
 import {SimpleMeshLayer} from '@deck.gl/mesh-layers';
 import {
   createTrunkMesh,
+  createDatePalmTrunkMesh,
   createPineCanopyMesh,
   createOakCanopyMesh,
   createPalmCanopyMesh,
@@ -102,6 +103,7 @@ const DEFAULT_CANOPY_COLORS: Record<TreeType, Record<Season, Color>> = {
 // ---------------------------------------------------------------------------
 
 const TRUNK_MESH = createTrunkMesh();
+const DATE_PALM_TRUNK_MESH = createDatePalmTrunkMesh();
 
 const CANOPY_MESHES: Record<TreeType, ReturnType<typeof createTrunkMesh>> = {
   pine: createPineCanopyMesh(3),
@@ -121,6 +123,13 @@ const ALL_TREE_TYPES: TreeType[] = ['pine', 'oak', 'palm', 'birch', 'cherry'];
  * 0.22 means the canopy base sits 22% of canopy-height below the trunk top.
  */
 const CANOPY_TRUNK_OVERLAP = 0.22;
+
+/**
+ * Extra date-palm shaft length, expressed as a fraction of canopy height.
+ * The shaft terminates inside the crown heart so varying trunk/canopy ratios
+ * cannot expose daylight between the two independently scaled meshes.
+ */
+const DATE_PALM_TRUNK_CANOPY_EXTENSION = 0.24;
 
 // ---------------------------------------------------------------------------
 // Crop helpers
@@ -279,7 +288,7 @@ type _TreeLayerProps<DataT> = {
    * Silhouette / species variant.
    * 'pine'   – layered conical tiers (evergreen)
    * 'oak'    – wide spherical canopy
-   * 'palm'   – tall thin trunk with flat crown
+   * 'palm'   – ring-scarred date-palm trunk with arching pinnate fronds
    * 'birch'  – narrow oval canopy, pale bark
    * 'cherry' – round lush canopy, seasonal blossom
    * @default 'pine'
@@ -597,34 +606,61 @@ export class TreeLayer<DataT = unknown, ExtraPropsT extends {} = {}> extends Com
     const {grouped, pineMeshes, liveCropPoints, droppedCropPoints} = this.state;
 
     // -----------------------------------------------------------------------
-    // 1. Trunk layer — one layer for ALL tree types, shared cylinder geometry
+    // 1. Trunk layers — date palms use their ring-scarred trunk mesh while
+    //    all other species continue to share the simpler tapered cylinder.
     // -----------------------------------------------------------------------
-    const trunkLayer = new SimpleMeshLayer(
-      this.getSubLayerProps({
-        id: 'trunks',
-        data: this.props.data,
-        mesh: TRUNK_MESH,
-        getPosition: d => {
-          const pos = getPosition(d);
-          return [pos[0], pos[1], getElevation(d) || 0];
-        },
-        getScale: d => {
-          const h = getHeight(d) * sizeScale;
-          const f = getTrunkHeightFraction(d);
-          const r = getTrunkRadius(d) * sizeScale;
-          return [r, r, h * f];
-        },
-        getColor: d => {
-          const explicit = getTrunkColor(d);
-          if (explicit) return explicit;
-          const type = getTreeType(d) || 'pine';
-          return DEFAULT_TRUNK_COLORS[type] ?? DEFAULT_TRUNK_COLORS.pine;
-        },
-        pickable: this.props.pickable,
-        material: {ambient: 0.45, diffuse: 0.55, shininess: 4},
-        updateTriggers: {getScale: sizeScale}
-      })
+    const nonPalmTrunkData = ALL_TREE_TYPES.filter(type => type !== 'palm').flatMap(
+      type => grouped[type]
     );
+    const buildTrunkLayer = (
+      id: string,
+      data: unknown[],
+      mesh: ReturnType<typeof createTrunkMesh>,
+      canopyExtension = 0
+    ) =>
+      new SimpleMeshLayer(
+        this.getSubLayerProps({
+          id,
+          data,
+          mesh,
+          getPosition: d => {
+            const pos = getPosition(d);
+            return [pos[0], pos[1], getElevation(d) || 0];
+          },
+          getScale: d => {
+            const h = getHeight(d) * sizeScale;
+            const f = getTrunkHeightFraction(d);
+            const r = getTrunkRadius(d) * sizeScale;
+            const trunkHeight = h * f;
+            const canopyHeight = h * (1 - f);
+            return [r, r, trunkHeight + canopyHeight * canopyExtension];
+          },
+          getColor: d => {
+            const explicit = getTrunkColor(d);
+            if (explicit) return explicit;
+            const type = getTreeType(d) || 'pine';
+            return DEFAULT_TRUNK_COLORS[type] ?? DEFAULT_TRUNK_COLORS.pine;
+          },
+          pickable: this.props.pickable,
+          material: {ambient: 0.45, diffuse: 0.55, shininess: 4},
+          updateTriggers: {getScale: sizeScale}
+        })
+      );
+    const trunkLayers = [
+      ...(nonPalmTrunkData.length > 0
+        ? [buildTrunkLayer('trunks', nonPalmTrunkData, TRUNK_MESH)]
+        : []),
+      ...(grouped.palm.length > 0
+        ? [
+            buildTrunkLayer(
+              'trunks-palm',
+              grouped.palm,
+              DATE_PALM_TRUNK_MESH,
+              DATE_PALM_TRUNK_CANOPY_EXTENSION
+            )
+          ]
+        : [])
+    ];
 
     // -----------------------------------------------------------------------
     // 2. Canopy layers
@@ -688,6 +724,6 @@ export class TreeLayer<DataT = unknown, ExtraPropsT extends {} = {}> extends Com
       );
     }
 
-    return [trunkLayer, ...canopyLayers, ...cropLayers];
+    return [...trunkLayers, ...canopyLayers, ...cropLayers];
   }
 }

--- a/modules/three/test/tree-layer.spec.ts
+++ b/modules/three/test/tree-layer.spec.ts
@@ -30,10 +30,10 @@ describe('TreeLayer', () => {
     expect(defaults.getSeason.value({})).toBe('summer');
   });
 
-  it('extends date-palm trunks into the crown', () => {
+  it('extends palm trunks into the crown', () => {
     const datum = {position: [0, 0] as [number, number]};
     const layer = new TreeLayer({
-      id: 'date-palm-crown-connection',
+      id: 'palm-crown-connection',
       data: [datum],
       getTreeType: () => 'palm',
       getHeight: () => 10,
@@ -103,10 +103,10 @@ describe('tree geometry generators', () => {
     expect(maxZ).toBeCloseTo(1, 1);
   });
 
-  it('date-palm trunk adds leaf-scar detail without changing unit bounds', () => {
+  it('palm trunk adds leaf-scar detail without changing unit bounds', () => {
     const basicTrunk = createTrunkMesh();
-    const datePalmTrunk = createDatePalmTrunkMesh();
-    const positions = datePalmTrunk.attributes.POSITION.value;
+    const palmTrunk = createDatePalmTrunkMesh();
+    const positions = palmTrunk.attributes.POSITION.value;
     let minZ = Infinity;
     let maxZ = -Infinity;
 
@@ -120,7 +120,7 @@ describe('tree geometry generators', () => {
     expect(maxZ).toBeLessThanOrEqual(1.01);
   });
 
-  it('date-palm crown has a dense radial, pinnate silhouette', () => {
+  it('palm crown has a dense radial, pinnate silhouette', () => {
     const mesh = createPalmCanopyMesh();
     const positions = mesh.attributes.POSITION.value;
     let minX = Infinity;
@@ -148,7 +148,7 @@ describe('tree geometry generators', () => {
     expect(maxZ).toBeGreaterThan(0.95);
   });
 
-  it('date-palm geometry is deterministic', () => {
+  it('palm geometry is deterministic', () => {
     const first = createPalmCanopyMesh();
     const second = createPalmCanopyMesh();
 

--- a/modules/three/test/tree-layer.spec.ts
+++ b/modules/three/test/tree-layer.spec.ts
@@ -6,6 +6,7 @@ import {describe, it, expect} from 'vitest';
 import {TreeLayer} from '../src/index';
 import {
   createTrunkMesh,
+  createDatePalmTrunkMesh,
   createPineCanopyMesh,
   createOakCanopyMesh,
   createPalmCanopyMesh,
@@ -27,6 +28,30 @@ describe('TreeLayer', () => {
     expect(defaults.getTreeType.value({})).toBe('pine');
     expect(defaults.getHeight.value({})).toBe(10);
     expect(defaults.getSeason.value({})).toBe('summer');
+  });
+
+  it('extends date-palm trunks into the crown', () => {
+    const datum = {position: [0, 0] as [number, number]};
+    const layer = new TreeLayer({
+      id: 'date-palm-crown-connection',
+      data: [datum],
+      getTreeType: () => 'palm',
+      getHeight: () => 10,
+      getTrunkHeightFraction: () => 0.8,
+      getTrunkRadius: () => 1
+    });
+
+    layer.state = {
+      grouped: {pine: [], oak: [], palm: [datum], birch: [], cherry: []},
+      pineMeshes: {},
+      liveCropPoints: [],
+      droppedCropPoints: []
+    } as typeof layer.state;
+
+    const palmTrunk = layer.renderLayers().find(subLayer => subLayer.id.endsWith('trunks-palm'));
+    const scale = palmTrunk?.props.getScale(datum);
+
+    expect(scale).toEqual([1, 1, 8.48]);
   });
 });
 
@@ -76,5 +101,58 @@ describe('tree geometry generators', () => {
     }
     expect(minZ).toBeGreaterThanOrEqual(-0.01);
     expect(maxZ).toBeCloseTo(1, 1);
+  });
+
+  it('date-palm trunk adds leaf-scar detail without changing unit bounds', () => {
+    const basicTrunk = createTrunkMesh();
+    const datePalmTrunk = createDatePalmTrunkMesh();
+    const positions = datePalmTrunk.attributes.POSITION.value;
+    let minZ = Infinity;
+    let maxZ = -Infinity;
+
+    for (let i = 2; i < positions.length; i += 3) {
+      minZ = Math.min(minZ, positions[i]);
+      maxZ = Math.max(maxZ, positions[i]);
+    }
+
+    expect(positions.length).toBeGreaterThan(basicTrunk.attributes.POSITION.value.length * 4);
+    expect(minZ).toBeGreaterThanOrEqual(-0.01);
+    expect(maxZ).toBeLessThanOrEqual(1.01);
+  });
+
+  it('date-palm crown has a dense radial, pinnate silhouette', () => {
+    const mesh = createPalmCanopyMesh();
+    const positions = mesh.attributes.POSITION.value;
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minY = Infinity;
+    let maxY = -Infinity;
+    let minZ = Infinity;
+    let maxZ = -Infinity;
+
+    for (let i = 0; i < positions.length; i += 3) {
+      minX = Math.min(minX, positions[i]);
+      maxX = Math.max(maxX, positions[i]);
+      minY = Math.min(minY, positions[i + 1]);
+      maxY = Math.max(maxY, positions[i + 1]);
+      minZ = Math.min(minZ, positions[i + 2]);
+      maxZ = Math.max(maxZ, positions[i + 2]);
+    }
+
+    expect(positions.length / 3).toBeGreaterThan(4000);
+    expect(minX).toBeLessThan(-0.9);
+    expect(maxX).toBeGreaterThan(0.9);
+    expect(minY).toBeLessThan(-0.9);
+    expect(maxY).toBeGreaterThan(0.9);
+    expect(minZ).toBeGreaterThan(0);
+    expect(maxZ).toBeGreaterThan(0.95);
+  });
+
+  it('date-palm geometry is deterministic', () => {
+    const first = createPalmCanopyMesh();
+    const second = createPalmCanopyMesh();
+
+    expect(second.attributes.POSITION.value).toEqual(first.attributes.POSITION.value);
+    expect(second.indices.value).toEqual(first.indices.value);
   });
 });


### PR DESCRIPTION
## Summary

- replace the generic flattened palm crown with a deterministic feathered palm silhouette
- add a tapered, ring-scarred trunk whose shaft terminates inside the crown heart
- document the improved palm geometry and lock it down with focused regression tests
- cover crown density, geometry bounds, determinism, and the trunk/crown connection

## Why

`TreeLayer`'s existing `palm` geometry read as a flattened canopy rather than a recognizable
palm. It also left the trunk and crown as independently scaled meshes, which could expose a
visible gap for some trunk-to-canopy ratios.

## Implementation

The shared procedural crown now contains 20 mature arching fronds, 8 upright spear fronds, and
284 pairs of tapered pinnate leaflets. It is generated once and remains one instanced canopy
mesh. Palms use a dedicated ring-scarred trunk mesh; mixed forests pay only one additional
instanced draw call, while non-palm tree geometry is unchanged.

The palm shaft extends by 24% of the canopy height, ending inside the crown heart. Because that
overlap is canopy-relative, the connection stays closed as tree proportions vary.

## Visual verification

| Before | After |
|---|---|
| <img width="512" alt="Before" src="https://github.com/user-attachments/assets/749d8a26-724e-4195-802c-ea53dd29655b" /> | <img width="512" alt="After" src="https://github.com/user-attachments/assets/aa879aa5-4fd4-4497-9624-464b705b18c7" /> |

- inspected the Palm Grove in the live Wild Forest example
- checked varied palm heights and trunk fractions at close range; no crown/trunk daylight remains
- confirmed a clean browser console

Review locally with `yarn start-local` from `examples/three/wild-forest`, then open
`http://127.0.0.1:8080/`.

## Validation

- `yarn`
- `yarn build`
- `yarn test-node modules/three/test/tree-layer.spec.ts` — 168 files passed; 1,426 tests passed, 9 skipped
- `yarn lint-fix`
- `yarn lint`
- `cd website && yarn && yarn build`
- `git diff --check`
