### PR TITLE
Fix broken graph-layer website examples

### DIFF
--- a/examples/graph-layers/graph-viewer/app.ts
+++ b/examples/graph-layers/graph-viewer/app.ts
@@ -337,19 +337,14 @@ export function mountGraphViewerExample(
     },
     darkModeTheme: {
       ...DarkTheme
+    },
+    onThemeModeChange(themeMode) {
+      if (state.themeMode !== themeMode) {
+        state.themeMode = themeMode;
+        syncWidgets();
+      }
     }
-  }) as ThemeWidget & {
-    _applyTheme: (themeMode: 'light' | 'dark') => void;
-    themeMode: 'light' | 'dark';
-  };
-  const originalApplyTheme = themeWidget._applyTheme.bind(themeWidget);
-  themeWidget._applyTheme = (themeMode: 'light' | 'dark') => {
-    originalApplyTheme(themeMode);
-    if (state.themeMode !== themeMode) {
-      state.themeMode = themeMode;
-      syncWidgets();
-    }
-  };
+  });
   const sidebarWidget = new SidebarPanelWidget({
     id: 'graph-viewer-sidebar',
     placement: 'top-right',

--- a/examples/graph-layers/graph-viewer/examples.ts
+++ b/examples/graph-layers/graph-viewer/examples.ts
@@ -656,7 +656,7 @@ const KNOWLEDGE_GRAPH_STYLE: ExampleStyles = {
       fontSize: 12,
       textAnchor: 'start',
       offset: [10, 0],
-      alignmentBaseline: 'middle',
+      alignmentBaseline: 'center',
       scaleWithZoom: false
     }
   ],
@@ -697,7 +697,7 @@ const MULTI_GRAPH_STYLE: ExampleStyles = {
       color: [255, 255, 255],
       fontSize: 14,
       textAnchor: 'middle',
-      alignmentBaseline: 'middle',
+      alignmentBaseline: 'center',
       scaleWithZoom: false
     }
   ],


### PR DESCRIPTION
## Summary

- use the supported ThemeWidget theme-change callback instead of patching a private method
- correct invalid TextLayer alignment values in the hive and multi-graph example styles
- restore rendering across all graph-layer website example routes

## Testing

- `yarn lint`
- `yarn --cwd website build`
- browser-verified simple graph, multi-graph, radial, hive plot, and DAG routes against the production build

## Local test note

The clean worktree pre-commit sweep reached 1,245 passing tests, but the shared dependency symlink could not resolve optional packages used by unrelated arrow/trace suites, and one unrelated trace test timed out. CI will run from a clean dependency install.