### PR TITLE
feat: Add dense rectangle controls to BlockLayer

### DIFF
--- a/docs/modules/infovis-layers/api-reference/block-layer.md
+++ b/docs/modules/infovis-layers/api-reference/block-layer.md
@@ -22,7 +22,9 @@ const layer = new BlockLayer({
   getSize: d => d.size,
   getFillColor: d => d.fillColor,
   getLineColor: d => d.lineColor,
-  getLineWidth: 1
+  getLineWidth: 1,
+  widthCutoffPixels: 0.5,
+  getOpacity: d => d.opacity
 });
 ```
 
@@ -58,9 +60,30 @@ Outline width. Default: `1`.
 
 Units used by `getLineWidth`. Default: `'pixels'`.
 
-### `widthMinPixels` / `heightMinPixels` / `sizeMaxPixels` (Number, optional)
+### `widthMinPixels` / `widthMaxPixels` / `heightMinPixels` / `sizeMaxPixels` (Number, optional)
 
 Pixel clamps applied after projecting block size.
+
+### `widthCutoffPixels` (Number, optional)
+
+Hides a block when its projected source width is below this threshold. The cutoff is applied before
+`widthMinPixels`, so very small intervals can be omitted instead of expanded to the minimum width.
+Default: `0`.
+
+### `strokeOffset` (Number, optional)
+
+Aligns the outline relative to the block bounds: `0` keeps the outline inside, `0.5` centers it on
+the boundary, and `1` places it outside. Default: `0`.
+
+### `getOpacity` (`Accessor<number>`, optional)
+
+Per-block multiplier applied after the fill and outline alpha channels. Default: `1`.
+
+### `overrideColor` / `getColorOverride` (`Color` / `Accessor<number>`, optional)
+
+`getColorOverride` selects whether an instance keeps its original RGB colors (`0`) or uses
+`overrideColor` (`1`). Fill and outline alpha channels are preserved. Defaults: `[0, 0, 0, 255]`
+and `0`.
 
 ## Source
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -74,6 +74,8 @@ Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community
 
 - Added generic animation, block, fast-text, UTF8 Arrow string-view, view-layout, and viewport-bounds helpers for trace-style visualizations.
 - `BlockLayer` now provides paired WebGPU WGSL and WebGL2 GLSL shaders for instanced fills, outlines, projection, and picking.
+- `BlockLayer` now supports independent width limits, dense-width cutoffs, stroke alignment, and
+  per-instance opacity or replacement colors for dense interval views.
 - `FastTextLayer` now renders its existing packed glyphs and generated font atlases on WebGPU and WebGL2; optimized upstream text and Arrow renderers remain planned for luma.gl v10.
 - `TimeDeltaLayer` now renders interval guides and headers using portable lines and fast text.
 

--- a/modules/infovis-layers/src/layers/block-layer/block-layer-uniforms.ts
+++ b/modules/infovis-layers/src/layers/block-layer/block-layer-uniforms.ts
@@ -8,9 +8,13 @@ const glslUniformBlock = `\
 uniform blockLayerUniforms {
   highp int sizeUnits;
   highp float widthMinPixels;
+  highp float widthMaxPixels;
+  highp float widthCutoffPixels;
   highp float heightMinPixels;
   highp float sizeMaxPixels;
   highp int lineWidthUnits;
+  highp float strokeOffset;
+  highp vec4 overrideColor;
 } blockLayer;
 `;
 
@@ -20,12 +24,20 @@ export type BlockProps = {
   sizeUnits: number;
   /** Minimum rendered block width in pixels. */
   widthMinPixels: number;
+  /** Maximum rendered block width in pixels. */
+  widthMaxPixels: number;
+  /** Minimum projected source width in pixels required to render the block. */
+  widthCutoffPixels: number;
   /** Minimum rendered block height in pixels. */
   heightMinPixels: number;
   /** Maximum rendered block width or height in pixels. */
   sizeMaxPixels: number;
   /** Numeric deck.gl unit for block outline width. */
   lineWidthUnits: number;
+  /** Stroke alignment relative to the block bounds. */
+  strokeOffset: number;
+  /** Normalized replacement color used by instances with an enabled color override. */
+  overrideColor: [number, number, number, number];
 };
 
 /** Shader module that defines uniforms consumed by {@link BlockLayer}. */
@@ -37,8 +49,12 @@ export const blockUniforms = {
   uniformTypes: {
     sizeUnits: 'i32',
     widthMinPixels: 'f32',
+    widthMaxPixels: 'f32',
+    widthCutoffPixels: 'f32',
     heightMinPixels: 'f32',
     sizeMaxPixels: 'f32',
-    lineWidthUnits: 'i32'
+    lineWidthUnits: 'i32',
+    strokeOffset: 'f32',
+    overrideColor: 'vec4<f32>'
   }
 } as const satisfies ShaderModule<BlockProps>;

--- a/modules/infovis-layers/src/layers/block-layer/block-layer-vertex.glsl.ts
+++ b/modules/infovis-layers/src/layers/block-layer/block-layer-vertex.glsl.ts
@@ -13,6 +13,8 @@ in vec2 instanceSizes;
 in float instanceLineWidths;
 in vec4 instanceFillColors;
 in vec4 instanceLineColors;
+in float instanceOpacities;
+in float instanceColorOverrides;
 in vec3 instancePickingColors;
 
 out vec2 unitPosition;
@@ -44,24 +46,33 @@ void main(void) {
   geometry.uv = positions.xy;
 
   vec2 pixelSize = project_size_to_pixel(instanceSizes, blockLayer.sizeUnits);
-  pixelSize.x = clamp_signed_size(pixelSize.x, blockLayer.widthMinPixels, blockLayer.sizeMaxPixels);
+  bool widthBelowCutoff = abs(pixelSize.x) < blockLayer.widthCutoffPixels;
+  float effectiveWidthMaxPixels = min(blockLayer.widthMaxPixels, blockLayer.sizeMaxPixels);
+  pixelSize.x = clamp_signed_size(pixelSize.x, blockLayer.widthMinPixels, effectiveWidthMaxPixels);
   pixelSize.y = clamp_signed_size(pixelSize.y, blockLayer.heightMinPixels, blockLayer.sizeMaxPixels);
+  lineWidth = project_size_to_pixel(vec2(instanceLineWidths, 0.0), blockLayer.lineWidthUnits).x;
+  vec2 strokePadding = vec2(lineWidth * blockLayer.strokeOffset);
+  pixelSize += 2.0 * strokePadding;
+  if (widthBelowCutoff) {
+    pixelSize = vec2(0.0);
+  }
   unitPosition = positions.xy;
   size = pixelSize;
-  lineWidth = project_size_to_pixel(vec2(instanceLineWidths, 0.0), blockLayer.lineWidthUnits).x;
 
   // Find the center of the point and add the current vertex
-  vec3 offset = vec3(unitPosition * project_pixel_size(pixelSize), 0.0);
+  vec3 offset = vec3(project_pixel_size(unitPosition * pixelSize - strokePadding), 0.0);
   DECKGL_FILTER_SIZE(offset, geometry);
 
   gl_Position = project_position_to_clipspace(instancePositions, instancePositions64Low, offset, geometry.position);
   DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
 
   // Apply opacity to instance color, or return instance picking color
-  vFillColor = vec4(instanceFillColors.rgb, instanceFillColors.a * layer.opacity);
+  vec3 fillColor = mix(instanceFillColors.rgb, blockLayer.overrideColor.rgb, instanceColorOverrides);
+  vFillColor = vec4(fillColor, instanceFillColors.a * instanceOpacities * layer.opacity);
   DECKGL_FILTER_COLOR(vFillColor, geometry);
 
-  vLineColor = vec4(instanceLineColors.rgb, instanceLineColors.a * layer.opacity);
+  vec3 lineColor = mix(instanceLineColors.rgb, blockLayer.overrideColor.rgb, instanceColorOverrides);
+  vLineColor = vec4(lineColor, instanceLineColors.a * instanceOpacities * layer.opacity);
   DECKGL_FILTER_COLOR(vLineColor, geometry);
 }
 `;

--- a/modules/infovis-layers/src/layers/block-layer/block-layer.ts
+++ b/modules/infovis-layers/src/layers/block-layer/block-layer.ts
@@ -30,16 +30,22 @@ const DEFAULT_COLOR: [number, number, number, number] = [0, 0, 0, 255];
 const defaultProps: DefaultProps<BlockLayerProps> = {
   sizeUnits: 'meters',
   widthMinPixels: {type: 'number', min: 0, value: 0},
+  widthMaxPixels: {type: 'number', min: 0, value: Number.MAX_SAFE_INTEGER},
+  widthCutoffPixels: {type: 'number', min: 0, value: 0},
   heightMinPixels: {type: 'number', min: 0, value: 0},
   sizeMaxPixels: {type: 'number', min: 0, value: Number.MAX_SAFE_INTEGER},
 
   lineWidthUnits: 'pixels',
+  strokeOffset: {type: 'number', min: 0, max: 1, value: 0},
 
   getPosition: {type: 'accessor', value: (x: any) => x.position},
   getSize: {type: 'accessor', value: [10, 10]},
   getLineWidth: {type: 'accessor', value: 1},
   getFillColor: {type: 'accessor', value: DEFAULT_COLOR},
-  getLineColor: {type: 'accessor', value: DEFAULT_COLOR}
+  getLineColor: {type: 'accessor', value: DEFAULT_COLOR},
+  getOpacity: {type: 'accessor', value: 1},
+  overrideColor: {type: 'color', value: DEFAULT_COLOR},
+  getColorOverride: {type: 'accessor', value: 0}
 };
 
 /** Properties supported by {@link BlockLayer}. */
@@ -61,6 +67,17 @@ type _BlockLayerProps<DataT> = {
    */
   widthMinPixels?: number;
   /**
+   * The maximum width in pixels. This prop can be used to prevent a wide block from covering the
+   * complete viewport when zoomed in.
+   * @defaultValue Number.MAX_SAFE_INTEGER
+   */
+  widthMaxPixels?: number;
+  /**
+   * Hides a block when its projected source width is below this pixel threshold.
+   * @defaultValue 0
+   */
+  widthCutoffPixels?: number;
+  /**
    * The minimum height in pixels. This prop can be used to prevent the block from getting too small when zoomed out.
    * @defaultValue 0
    */
@@ -76,6 +93,13 @@ type _BlockLayerProps<DataT> = {
    * @defaultValue 'pixels'
    */
   lineWidthUnits?: Unit;
+
+  /**
+   * The alignment of the stroke relative to the block bounds. `0` keeps the stroke inside the
+   * block, `0.5` centers it on the boundary, and `1` places it outside.
+   * @defaultValue 0
+   */
+  strokeOffset?: number;
 
   /**
    * The outline width of each object.
@@ -100,6 +124,23 @@ type _BlockLayerProps<DataT> = {
    * @defaultValue [0, 0, 0, 255]
    */
   getFillColor?: Accessor<DataT, Color>;
+  /**
+   * Per-block opacity multiplier applied after the fill and line color alpha channels.
+   * @defaultValue 1
+   */
+  getOpacity?: Accessor<DataT, number>;
+  /**
+   * Replacement RGB color applied to instances selected by `getColorOverride`. The original fill
+   * and line alpha channels are preserved.
+   * @defaultValue [0, 0, 0, 255]
+   */
+  overrideColor?: Color;
+  /**
+   * Per-block replacement-color selector. `0` preserves the original colors and `1` applies
+   * `overrideColor`.
+   * @defaultValue 0
+   */
+  getColorOverride?: Accessor<DataT, number>;
 };
 
 /** Renders axis-aligned rectangular blocks with fill and outline colors. */
@@ -159,6 +200,18 @@ export class BlockLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
         transition: true,
         accessor: 'getFillColor',
         defaultValue: DEFAULT_COLOR
+      },
+      instanceOpacities: {
+        size: 1,
+        transition: true,
+        accessor: 'getOpacity',
+        defaultValue: 1
+      },
+      instanceColorOverrides: {
+        size: 1,
+        type: 'uint8',
+        accessor: 'getColorOverride',
+        defaultValue: 0
       }
     });
   }
@@ -174,14 +227,33 @@ export class BlockLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
   }
 
   override draw() {
-    const {sizeUnits, widthMinPixels, heightMinPixels, sizeMaxPixels, lineWidthUnits} = this.props;
+    const {
+      sizeUnits,
+      widthMinPixels,
+      widthMaxPixels,
+      widthCutoffPixels,
+      heightMinPixels,
+      sizeMaxPixels,
+      lineWidthUnits,
+      strokeOffset,
+      overrideColor
+    } = this.props;
     const model = this.state.model!;
     const blockProps: BlockProps = {
       sizeUnits: UNIT[sizeUnits],
       widthMinPixels,
+      widthMaxPixels,
+      widthCutoffPixels,
       heightMinPixels,
       sizeMaxPixels,
-      lineWidthUnits: UNIT[lineWidthUnits]
+      lineWidthUnits: UNIT[lineWidthUnits],
+      strokeOffset: Math.min(1, Math.max(0, strokeOffset)),
+      overrideColor: [
+        overrideColor[0] / 255,
+        overrideColor[1] / 255,
+        overrideColor[2] / 255,
+        (overrideColor[3] ?? 255) / 255
+      ]
     };
     model.shaderInputs.setProps({blockLayer: blockProps});
     model.draw(this.context.renderPass);
@@ -197,6 +269,8 @@ export class BlockLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
       'instanceLineWidths',
       'instanceLineColors',
       'instanceFillColors',
+      'instanceOpacities',
+      'instanceColorOverrides',
       'instancePickingColors'
     ]);
     const webgpuBufferLayout = bufferLayout

--- a/modules/infovis-layers/src/layers/block-layer/block-layer.wgsl.ts
+++ b/modules/infovis-layers/src/layers/block-layer/block-layer.wgsl.ts
@@ -7,9 +7,13 @@ export default /* wgsl */ `
 struct BlockUniforms {
   sizeUnits: i32,
   widthMinPixels: f32,
+  widthMaxPixels: f32,
+  widthCutoffPixels: f32,
   heightMinPixels: f32,
   sizeMaxPixels: f32,
   lineWidthUnits: i32,
+  strokeOffset: f32,
+  overrideColor: vec4<f32>,
 };
 
 @group(0) @binding(auto) var<uniform> blockLayer: BlockUniforms;
@@ -21,7 +25,9 @@ struct BlockAttributes {
   @location(3) instanceLineWidths: f32,
   @location(4) instanceLineColors: vec4<f32>,
   @location(5) instanceFillColors: vec4<f32>,
-  @location(6) instancePickingColors: vec3<f32>,
+  @location(6) instanceOpacities: f32,
+  @location(7) instanceColorOverrides: f32,
+  @location(8) instancePickingColors: vec3<f32>,
 };
 
 struct BlockVaryings {
@@ -52,19 +58,30 @@ fn vertexMain(attributes: BlockAttributes) -> BlockVaryings {
   geometry.uv = attributes.positions.xy;
 
   var pixelSize = block_size_to_pixels(attributes.instanceSizes, blockLayer.sizeUnits);
+  let widthBelowCutoff = abs(pixelSize.x) < blockLayer.widthCutoffPixels;
+  let effectiveWidthMaxPixels = min(blockLayer.widthMaxPixels, blockLayer.sizeMaxPixels);
   pixelSize.x = block_clamp_signed_size(
     pixelSize.x,
     blockLayer.widthMinPixels,
-    blockLayer.sizeMaxPixels
+    effectiveWidthMaxPixels
   );
   pixelSize.y = block_clamp_signed_size(
     pixelSize.y,
     blockLayer.heightMinPixels,
     blockLayer.sizeMaxPixels
   );
+  let lineWidth = project_unit_size_to_pixel(
+    attributes.instanceLineWidths,
+    blockLayer.lineWidthUnits
+  );
+  let strokePadding = vec2<f32>(lineWidth * blockLayer.strokeOffset);
+  pixelSize = pixelSize + 2.0 * strokePadding;
+  if (widthBelowCutoff) {
+    pixelSize = vec2<f32>(0.0);
+  }
 
   let offset = vec3<f32>(
-    attributes.positions.xy * project_pixel_size_vec2(pixelSize),
+    project_pixel_size_vec2(attributes.positions.xy * pixelSize - strokePadding),
     0.0
   );
   let projected = project_position_to_clipspace_and_commonspace(
@@ -77,18 +94,25 @@ fn vertexMain(attributes: BlockAttributes) -> BlockVaryings {
   var varyings: BlockVaryings;
   varyings.position = projected.clipPosition;
   varyings.unitPosition = attributes.positions.xy;
-  varyings.fillColor = vec4<f32>(
+  let fillColor = mix(
     attributes.instanceFillColors.rgb,
-    attributes.instanceFillColors.a * layer.opacity
+    blockLayer.overrideColor.rgb,
+    attributes.instanceColorOverrides
+  );
+  varyings.fillColor = vec4<f32>(
+    fillColor,
+    attributes.instanceFillColors.a * attributes.instanceOpacities * layer.opacity
+  );
+  let lineColor = mix(
+    attributes.instanceLineColors.rgb,
+    blockLayer.overrideColor.rgb,
+    attributes.instanceColorOverrides
   );
   varyings.lineColor = vec4<f32>(
-    attributes.instanceLineColors.rgb,
-    attributes.instanceLineColors.a * layer.opacity
+    lineColor,
+    attributes.instanceLineColors.a * attributes.instanceOpacities * layer.opacity
   );
-  varyings.lineWidth = project_unit_size_to_pixel(
-    attributes.instanceLineWidths,
-    blockLayer.lineWidthUnits
-  );
+  varyings.lineWidth = lineWidth;
   varyings.size = pixelSize;
   varyings.pickingColor = attributes.instancePickingColors;
   return varyings;

--- a/modules/infovis-layers/test/block-layer.spec.ts
+++ b/modules/infovis-layers/test/block-layer.spec.ts
@@ -1,0 +1,66 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, it} from 'vitest';
+
+import {BlockLayer} from '../src/layers/block-layer/block-layer';
+import blockLayerVertexShader from '../src/layers/block-layer/block-layer-vertex.glsl';
+import blockLayerWebgpuShader from '../src/layers/block-layer/block-layer.wgsl';
+
+describe('BlockLayer dense rectangle controls', () => {
+  it('defaults to the existing visual behavior', () => {
+    const defaults = BlockLayer.defaultProps as Record<string, unknown>;
+
+    expect(defaults.widthMaxPixels).toMatchObject({value: Number.MAX_SAFE_INTEGER});
+    expect(defaults.widthCutoffPixels).toMatchObject({value: 0});
+    expect(defaults.strokeOffset).toMatchObject({value: 0});
+    expect(defaults.getOpacity).toMatchObject({value: 1});
+    expect(defaults.getColorOverride).toMatchObject({value: 0});
+    expect(defaults.overrideColor).toMatchObject({value: [0, 0, 0, 255]});
+  });
+
+  it('keeps width clamps and cutoff behavior aligned across WebGL2 and WebGPU', () => {
+    expect(blockLayerVertexShader).toContain(
+      'float effectiveWidthMaxPixels = min(blockLayer.widthMaxPixels, blockLayer.sizeMaxPixels);'
+    );
+    expect(blockLayerVertexShader).toContain(
+      'bool widthBelowCutoff = abs(pixelSize.x) < blockLayer.widthCutoffPixels;'
+    );
+    expect(blockLayerWebgpuShader).toContain(
+      'let effectiveWidthMaxPixels = min(blockLayer.widthMaxPixels, blockLayer.sizeMaxPixels);'
+    );
+    expect(blockLayerWebgpuShader).toContain(
+      'let widthBelowCutoff = abs(pixelSize.x) < blockLayer.widthCutoffPixels;'
+    );
+  });
+
+  it('keeps stroke alignment behavior aligned across WebGL2 and WebGPU', () => {
+    expect(blockLayerVertexShader).toContain(
+      'vec2 strokePadding = vec2(lineWidth * blockLayer.strokeOffset);'
+    );
+    expect(blockLayerVertexShader).toContain(
+      'project_pixel_size(unitPosition * pixelSize - strokePadding)'
+    );
+    expect(blockLayerWebgpuShader).toContain(
+      'let strokePadding = vec2<f32>(lineWidth * blockLayer.strokeOffset);'
+    );
+    expect(blockLayerWebgpuShader).toContain(
+      'project_pixel_size_vec2(attributes.positions.xy * pixelSize - strokePadding)'
+    );
+  });
+
+  it('keeps opacity and replacement-color behavior aligned across WebGL2 and WebGPU', () => {
+    expect(blockLayerVertexShader).toContain(
+      'instanceFillColors.a * instanceOpacities * layer.opacity'
+    );
+    expect(blockLayerVertexShader).toContain(
+      'mix(instanceFillColors.rgb, blockLayer.overrideColor.rgb, instanceColorOverrides)'
+    );
+    expect(blockLayerWebgpuShader).toContain(
+      'attributes.instanceFillColors.a * attributes.instanceOpacities * layer.opacity'
+    );
+    expect(blockLayerWebgpuShader).toContain('blockLayer.overrideColor.rgb');
+    expect(blockLayerWebgpuShader).toContain('attributes.instanceColorOverrides');
+  });
+});


### PR DESCRIPTION
## Summary

- add independent `widthMaxPixels` and `widthCutoffPixels` controls for dense rectangles
- add `strokeOffset` for inside, centered, or outside outlines
- add per-instance `getOpacity` and `getColorOverride` with a shared `overrideColor`
- keep the WebGL2 GLSL and WebGPU WGSL implementations in parity
- document the new props and add focused regression coverage

## Why

`BlockLayer` is useful for dense interval-style views, but downstream users currently need local forks to hide sub-pixel intervals, cap very wide intervals, center outlines, or dim/recolor subsets. These are generic rectangle-rendering controls and do not add any trace-specific behavior.

## Compatibility

All defaults preserve the current rendering behavior:

- no width cutoff
- effectively unbounded width
- inside-aligned outlines
- opacity multiplier of 1
- no color replacement

## Validation

- `yarn lint-fix`
- targeted BlockLayer, animation, and WebGPU shader tests: 12 passed
- full `yarn test`: 616 passed, 9 skipped
- `git diff --check`
- `yarn build` compiled the packages including `infovis-layers`; the trailing local Lerna project-graph step failed in the multi-worktree environment and is left for CI to verify
