### PR TITLE
Add a JSON-safe ColorLegendWidget

### DIFF
--- a/docs/modules/widgets/README.md
+++ b/docs/modules/widgets/README.md
@@ -8,6 +8,8 @@ Alongside classic navigation and overlay widgets, the package exports
 
 For renderer selection and reusable luma device lifecycle, the package also exports `DeviceManager` and `DeviceTabsWidget`.
 
+For data-driven presentation, `ColorLegendWidget` renders JSON-safe categorical, continuous, and palette color keys without coupling the widget to an application's data model.
+
 Panel definitions, panel containers, specialized toolbar/toast components, and
 standalone mounting live in [`@deck.gl-community/panels`](/docs/modules/panels).
 Import components from `panels`, then pass them through `PanelWidget` or one of
@@ -58,6 +60,8 @@ See the [Panels developer guide](/docs/modules/panels/developer-guide/using-pane
 
 Use [`DeviceManager`](./api-reference/device-manager.md) when an application needs one reusable WebGPU or WebGL device that can be shared across UI surfaces and reparented into different DOM hosts. Use [`DeviceTabsWidget`](./api-reference/device-tabs-widget.md) when you want a built-in widget for switching the active backend.
 
+Use [`ColorLegendWidget`](./api-reference/color-legend-widget.md) when a view needs a serializable, bounded color key that can combine categories, gradients, and compact palettes.
+
 The [SharedTile2DLayer example](/examples/geo-layers/shared-tile-2d-layer) uses panel widgets to combine markdown and live probe.gl stats in one collapsible `BoxPanelWidget`.
 
 ### HTML overlays
@@ -96,6 +100,7 @@ map positions via the widget lifecycle.
 
 ## Advanced UI Widgets
 
+- [ColorLegendWidget](./api-reference/color-legend-widget.md)
 - [DeviceManager](./api-reference/device-manager.md)
 - [DeviceTabsWidget](./api-reference/device-tabs-widget.md)
 - [OmniBoxWidget](./api-reference/omni-box-widget.md)

--- a/docs/modules/widgets/api-reference/color-legend-widget.md
+++ b/docs/modules/widgets/api-reference/color-legend-widget.md
@@ -1,0 +1,141 @@
+# ColorLegendWidget
+
+<p className="badges">
+  <img src="https://img.shields.io/badge/from-v9.4-green.svg?style=flat-square" alt="from v9.4" />
+</p>
+
+`ColorLegendWidget` renders declarative color keys in a deck.gl HTML widget. Its payload is JSON-safe, so applications can prepare legend content outside the rendering layer and pass it through unchanged.
+
+The widget supports categorical lists, continuous gradients, and compact palettes in one ordered legend. Large categorical lists stay bounded by default and can expose a bounded expanded view. Categorical entries with a `title` expose that text through a keyboard-accessible, viewport-clamped tooltip that stays visible outside an expanded list's scroll container.
+
+## Import
+
+```ts
+import {
+  ColorLegendWidget,
+  type ColorLegendPayload,
+  type ColorLegendWidgetProps
+} from '@deck.gl-community/widgets';
+```
+
+## Types
+
+```ts
+type ColorLegendColor =
+  | string
+  | readonly [red: number, green: number, blue: number]
+  | readonly [red: number, green: number, blue: number, alpha: number];
+
+type ColorLegendPayload = {
+  readonly id: string;
+  readonly title: string;
+  readonly description?: string;
+  readonly ariaLabel?: string;
+  readonly sections: readonly ColorLegendSection[];
+};
+
+type ColorLegendSection =
+  | ColorLegendCategoricalSection
+  | ColorLegendContinuousSection
+  | ColorLegendPaletteSection;
+
+type ColorLegendWidgetProps = WidgetProps & {
+  readonly payload: ColorLegendPayload;
+  readonly placement?: WidgetPlacement;
+  readonly viewId?: string | null;
+  readonly onClose?: () => void;
+};
+```
+
+Categorical sections contain labeled swatches:
+
+```ts
+type ColorLegendCategoricalSection = {
+  readonly type: 'categorical';
+  readonly id: string;
+  readonly title?: string;
+  readonly entries: readonly {
+    readonly color: ColorLegendColor;
+    readonly label: string;
+    readonly description?: string;
+    readonly title?: string;
+  }[];
+  readonly totalCount?: number;
+  readonly maxVisibleEntries?: number;
+  readonly maxExpandedEntries?: number;
+};
+```
+
+Continuous sections contain low-to-high stops, and palette sections contain a compact row of colors:
+
+```ts
+type ColorLegendContinuousSection = {
+  readonly type: 'continuous';
+  readonly id: string;
+  readonly title?: string;
+  readonly stops: readonly {
+    readonly color: ColorLegendColor;
+    readonly label: string;
+  }[];
+};
+
+type ColorLegendPaletteSection = {
+  readonly type: 'palette';
+  readonly id: string;
+  readonly title?: string;
+  readonly label?: string;
+  readonly colors: readonly {
+    readonly color: ColorLegendColor;
+    readonly label?: string;
+  }[];
+};
+```
+
+## Usage
+
+```ts
+import {ColorLegendWidget} from '@deck.gl-community/widgets';
+
+const colorLegend = new ColorLegendWidget({
+  placement: 'bottom-right',
+  payload: {
+    id: 'latency',
+    title: 'Latency',
+    description: 'P95 duration by operation',
+    sections: [
+      {
+        id: 'duration',
+        type: 'continuous',
+        title: 'Duration',
+        stops: [
+          {label: 'Fast', color: '#22c55e'},
+          {label: 'Slow', color: '#ef4444'}
+        ]
+      },
+      {
+        id: 'operation',
+        type: 'categorical',
+        entries: [
+          {label: 'Read', description: 'Cached and local', color: [33, 150, 243]},
+          {label: 'Write', color: [156, 39, 176, 255]}
+        ]
+      },
+      {
+        id: 'fallback',
+        type: 'palette',
+        label: 'Hash-derived operations',
+        colors: [{color: '#ffc107'}, {color: [128, 128, 128, 128], label: 'Fallback'}]
+      }
+    ]
+  }
+});
+```
+
+## Remarks
+
+- The payload uses only strings, numbers, arrays, and objects; it can be serialized, stored, or transferred between application layers.
+- Categorical sections render at most 10 entries initially and 100 after expansion unless the section overrides `maxVisibleEntries` or `maxExpandedEntries`.
+- `totalCount` can report categories that are intentionally omitted from the prepared payload.
+- A categorical entry's optional `title` is available on its row, label, and swatch, and opens a focusable/hoverable tooltip that is portaled outside clipped widget content.
+- Supplying `onClose` adds an accessible dismiss button to the header.
+- CSS follows deck.gl widget theme tokens such as `--menu-background`, `--menu-text`, `--button-background`, `--button-text`, and `--button-stroke`.

--- a/docs/modules/widgets/sidebar.json
+++ b/docs/modules/widgets/sidebar.json
@@ -41,6 +41,7 @@
           "type": "category",
           "label": "Advanced UI Widgets",
           "items": [
+            "modules/widgets/api-reference/color-legend-widget",
             "modules/widgets/api-reference/device-manager",
             "modules/widgets/api-reference/device-tabs-widget",
             "modules/widgets/api-reference/omni-box-widget",

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -93,6 +93,7 @@ Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community
 
 ### `@deck.gl-community/widgets`
 
+- `ColorLegendWidget` - NEW JSON-safe color legend for categorical lists, continuous gradients, and compact palettes, with bounded expansion, accessible controls, and deck.gl theme-token styling.
 - `PanelWidget` - NEW generic deck adapter for any panel-owned `PanelComponent`.
 - Thin named adapters now cover real panel containers plus specialized toolbar
   and toast components without duplicating panel rendering logic.

--- a/modules/widgets/README.md
+++ b/modules/widgets/README.md
@@ -13,6 +13,8 @@ This module packages UI widgets that integrate with [deck.gl](https://deck.gl) v
 
 For renderer lifecycle management, the package also exports `DeviceManager` and `DeviceTabsWidget`. Together they let applications choose WebGPU or WebGL, reuse one cached luma device per backend, and reparent the managed canvas between host elements.
 
+`ColorLegendWidget` renders caller-supplied JSON-safe categorical, continuous, and palette color keys while keeping large categorical lists bounded.
+
 Panel definitions, panel containers, specialized toolbar/toast components, and
 standalone mounting live in `@deck.gl-community/panels`. Import components from
 `panels`, then pass them through `PanelWidget` or one of the thin named
@@ -61,6 +63,8 @@ For the deck-facing panel widget APIs, see the [Widget Panels example](../../exa
 - reusable panel definitions imported from `@deck.gl-community/panels`
 
 Use `DeviceManager` directly when your application wants custom backend-selection UI or needs to move the managed canvas between containers. Use `DeviceTabsWidget` when you want a ready-made widget for switching between `webgpu` and `webgl2`.
+
+Use `ColorLegendWidget` when a view needs a serializable color key that can be prepared independently from its deck.gl rendering lifecycle.
 
 Standalone UI such as `ToolbarComponent`, `ToastComponent`, and `toastManager`
 is exported from `@deck.gl-community/panels`. The widgets package exports

--- a/modules/widgets/src/index.ts
+++ b/modules/widgets/src/index.ts
@@ -29,6 +29,19 @@ export {
   type DeviceTabsWidgetProps
 } from './widgets/device-tabs-widget';
 export {
+  ColorLegendWidget,
+  type ColorLegendCategoricalEntry,
+  type ColorLegendCategoricalSection,
+  type ColorLegendColor,
+  type ColorLegendContinuousSection,
+  type ColorLegendContinuousStop,
+  type ColorLegendPaletteColor,
+  type ColorLegendPaletteSection,
+  type ColorLegendPayload,
+  type ColorLegendSection,
+  type ColorLegendWidgetProps
+} from './widgets/color-legend-widget';
+export {
   OmniBoxWidget,
   type OmniBoxOption,
   type OmniBoxOptionProvider,

--- a/modules/widgets/src/widgets/color-legend-widget.test.tsx
+++ b/modules/widgets/src/widgets/color-legend-widget.test.tsx
@@ -54,6 +54,26 @@ describe('ColorLegendWidget', () => {
     );
   });
 
+  it('renders a one-stop continuous scale as a solid color', () => {
+    const {root} = mountWidget({
+      payload: {
+        id: 'single-stop',
+        title: 'Status',
+        sections: [
+          {
+            id: 'status',
+            type: 'continuous',
+            stops: [{label: 'Only value', color: '#ef4444'}]
+          }
+        ]
+      }
+    });
+
+    const scale = root.querySelector<HTMLElement>('[data-testid="color-legend-gradient"]');
+    expect(scale?.style.backgroundImage).toBe('');
+    expect(scale?.style.backgroundColor).toBe('rgb(239, 68, 68)');
+  });
+
   it('bounds categorical DOM while preserving exact overflow through expansion', () => {
     const payload: ColorLegendPayload = {
       id: 'many-categories',
@@ -264,6 +284,52 @@ describe('ColorLegendWidget', () => {
     expect(tooltip?.style.left).toBe('328px');
     expect(tooltip?.style.transform).toBe('translate(-100%, -50%)');
     expect(Number.parseInt(tooltip?.style.left ?? '0', 10) - 320).toBe(8);
+  });
+
+  it('vertically clamps a measured wrapped tooltip inside the viewport', () => {
+    vi.stubGlobal('innerWidth', 240);
+    vi.stubGlobal('innerHeight', 160);
+    const {root} = mountWidget({
+      payload: {
+        id: 'vertical-clamp',
+        title: 'Operations',
+        sections: [
+          {
+            id: 'operations',
+            type: 'categorical',
+            entries: [
+              {
+                label: 'Pipeline send',
+                color: '#22c55e',
+                title:
+                  'A long descriptive entry title that wraps across several lines in the tooltip'
+              }
+            ]
+          }
+        ]
+      }
+    });
+    const row = root.querySelector('li');
+    vi.spyOn(row!, 'getBoundingClientRect').mockReturnValue(new DOMRect(20, 140, 160, 16));
+
+    act(() => {
+      row?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+
+    const initialTooltip = document.querySelector<HTMLElement>(
+      '[data-testid="color-legend-entry-tooltip"]'
+    );
+    vi.spyOn(initialTooltip!, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 224, 80));
+
+    act(() => {
+      row?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+
+    const tooltip = document.querySelector<HTMLElement>(
+      '[data-testid="color-legend-entry-tooltip"]'
+    );
+    expect(tooltip?.style.maxHeight).toBe('144px');
+    expect(tooltip?.style.top).toBe('112px');
   });
 
   it('opens an accessible tooltip when a titled legend entry receives keyboard focus', () => {

--- a/modules/widgets/src/widgets/color-legend-widget.test.tsx
+++ b/modules/widgets/src/widgets/color-legend-widget.test.tsx
@@ -1,0 +1,494 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {act} from 'preact/test-utils';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {ColorLegendWidget} from './color-legend-widget';
+
+import type {ColorLegendPayload} from './color-legend-widget';
+import type {Deck} from '@deck.gl/core';
+
+type MountedColorLegendWidget = {
+  /** Mounted widget instance. */
+  readonly widget: ColorLegendWidget;
+  /** DOM root created through the deck.gl lifecycle. */
+  readonly root: HTMLDivElement;
+};
+
+const mountedWidgets: MountedColorLegendWidget[] = [];
+
+afterEach(() => {
+  for (const {widget, root} of mountedWidgets.splice(0)) {
+    act(() => widget.onRemove());
+    root.remove();
+  }
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('ColorLegendWidget', () => {
+  it('renders a rich JSON round trip with continuous, categorical, and palette sections', () => {
+    const payload = JSON.parse(JSON.stringify(RICH_PAYLOAD)) as ColorLegendPayload;
+    const {widget, root} = mountWidget({payload, viewId: 'main'});
+
+    expect(widget.id).toBe('color-legend');
+    expect(widget.placement).toBe('bottom-right');
+    expect(widget.viewId).toBe('main');
+    expect(root.style.pointerEvents).toBe('none');
+    expect(root.textContent).toContain('Latency');
+    expect(root.textContent).toContain('P95 duration by operation');
+    expect(root.textContent).toContain('Slow');
+    expect(root.textContent).toContain('Fast');
+    expect(root.textContent).toContain('Read');
+    expect(root.textContent).toContain('Cached and local');
+    expect(root.textContent).toContain('Hash-derived operations');
+    expect(root.querySelectorAll('[data-testid="color-legend-gradient"]')).toHaveLength(1);
+    expect(root.querySelectorAll('[data-testid="color-legend-swatch"]')).toHaveLength(5);
+    expect(
+      root.querySelector<HTMLElement>('[data-testid="color-legend-swatch"]')?.style.backgroundColor
+    ).toBe('rgb(33, 150, 243)');
+    expect(root.querySelector<HTMLElement>('[title="Fallback"]')?.style.backgroundColor).toBe(
+      'rgba(128, 128, 128, 0.5)'
+    );
+  });
+
+  it('bounds categorical DOM while preserving exact overflow through expansion', () => {
+    const payload: ColorLegendPayload = {
+      id: 'many-categories',
+      title: 'Components',
+      sections: [
+        {
+          id: 'components',
+          type: 'categorical',
+          entries: Array.from({length: 150}, (_, index) => ({
+            label: `Component ${index}`,
+            color: [index, 64, 128, 255]
+          })),
+          totalCount: 1_000
+        }
+      ]
+    };
+    const {root} = mountWidget({payload});
+
+    expect(root.querySelectorAll('[data-testid="color-legend-swatch"]')).toHaveLength(10);
+    expect(root.textContent).toContain('+990 more');
+
+    act(() =>
+      root
+        .querySelector<HTMLButtonElement>('button[aria-label="Show all color categories"]')
+        ?.click()
+    );
+
+    expect(root.querySelectorAll('[data-testid="color-legend-swatch"]')).toHaveLength(100);
+    expect(root.textContent).toContain('Component 99');
+    expect(root.textContent).toContain('+900 more');
+    expect(root.textContent).not.toContain('Component 100');
+
+    act(() =>
+      root
+        .querySelector<HTMLButtonElement>('button[aria-label="Collapse color categories"]')
+        ?.click()
+    );
+    expect(root.querySelectorAll('[data-testid="color-legend-swatch"]')).toHaveLength(10);
+  });
+
+  it('exposes optional entry hover text on its row, label, and swatch without blocking the canvas', () => {
+    vi.stubGlobal('innerWidth', 1_024);
+    const title = 'Keyword: WRITE · Source: save_data';
+    const {root} = mountWidget({
+      payload: {
+        id: 'operations',
+        title: 'Operations',
+        sections: [
+          {
+            id: 'operations',
+            type: 'categorical',
+            entries: [
+              {label: 'Save data', color: '#22c55e', title},
+              {label: 'Read data', color: '#3b82f6'}
+            ]
+          }
+        ]
+      }
+    });
+    const [titledRow, plainRow] = Array.from(root.querySelectorAll('li'));
+
+    expect(root.style.pointerEvents).toBe('none');
+    expect(
+      root.querySelector<HTMLElement>('[data-testid="color-legend"]')?.style.pointerEvents
+    ).toBe('none');
+    expect(titledRow?.title).toBe(title);
+    expect(titledRow?.style.pointerEvents).toBe('auto');
+    expect(
+      titledRow?.querySelector('[data-testid="color-legend-swatch"]')?.getAttribute('title')
+    ).toBe(title);
+    expect(titledRow?.querySelector('span > span')?.getAttribute('title')).toBe(title);
+    expect(plainRow?.title).toBe('');
+    expect(plainRow?.style.pointerEvents).toBe('');
+    expect(plainRow?.querySelector('span > span')?.getAttribute('title')).toBe('Read data');
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).toBeNull();
+
+    vi.spyOn(titledRow!, 'getBoundingClientRect').mockReturnValue(new DOMRect(700, 120, 160, 16));
+    act(() => {
+      titledRow?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+
+    const tooltip = document.querySelector<HTMLElement>(
+      '[data-testid="color-legend-entry-tooltip"]'
+    );
+    expect(tooltip?.getAttribute('role')).toBe('tooltip');
+    expect(tooltip?.textContent).toBe(title);
+    expect(tooltip?.parentElement).toBe(document.body);
+    expect(root.contains(tooltip)).toBe(false);
+    expect(tooltip?.style.position).toBe('fixed');
+    expect(tooltip?.style.pointerEvents).toBe('none');
+    expect(tooltip?.style.left).toBe('692px');
+    expect(tooltip?.style.top).toBe('128px');
+    expect(tooltip?.style.transform).toBe('translate(-100%, -50%)');
+
+    act(() => {
+      titledRow?.dispatchEvent(new MouseEvent('mouseleave', {bubbles: true}));
+    });
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).toBeNull();
+  });
+
+  it('keeps expanded-row tooltips visible outside the scrollable legend and clears them on scroll', () => {
+    const {root} = mountWidget({
+      payload: {
+        id: 'expanded-operations',
+        title: 'Operations',
+        sections: [
+          {
+            id: 'operations',
+            type: 'categorical',
+            entries: Array.from({length: 12}, (_, index) => ({
+              label: `Operation ${index}`,
+              color: '#22c55e',
+              title: `Keyword: OP_${index} · Source: operation_${index}`
+            }))
+          }
+        ]
+      }
+    });
+
+    act(() =>
+      root
+        .querySelector<HTMLButtonElement>('button[aria-label="Show all color categories"]')
+        ?.click()
+    );
+    const expandedList = root.querySelector('ul');
+    const finalRow = Array.from(root.querySelectorAll('li')).find(row =>
+      row.textContent?.includes('Operation 11')
+    );
+    expect(expandedList?.style.overflowY).toBe('auto');
+
+    act(() => {
+      finalRow?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+
+    const tooltip = document.querySelector('[data-testid="color-legend-entry-tooltip"]');
+    expect(tooltip?.textContent).toBe('Keyword: OP_11 · Source: operation_11');
+    expect(tooltip?.parentElement).toBe(document.body);
+    expect(expandedList?.contains(tooltip)).toBe(false);
+
+    act(() => {
+      expandedList?.dispatchEvent(new Event('scroll'));
+    });
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).toBeNull();
+  });
+
+  it('preserves the resolved deck theme after portaling a tooltip outside the legend', () => {
+    const {root} = mountWidget({
+      payload: {
+        id: 'dark-operations',
+        title: 'Operations',
+        sections: [
+          {
+            id: 'operations',
+            type: 'categorical',
+            entries: [{label: 'Save data', color: '#22c55e', title: 'Keyword: WRITE'}]
+          }
+        ]
+      }
+    });
+    const legend = root.querySelector<HTMLElement>('[data-testid="color-legend"]');
+    expect(legend).not.toBeNull();
+    legend!.style.background = 'rgb(17, 24, 39)';
+    legend!.style.color = 'rgb(243, 244, 246)';
+    legend!.style.borderColor = 'rgb(75, 85, 99)';
+    legend!.style.borderRadius = '9px';
+    legend!.style.boxShadow = 'rgb(0, 0, 0) 0px 2px 4px';
+
+    act(() => {
+      root.querySelector('li')?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+
+    const tooltip = document.querySelector<HTMLElement>(
+      '[data-testid="color-legend-entry-tooltip"]'
+    );
+    expect(tooltip?.style.backgroundColor).toBe('rgb(17, 24, 39)');
+    expect(tooltip?.style.color).toBe('rgb(243, 244, 246)');
+    expect(tooltip?.style.borderColor).toBe('rgb(75, 85, 99)');
+    expect(tooltip?.style.borderRadius).toBe('9px');
+    expect(tooltip?.style.boxShadow).toBe('rgb(0, 0, 0) 0px 2px 4px 0px');
+  });
+
+  it('keeps long tooltip text inside narrow viewport boundaries', () => {
+    vi.stubGlobal('innerWidth', 400);
+    const {root} = mountWidget({
+      payload: {
+        id: 'narrow-operations',
+        title: 'Operations',
+        sections: [
+          {
+            id: 'operations',
+            type: 'categorical',
+            entries: [{label: 'Pipeline send', color: '#22c55e', title: 'Keyword: PIPE_SEND'}]
+          }
+        ]
+      }
+    });
+    const row = root.querySelector('li');
+    vi.spyOn(row!, 'getBoundingClientRect').mockReturnValue(new DOMRect(176, 120, 224, 16));
+
+    act(() => {
+      row?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+
+    const tooltip = document.querySelector<HTMLElement>(
+      '[data-testid="color-legend-entry-tooltip"]'
+    );
+    expect(tooltip?.style.maxWidth).toBe('320px');
+    expect(tooltip?.style.left).toBe('328px');
+    expect(tooltip?.style.transform).toBe('translate(-100%, -50%)');
+    expect(Number.parseInt(tooltip?.style.left ?? '0', 10) - 320).toBe(8);
+  });
+
+  it('opens an accessible tooltip when a titled legend entry receives keyboard focus', () => {
+    const {root} = mountWidget({
+      payload: {
+        id: 'keyboard-operations',
+        title: 'Operations',
+        sections: [
+          {
+            id: 'operations',
+            type: 'categorical',
+            entries: [
+              {label: 'Save data', color: '#22c55e', title: 'Keyword: WRITE'},
+              {label: 'Read data', color: '#3b82f6'}
+            ]
+          }
+        ]
+      }
+    });
+    const [titledRow, plainRow] = Array.from(root.querySelectorAll('li'));
+    expect(titledRow?.tabIndex).toBe(0);
+    expect(plainRow?.hasAttribute('tabindex')).toBe(false);
+
+    act(() => {
+      titledRow?.focus();
+    });
+
+    const tooltip = document.querySelector<HTMLElement>(
+      '[data-testid="color-legend-entry-tooltip"]'
+    );
+    expect(tooltip?.getAttribute('role')).toBe('tooltip');
+    expect(tooltip?.textContent).toBe('Keyword: WRITE');
+    expect(titledRow?.getAttribute('aria-describedby')).toBe(tooltip?.id);
+
+    act(() => {
+      titledRow?.blur();
+    });
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).toBeNull();
+    expect(titledRow?.hasAttribute('aria-describedby')).toBe(false);
+  });
+
+  it('clears tooltips when a scrollable ancestor moves or the viewport resizes', () => {
+    const {root} = mountWidget({
+      payload: {
+        id: 'ancestor-operations',
+        title: 'Operations',
+        sections: [
+          {
+            id: 'operations',
+            type: 'categorical',
+            entries: [{label: 'Save data', color: '#22c55e', title: 'Keyword: WRITE'}]
+          }
+        ]
+      }
+    });
+    const ancestor = document.createElement('section');
+    document.body.append(ancestor);
+    ancestor.append(root);
+    const row = root.querySelector('li');
+
+    act(() => {
+      row?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).not.toBeNull();
+
+    act(() => {
+      ancestor.dispatchEvent(new Event('scroll'));
+    });
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).toBeNull();
+
+    act(() => {
+      row?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).toBeNull();
+
+    document.body.append(root);
+    ancestor.remove();
+  });
+
+  it('removes stale hover text when the section payload changes without replacing its widget', () => {
+    const {root, widget} = mountWidget({
+      payload: {
+        id: 'block-types',
+        title: 'Operations',
+        sections: [
+          {
+            id: 'block-types',
+            type: 'categorical',
+            entries: [{label: 'Parameter fetch', color: '#22c55e', title: 'Keyword: PARAM_FETCH'}]
+          }
+        ]
+      }
+    });
+
+    act(() => {
+      root.querySelector('li')?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).not.toBeNull();
+
+    act(() =>
+      widget.setProps({
+        payload: {
+          id: 'block-types',
+          title: 'Traditional operations',
+          sections: [
+            {
+              id: 'block-types',
+              type: 'categorical',
+              entries: [{label: 'ATTENTION', color: '#3b82f6'}]
+            }
+          ]
+        }
+      })
+    );
+
+    expect(root.textContent).toContain('ATTENTION');
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).toBeNull();
+  });
+
+  it('removes a visible portaled tooltip when the owning legend widget is removed', () => {
+    const {root, widget} = mountWidget({
+      payload: {
+        id: 'removal',
+        title: 'Operations',
+        sections: [
+          {
+            id: 'operations',
+            type: 'categorical',
+            entries: [{label: 'Save data', color: '#22c55e', title: 'Keyword: WRITE'}]
+          }
+        ]
+      }
+    });
+    const row = root.querySelector('li');
+    act(() => {
+      row?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).not.toBeNull();
+
+    act(() => widget.onRemove());
+
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).toBeNull();
+  });
+
+  it('updates its payload, placement, view, and close action without replacing the widget', () => {
+    const onClose = vi.fn();
+    const {widget, root} = mountWidget({payload: RICH_PAYLOAD, onClose});
+
+    act(() =>
+      root.querySelector<HTMLButtonElement>('button[aria-label="Close color legend"]')?.click()
+    );
+    expect(onClose).toHaveBeenCalledOnce();
+
+    act(() =>
+      widget.setProps({
+        placement: 'top-left',
+        viewId: 'overview',
+        payload: {
+          id: 'status',
+          title: 'Status',
+          sections: [
+            {
+              id: 'status-values',
+              type: 'categorical',
+              entries: [{label: 'Healthy', color: '#22c55e'}]
+            }
+          ]
+        }
+      })
+    );
+
+    expect(widget.placement).toBe('top-left');
+    expect(widget.viewId).toBe('overview');
+    expect(root.textContent).toContain('Healthy');
+    expect(root.textContent).not.toContain('Latency');
+  });
+});
+
+const RICH_PAYLOAD: ColorLegendPayload = {
+  id: 'latency',
+  title: 'Latency',
+  description: 'P95 duration by operation',
+  sections: [
+    {
+      id: 'duration',
+      type: 'continuous',
+      title: 'Duration',
+      stops: [
+        {label: 'Fast', color: '#22c55e'},
+        {label: 'Slow', color: '#ef4444'}
+      ]
+    },
+    {
+      id: 'operation',
+      type: 'categorical',
+      entries: [
+        {label: 'Read', description: 'Cached and local', color: [33, 150, 243]},
+        {label: 'Write', color: [156, 39, 176, 255]}
+      ]
+    },
+    {
+      id: 'fallback',
+      type: 'palette',
+      label: 'Hash-derived operations',
+      colors: [
+        {color: '#ffc107'},
+        {color: [128, 128, 128, 128], label: 'Fallback'},
+        {color: 'rebeccapurple'}
+      ]
+    }
+  ]
+};
+
+/** Mounts one widget through the same lifecycle hooks deck.gl calls. */
+function mountWidget(
+  props: ConstructorParameters<typeof ColorLegendWidget>[0]
+): MountedColorLegendWidget {
+  const widget = new ColorLegendWidget(props);
+  const root = widget._onAdd({deck: {} as Deck, viewId: props.viewId ?? null});
+  widget.rootElement = root;
+  document.body.append(root);
+  act(() => widget.updateHTML());
+  mountedWidgets.push({widget, root});
+  return {widget, root};
+}

--- a/modules/widgets/src/widgets/color-legend-widget.test.tsx
+++ b/modules/widgets/src/widgets/color-legend-widget.test.tsx
@@ -310,26 +310,28 @@ describe('ColorLegendWidget', () => {
       }
     });
     const row = root.querySelector('li');
-    vi.spyOn(row!, 'getBoundingClientRect').mockReturnValue(new DOMRect(20, 140, 160, 16));
+    let rowBounds = new DOMRect(20, 140, 160, 16);
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+      this: HTMLElement
+    ) {
+      return this === row ? rowBounds : new DOMRect(0, 0, 224, 80);
+    });
 
     act(() => {
       row?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
     });
 
-    const initialTooltip = document.querySelector<HTMLElement>(
-      '[data-testid="color-legend-entry-tooltip"]'
-    );
-    vi.spyOn(initialTooltip!, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 224, 80));
-
-    act(() => {
-      row?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
-    });
-
-    const tooltip = document.querySelector<HTMLElement>(
-      '[data-testid="color-legend-entry-tooltip"]'
-    );
+    let tooltip = document.querySelector<HTMLElement>('[data-testid="color-legend-entry-tooltip"]');
     expect(tooltip?.style.maxHeight).toBe('144px');
     expect(tooltip?.style.top).toBe('112px');
+
+    rowBounds = new DOMRect(20, 0, 160, 16);
+    act(() => {
+      row?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+
+    tooltip = document.querySelector<HTMLElement>('[data-testid="color-legend-entry-tooltip"]');
+    expect(tooltip?.style.top).toBe('48px');
   });
 
   it('opens an accessible tooltip when a titled legend entry receives keyboard focus', () => {

--- a/modules/widgets/src/widgets/color-legend-widget.tsx
+++ b/modules/widgets/src/widgets/color-legend-widget.tsx
@@ -1,0 +1,716 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** @jsxImportSource preact */
+import {Widget} from '@deck.gl/core';
+import {render} from 'preact';
+import {createPortal} from 'preact/compat';
+import {useEffect, useId, useState} from 'preact/hooks';
+
+import type {WidgetPlacement, WidgetProps} from '@deck.gl/core';
+import type {JSX} from 'preact';
+
+/** JSON-safe CSS color or deck.gl-style RGB(A) tuple. Tuple channels use the 0-255 range. */
+export type ColorLegendColor =
+  | string
+  | readonly [red: number, green: number, blue: number]
+  | readonly [red: number, green: number, blue: number, alpha: number];
+
+/** One labeled swatch in a categorical legend section. */
+export type ColorLegendCategoricalEntry = {
+  /** Color rendered by the swatch. */
+  readonly color: ColorLegendColor;
+  /** Primary category label. */
+  readonly label: string;
+  /** Optional secondary explanation rendered below the label. */
+  readonly description?: string;
+  /** Optional accessible hover text shared by the complete row, its label, and its swatch. */
+  readonly title?: string;
+};
+
+/** One low-to-high stop in a continuous color scale. */
+export type ColorLegendContinuousStop = {
+  /** Color at this point in the scale. */
+  readonly color: ColorLegendColor;
+  /** Human-readable value rendered beside the stop. */
+  readonly label: string;
+};
+
+/** One color in a compact palette strip. */
+export type ColorLegendPaletteColor = {
+  /** Color rendered in the palette. */
+  readonly color: ColorLegendColor;
+  /** Optional accessible and hover label for this individual color. */
+  readonly label?: string;
+};
+
+/** Expandable list of discrete categories. */
+export type ColorLegendCategoricalSection = {
+  /** Discriminator for a categorical section. */
+  readonly type: 'categorical';
+  /** Stable JSON identifier used to preserve this section's interaction state. */
+  readonly id: string;
+  /** Optional heading above this section. */
+  readonly title?: string;
+  /** Prepared entries, ordered as they should appear. */
+  readonly entries: readonly ColorLegendCategoricalEntry[];
+  /** Exact category count, including entries omitted from this bounded payload. */
+  readonly totalCount?: number;
+  /** Number of entries shown before expansion. Defaults to 10. */
+  readonly maxVisibleEntries?: number;
+  /** Number of prepared entries shown after expansion. Defaults to 100. */
+  readonly maxExpandedEntries?: number;
+};
+
+/** Vertical gradient with labeled stops. Stops are ordered from low to high. */
+export type ColorLegendContinuousSection = {
+  /** Discriminator for a continuous section. */
+  readonly type: 'continuous';
+  /** Stable JSON identifier for this section. */
+  readonly id: string;
+  /** Optional heading above this section. */
+  readonly title?: string;
+  /** Gradient stops ordered from the smallest value to the largest value. */
+  readonly stops: readonly ColorLegendContinuousStop[];
+};
+
+/** Compact row of colors used when individual categories are intentionally not enumerated. */
+export type ColorLegendPaletteSection = {
+  /** Discriminator for a palette section. */
+  readonly type: 'palette';
+  /** Stable JSON identifier for this section. */
+  readonly id: string;
+  /** Optional heading above this section. */
+  readonly title?: string;
+  /** Optional explanation rendered beside the palette strip. */
+  readonly label?: string;
+  /** Colors shown from left to right. */
+  readonly colors: readonly ColorLegendPaletteColor[];
+};
+
+/** One declarative section in a color legend payload. */
+export type ColorLegendSection =
+  | ColorLegendCategoricalSection
+  | ColorLegendContinuousSection
+  | ColorLegendPaletteSection;
+
+/** Serializable content rendered by {@link ColorLegendWidget}. */
+export type ColorLegendPayload = {
+  /** Stable identifier for the selected scheme and its local interaction state. */
+  readonly id: string;
+  /** Visible legend heading. */
+  readonly title: string;
+  /** Optional short explanation below the heading. */
+  readonly description?: string;
+  /** Optional accessible label. Defaults to "{title} legend". */
+  readonly ariaLabel?: string;
+  /** Ordered categorical, continuous, and palette sections. */
+  readonly sections: readonly ColorLegendSection[];
+};
+
+/** Props for a deck.gl widget driven by a JSON-safe color legend payload. */
+export type ColorLegendWidgetProps = WidgetProps & {
+  /** Serializable legend definition prepared by the caller. */
+  readonly payload: ColorLegendPayload;
+  /** Deck widget placement within the selected view. Defaults to bottom-right. */
+  readonly placement?: WidgetPlacement;
+  /** Deck view that owns the widget. */
+  readonly viewId?: string | null;
+  /** Optional action shown as a dismiss button in the legend header. */
+  readonly onClose?: () => void;
+};
+
+/** Deck.gl widget that renders categorical, continuous, and palette color keys from JSON. */
+export class ColorLegendWidget extends Widget<ColorLegendWidgetProps> {
+  /** Theme-owned deck widget class attached to the legend host. */
+  override className = 'deck-widget-color-legend';
+  /** Default corner for floating color legends. */
+  override placement: WidgetPlacement = 'bottom-right';
+
+  /** Latest element owned by Preact so it can be cleanly unmounted. */
+  #rootElement: HTMLElement | null = null;
+
+  /** Creates a color legend widget from a JSON-safe payload. */
+  constructor(props: ColorLegendWidgetProps) {
+    super({id: 'color-legend', ...props});
+    this.placement = props.placement ?? this.placement;
+    this.viewId = props.viewId ?? this.viewId;
+  }
+
+  /** Keeps placement and view ownership synchronized with deck-managed prop updates. */
+  override setProps(props: Partial<ColorLegendWidgetProps>): void {
+    this.placement = props.placement ?? this.placement;
+    if (props.viewId !== undefined) {
+      this.viewId = props.viewId;
+    }
+    super.setProps(props);
+  }
+
+  /** Renders the latest declarative payload without inspecting application data. */
+  override onRenderHTML(rootElement: HTMLElement): void {
+    this.#rootElement = rootElement;
+    rootElement.style.pointerEvents = 'none';
+    render(
+      <ColorLegendView payload={this.props.payload} onClose={this.props.onClose} />,
+      rootElement
+    );
+  }
+
+  /** Releases the Preact tree when deck.gl removes the widget. */
+  override onRemove(): void {
+    if (this.#rootElement) {
+      render(null, this.#rootElement);
+      this.#rootElement = null;
+    }
+  }
+}
+
+const DEFAULT_VISIBLE_ENTRY_COUNT = 10;
+const DEFAULT_EXPANDED_ENTRY_COUNT = 100;
+
+const LEGEND_STYLE: JSX.CSSProperties = {
+  pointerEvents: 'none',
+  maxWidth: '224px',
+  boxSizing: 'border-box',
+  padding: '6px 8px',
+  border: '1px solid var(--button-stroke, rgba(148, 163, 184, 0.35))',
+  borderRadius: 'var(--button-corner-radius, 6px)',
+  background: 'var(--menu-background, var(--button-background, rgba(255, 255, 255, 0.95)))',
+  color: 'var(--menu-text, var(--button-text, currentColor))',
+  boxShadow: 'var(--button-shadow, 0 1px 3px rgba(0, 0, 0, 0.15))',
+  fontSize: '12px',
+  lineHeight: 1.25,
+  transform: 'scale(0.9)',
+  transformOrigin: 'bottom right'
+};
+
+const HEADER_STYLE: JSX.CSSProperties = {
+  pointerEvents: 'auto',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '8px',
+  marginBottom: '6px',
+  fontWeight: 500
+};
+
+const MUTED_TEXT_STYLE: JSX.CSSProperties = {
+  color: 'var(--menu-text-muted, var(--button-icon-idle, currentColor))',
+  opacity: 0.78
+};
+
+const CLOSE_BUTTON_STYLE: JSX.CSSProperties = {
+  pointerEvents: 'auto',
+  appearance: 'none',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '16px',
+  height: '16px',
+  padding: 0,
+  border: 0,
+  borderRadius: '3px',
+  background: 'transparent',
+  color: 'var(--button-icon-idle, currentColor)',
+  cursor: 'pointer',
+  opacity: 0,
+  transition: 'opacity 120ms ease'
+};
+
+const ACTION_BUTTON_STYLE: JSX.CSSProperties = {
+  pointerEvents: 'auto',
+  appearance: 'none',
+  padding: 0,
+  border: 0,
+  background: 'transparent',
+  color: 'var(--button-icon-idle, currentColor)',
+  font: 'inherit',
+  cursor: 'pointer'
+};
+
+const ENTRY_TOOLTIP_STYLE: JSX.CSSProperties = {
+  position: 'fixed',
+  zIndex: 2_147_483_647,
+  width: 'max-content',
+  boxSizing: 'border-box',
+  padding: '6px 8px',
+  border: '1px solid CanvasText',
+  borderRadius: '6px',
+  background: 'Canvas',
+  color: 'CanvasText',
+  boxShadow: 'none',
+  fontSize: '12px',
+  lineHeight: 1.35,
+  whiteSpace: 'normal',
+  overflowWrap: 'anywhere',
+  pointerEvents: 'none'
+};
+
+type ColorLegendViewProps = {
+  /** Serializable content to render. */
+  readonly payload: ColorLegendPayload;
+  /** Optional dismiss action for the legend header. */
+  readonly onClose?: () => void;
+};
+
+type ColorLegendSectionViewProps = {
+  /** Discriminated section to render. */
+  readonly section: ColorLegendSection;
+  /** Whether this section's complete prepared entry set is visible. */
+  readonly isExpanded: boolean;
+  /** Updates this section's expansion state. */
+  readonly onExpandedChange: (isExpanded: boolean) => void;
+};
+
+type CategoricalSectionViewProps = {
+  /** Categorical section to render. */
+  readonly section: ColorLegendCategoricalSection;
+  /** Whether the expanded prepared entry prefix is visible. */
+  readonly isExpanded: boolean;
+  /** Updates this section's expansion state. */
+  readonly onExpandedChange: (isExpanded: boolean) => void;
+};
+
+/** Viewport-positioned tooltip state for the single currently hovered legend row. */
+type ColorLegendHoveredEntry = {
+  /** Immutable categorical section that owned the row when its tooltip opened. */
+  readonly section: ColorLegendCategoricalSection;
+  /** Immutable legend entry associated with the visible tooltip and focus target. */
+  readonly entry: ColorLegendCategoricalEntry;
+  /** Full prepared hover text supplied by the categorical legend entry. */
+  readonly title: string;
+  /** Viewport-relative tooltip anchor position on the horizontal axis. */
+  readonly left: number;
+  /** Viewport-relative vertical midpoint of the hovered legend row. */
+  readonly top: number;
+  /** Whether the tooltip should open to the left or right of its anchor. */
+  readonly placement: 'left' | 'right';
+  /** Maximum tooltip width that still fits inside the current viewport. */
+  readonly maxWidth: number;
+  /** Resolved legend surface color retained outside the deck theme's DOM scope. */
+  readonly backgroundColor: string;
+  /** Resolved legend foreground color retained outside the deck theme's DOM scope. */
+  readonly color: string;
+  /** Resolved legend border color retained outside the deck theme's DOM scope. */
+  readonly borderColor: string;
+  /** Resolved legend corner radius retained outside the deck theme's DOM scope. */
+  readonly borderRadius: string;
+  /** Resolved legend shadow retained outside the deck theme's DOM scope. */
+  readonly boxShadow: string;
+  /** Document that owns the legend row and its clipping-independent portal. */
+  readonly ownerDocument: Document;
+};
+
+type ContinuousSectionViewProps = {
+  /** Continuous scale to render. */
+  readonly section: ColorLegendContinuousSection;
+};
+
+type PaletteSectionViewProps = {
+  /** Compact palette to render. */
+  readonly section: ColorLegendPaletteSection;
+};
+
+type ColorSwatchProps = {
+  /** Color rendered by the swatch. */
+  readonly color: ColorLegendColor;
+  /** CSS width and height for the square. */
+  readonly size?: string;
+  /** Optional accessible and hover label. */
+  readonly title?: string;
+};
+
+/** Preact view for one serializable color legend. */
+function ColorLegendView({payload, onClose}: ColorLegendViewProps) {
+  const [expandedSectionKey, setExpandedSectionKey] = useState<string | null>(null);
+  const [isHeaderHovered, setIsHeaderHovered] = useState(false);
+  const [isCloseFocused, setIsCloseFocused] = useState(false);
+
+  if (payload.sections.length === 0) {
+    return null;
+  }
+
+  return (
+    <aside
+      aria-label={payload.ariaLabel ?? `${payload.title} legend`}
+      className="deck-widget-color-legend-content"
+      data-testid="color-legend"
+      style={LEGEND_STYLE}
+    >
+      <div
+        style={HEADER_STYLE}
+        onMouseEnter={() => setIsHeaderHovered(true)}
+        onMouseLeave={() => setIsHeaderHovered(false)}
+      >
+        <span>{payload.title}</span>
+        {onClose ? (
+          <button
+            aria-label="Close color legend"
+            className="deck-widget-color-legend-close"
+            style={{
+              ...CLOSE_BUTTON_STYLE,
+              opacity: isHeaderHovered || isCloseFocused ? 1 : 0
+            }}
+            type="button"
+            onBlur={() => setIsCloseFocused(false)}
+            onClick={onClose}
+            onFocus={() => setIsCloseFocused(true)}
+          >
+            <svg aria-hidden="true" height="12" viewBox="0 0 12 12" width="12">
+              <path d="M2 2l8 8M10 2l-8 8" fill="none" stroke="currentColor" stroke-width="1.5" />
+            </svg>
+          </button>
+        ) : null}
+      </div>
+      {payload.description ? (
+        <div style={{...MUTED_TEXT_STYLE, marginBottom: '7px'}}>{payload.description}</div>
+      ) : null}
+      <div style={{display: 'flex', flexDirection: 'column', gap: '7px'}}>
+        {payload.sections.map(section => {
+          const sectionKey = `${payload.id}:${section.id}`;
+          return (
+            <ColorLegendSectionView
+              key={section.id}
+              section={section}
+              isExpanded={expandedSectionKey === sectionKey}
+              onExpandedChange={isExpanded => setExpandedSectionKey(isExpanded ? sectionKey : null)}
+            />
+          );
+        })}
+      </div>
+    </aside>
+  );
+}
+
+/** Renders one discriminated legend section. */
+function ColorLegendSectionView({
+  section,
+  isExpanded,
+  onExpandedChange
+}: ColorLegendSectionViewProps) {
+  return (
+    <section>
+      {section.title ? (
+        <div style={{marginBottom: '4px', fontWeight: 500}}>{section.title}</div>
+      ) : null}
+      {section.type === 'categorical' ? (
+        <CategoricalSectionView
+          section={section}
+          isExpanded={isExpanded}
+          onExpandedChange={onExpandedChange}
+        />
+      ) : section.type === 'continuous' ? (
+        <ContinuousSectionView section={section} />
+      ) : (
+        <PaletteSectionView section={section} />
+      )}
+    </section>
+  );
+}
+
+/** Renders a bounded categorical list with optional expansion. */
+function CategoricalSectionView({
+  section,
+  isExpanded,
+  onExpandedChange
+}: CategoricalSectionViewProps) {
+  const [hoveredEntry, setHoveredEntry] = useState<ColorLegendHoveredEntry | null>(null);
+  const tooltipId = useId();
+  const activeHoveredEntry = hoveredEntry?.section === section ? hoveredEntry : null;
+
+  useEffect(() => {
+    const ownerWindow = activeHoveredEntry?.ownerDocument.defaultView;
+    if (!ownerWindow) {
+      return undefined;
+    }
+
+    const dismissTooltip = () => setHoveredEntry(null);
+    ownerWindow.addEventListener('scroll', dismissTooltip, true);
+    ownerWindow.addEventListener('resize', dismissTooltip);
+    return () => {
+      ownerWindow.removeEventListener('scroll', dismissTooltip, true);
+      ownerWindow.removeEventListener('resize', dismissTooltip);
+    };
+  }, [activeHoveredEntry]);
+
+  const visibleLimit = normalizeEntryLimit(
+    isExpanded ? section.maxExpandedEntries : section.maxVisibleEntries,
+    isExpanded ? DEFAULT_EXPANDED_ENTRY_COUNT : DEFAULT_VISIBLE_ENTRY_COUNT
+  );
+  const visibleEntries = section.entries.slice(0, visibleLimit);
+  const totalCount = Math.max(section.totalCount ?? section.entries.length, section.entries.length);
+  const hiddenCount = Math.max(0, totalCount - visibleEntries.length);
+  const canExpand = !isExpanded && section.entries.length > visibleEntries.length;
+
+  return (
+    <>
+      <ul
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '2px',
+          maxHeight: isExpanded ? '288px' : undefined,
+          margin: 0,
+          padding: 0,
+          overflowY: isExpanded ? 'auto' : undefined,
+          listStyle: 'none',
+          pointerEvents: isExpanded ? 'auto' : undefined
+        }}
+        onScroll={() => setHoveredEntry(null)}
+      >
+        {visibleEntries.map((entry, index) => (
+          <li
+            key={`${entry.label}:${index}`}
+            style={{
+              display: 'flex',
+              minWidth: 0,
+              alignItems: 'center',
+              gap: '6px',
+              pointerEvents: entry.title ? 'auto' : undefined
+            }}
+            aria-describedby={activeHoveredEntry?.entry === entry ? tooltipId : undefined}
+            tabIndex={entry.title ? 0 : undefined}
+            title={entry.title}
+            onMouseEnter={
+              entry.title
+                ? event =>
+                    showColorLegendEntryTooltip(
+                      event.currentTarget,
+                      entry,
+                      section,
+                      setHoveredEntry
+                    )
+                : undefined
+            }
+            onMouseLeave={entry.title ? () => setHoveredEntry(null) : undefined}
+            onFocus={
+              entry.title
+                ? event =>
+                    showColorLegendEntryTooltip(
+                      event.currentTarget,
+                      entry,
+                      section,
+                      setHoveredEntry
+                    )
+                : undefined
+            }
+            onBlur={entry.title ? () => setHoveredEntry(null) : undefined}
+          >
+            <ColorSwatch color={entry.color} title={entry.title} />
+            <span style={{minWidth: 0, overflow: 'hidden'}}>
+              <span
+                style={{
+                  ...MUTED_TEXT_STYLE,
+                  display: 'block',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap'
+                }}
+                title={entry.title ?? entry.label}
+              >
+                {entry.label}
+              </span>
+              {entry.description ? (
+                <span
+                  style={{...MUTED_TEXT_STYLE, display: 'block', fontSize: '11px', opacity: 0.65}}
+                >
+                  {entry.description}
+                </span>
+              ) : null}
+            </span>
+          </li>
+        ))}
+        {hiddenCount > 0 ? (
+          <li>
+            {canExpand ? (
+              <button
+                aria-label="Show all color categories"
+                className="deck-widget-color-legend-action"
+                style={ACTION_BUTTON_STYLE}
+                type="button"
+                onClick={() => onExpandedChange(true)}
+              >
+                {`+${hiddenCount.toLocaleString()} more`}
+              </button>
+            ) : (
+              <span style={MUTED_TEXT_STYLE}>{`+${hiddenCount.toLocaleString()} more`}</span>
+            )}
+          </li>
+        ) : null}
+        {isExpanded ? (
+          <li>
+            <button
+              aria-label="Collapse color categories"
+              className="deck-widget-color-legend-action"
+              style={ACTION_BUTTON_STYLE}
+              type="button"
+              onClick={() => onExpandedChange(false)}
+            >
+              Show less
+            </button>
+          </li>
+        ) : null}
+      </ul>
+      {activeHoveredEntry
+        ? createPortal(
+            <span
+              id={tooltipId}
+              role="tooltip"
+              data-testid="color-legend-entry-tooltip"
+              style={{
+                ...ENTRY_TOOLTIP_STYLE,
+                background: activeHoveredEntry.backgroundColor,
+                color: activeHoveredEntry.color,
+                borderColor: activeHoveredEntry.borderColor,
+                borderRadius: activeHoveredEntry.borderRadius,
+                boxShadow: activeHoveredEntry.boxShadow,
+                left: `${activeHoveredEntry.left}px`,
+                top: `${activeHoveredEntry.top}px`,
+                maxWidth: `${activeHoveredEntry.maxWidth}px`,
+                transform:
+                  activeHoveredEntry.placement === 'left'
+                    ? 'translate(-100%, -50%)'
+                    : 'translate(0, -50%)'
+              }}
+            >
+              {activeHoveredEntry.title}
+            </span>,
+            activeHoveredEntry.ownerDocument.body
+          )
+        : null}
+    </>
+  );
+}
+
+/** Opens a viewport-clamped tooltip using the resolved theme of its owning legend. */
+function showColorLegendEntryTooltip(
+  row: HTMLElement,
+  entry: ColorLegendCategoricalEntry,
+  section: ColorLegendCategoricalSection,
+  onShow: (hoveredEntry: ColorLegendHoveredEntry) => void
+): void {
+  const title = entry.title;
+  if (!title) {
+    return;
+  }
+
+  const bounds = row.getBoundingClientRect();
+  const ownerWindow = row.ownerDocument.defaultView;
+  const viewportWidth = ownerWindow?.innerWidth ?? bounds.right;
+  const maxWidth = Math.min(320, Math.max(0, viewportWidth - 16));
+  const placement = bounds.left >= viewportWidth - bounds.right ? 'left' : 'right';
+  const left =
+    placement === 'left'
+      ? Math.min(viewportWidth - 8, Math.max(maxWidth + 8, bounds.left - 8))
+      : Math.max(8, Math.min(viewportWidth - maxWidth - 8, bounds.right + 8));
+  const legend = row.closest<HTMLElement>('[data-testid="color-legend"]') ?? row;
+  const theme = ownerWindow?.getComputedStyle(legend);
+
+  onShow({
+    section,
+    entry,
+    title,
+    left,
+    top: bounds.top + bounds.height / 2,
+    placement,
+    maxWidth,
+    backgroundColor: theme?.backgroundColor || 'Canvas',
+    color: theme?.color || 'CanvasText',
+    borderColor: theme?.borderColor || theme?.color || 'CanvasText',
+    borderRadius: theme?.borderRadius || '6px',
+    boxShadow: theme?.boxShadow || 'none',
+    ownerDocument: row.ownerDocument
+  });
+}
+
+/** Renders one vertical continuous gradient and its high-to-low labels. */
+function ContinuousSectionView({section}: ContinuousSectionViewProps) {
+  return (
+    <div style={{display: 'flex', alignItems: 'stretch', gap: '8px'}}>
+      <div
+        aria-hidden="true"
+        data-testid="color-legend-gradient"
+        style={{
+          width: '8px',
+          minHeight: '64px',
+          flexShrink: 0,
+          borderRadius: '9999px',
+          backgroundImage: formatColorScaleGradient(section.stops)
+        }}
+      />
+      <div
+        style={{
+          ...MUTED_TEXT_STYLE,
+          display: 'flex',
+          minHeight: '64px',
+          flexDirection: 'column-reverse',
+          justifyContent: 'space-between',
+          gap: '8px'
+        }}
+      >
+        {section.stops.map((stop, index) => (
+          <span key={`${stop.label}:${index}`}>{stop.label}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Renders a compact strip for palettes whose categories should not be enumerated. */
+function PaletteSectionView({section}: PaletteSectionViewProps) {
+  return (
+    <div style={{display: 'flex', alignItems: 'center', gap: '8px'}}>
+      <span style={{display: 'flex', flexShrink: 0, gap: '2px'}}>
+        {section.colors.map((entry, index) => (
+          <ColorSwatch
+            key={`${formatLegendColor(entry.color)}:${index}`}
+            color={entry.color}
+            size="10px"
+            title={entry.label}
+          />
+        ))}
+      </span>
+      {section.label ? <span style={MUTED_TEXT_STYLE}>{section.label}</span> : null}
+    </div>
+  );
+}
+
+/** Renders one small, non-interactive color sample. */
+function ColorSwatch({color, size = '8px', title}: ColorSwatchProps) {
+  return (
+    <span
+      aria-hidden={title ? undefined : true}
+      aria-label={title}
+      data-testid="color-legend-swatch"
+      role={title ? 'img' : undefined}
+      style={{
+        width: size,
+        height: size,
+        flexShrink: 0,
+        borderRadius: '2px',
+        backgroundColor: formatLegendColor(color)
+      }}
+      title={title}
+    />
+  );
+}
+
+/** Normalizes caller-provided entry limits to a safe non-negative integer. */
+function normalizeEntryLimit(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value ?? fallback)) : fallback;
+}
+
+/** Converts one JSON-safe color value into CSS. */
+function formatLegendColor(color: ColorLegendColor): string {
+  if (typeof color === 'string') {
+    return color;
+  }
+  const [red, green, blue, alpha = 255] = color;
+  return `rgba(${red}, ${green}, ${blue}, ${alpha / 255})`;
+}
+
+/** Creates a bottom-to-top gradient from low-to-high declarative stops. */
+function formatColorScaleGradient(stops: readonly ColorLegendContinuousStop[]): string {
+  return `linear-gradient(to top, ${stops.map(stop => formatLegendColor(stop.color)).join(', ')})`;
+}

--- a/modules/widgets/src/widgets/color-legend-widget.tsx
+++ b/modules/widgets/src/widgets/color-legend-widget.tsx
@@ -6,7 +6,7 @@
 import {Widget} from '@deck.gl/core';
 import {render} from 'preact';
 import {createPortal} from 'preact/compat';
-import {useEffect, useId, useState} from 'preact/hooks';
+import {useEffect, useId, useLayoutEffect, useRef, useState} from 'preact/hooks';
 
 import type {WidgetPlacement, WidgetProps} from '@deck.gl/core';
 import type {JSX} from 'preact';
@@ -168,6 +168,8 @@ export class ColorLegendWidget extends Widget<ColorLegendWidgetProps> {
 
 const DEFAULT_VISIBLE_ENTRY_COUNT = 10;
 const DEFAULT_EXPANDED_ENTRY_COUNT = 100;
+const TOOLTIP_VIEWPORT_MARGIN = 8;
+const TOOLTIP_MAX_WIDTH = 320;
 
 const LEGEND_STYLE: JSX.CSSProperties = {
   pointerEvents: 'none',
@@ -416,6 +418,7 @@ function CategoricalSectionView({
   onExpandedChange
 }: CategoricalSectionViewProps) {
   const [hoveredEntry, setHoveredEntry] = useState<ColorLegendHoveredEntry | null>(null);
+  const tooltipElementRef = useRef<HTMLSpanElement | null>(null);
   const tooltipId = useId();
   const activeHoveredEntry = hoveredEntry?.section === section ? hoveredEntry : null;
 
@@ -432,6 +435,25 @@ function CategoricalSectionView({
       ownerWindow.removeEventListener('scroll', dismissTooltip, true);
       ownerWindow.removeEventListener('resize', dismissTooltip);
     };
+  }, [activeHoveredEntry]);
+
+  useLayoutEffect(() => {
+    const tooltipElement = tooltipElementRef.current;
+    if (!tooltipElement || !activeHoveredEntry) {
+      return;
+    }
+
+    const viewportHeight = getTooltipViewportHeight(activeHoveredEntry.ownerDocument);
+    if (viewportHeight === null) {
+      return;
+    }
+
+    const measuredHeight = tooltipElement.getBoundingClientRect().height;
+    tooltipElement.style.top = `${clampTooltipTop(
+      activeHoveredEntry.top,
+      measuredHeight,
+      viewportHeight
+    )}px`;
   }, [activeHoveredEntry]);
 
   const visibleLimit = normalizeEntryLimit(
@@ -555,6 +577,7 @@ function CategoricalSectionView({
       {activeHoveredEntry
         ? createPortal(
             <span
+              ref={tooltipElementRef}
               id={tooltipId}
               role="tooltip"
               data-testid="color-legend-entry-tooltip"
@@ -568,6 +591,8 @@ function CategoricalSectionView({
                 left: `${activeHoveredEntry.left}px`,
                 top: `${activeHoveredEntry.top}px`,
                 maxWidth: `${activeHoveredEntry.maxWidth}px`,
+                maxHeight: getTooltipMaxHeight(activeHoveredEntry.ownerDocument),
+                overflow: 'hidden',
                 transform:
                   activeHoveredEntry.placement === 'left'
                     ? 'translate(-100%, -50%)'
@@ -598,12 +623,24 @@ function showColorLegendEntryTooltip(
   const bounds = row.getBoundingClientRect();
   const ownerWindow = row.ownerDocument.defaultView;
   const viewportWidth = ownerWindow?.innerWidth ?? bounds.right;
-  const maxWidth = Math.min(320, Math.max(0, viewportWidth - 16));
+  const maxWidth = Math.min(
+    TOOLTIP_MAX_WIDTH,
+    Math.max(0, viewportWidth - TOOLTIP_VIEWPORT_MARGIN * 2)
+  );
   const placement = bounds.left >= viewportWidth - bounds.right ? 'left' : 'right';
   const left =
     placement === 'left'
-      ? Math.min(viewportWidth - 8, Math.max(maxWidth + 8, bounds.left - 8))
-      : Math.max(8, Math.min(viewportWidth - maxWidth - 8, bounds.right + 8));
+      ? Math.min(
+          viewportWidth - TOOLTIP_VIEWPORT_MARGIN,
+          Math.max(maxWidth + TOOLTIP_VIEWPORT_MARGIN, bounds.left - TOOLTIP_VIEWPORT_MARGIN)
+        )
+      : Math.max(
+          TOOLTIP_VIEWPORT_MARGIN,
+          Math.min(
+            viewportWidth - maxWidth - TOOLTIP_VIEWPORT_MARGIN,
+            bounds.right + TOOLTIP_VIEWPORT_MARGIN
+          )
+        );
   const legend = row.closest<HTMLElement>('[data-testid="color-legend"]') ?? row;
   const theme = ownerWindow?.getComputedStyle(legend);
 
@@ -624,8 +661,34 @@ function showColorLegendEntryTooltip(
   });
 }
 
+/** Returns a finite viewport height when the tooltip's owning document has one. */
+function getTooltipViewportHeight(ownerDocument: Document): number | null {
+  const viewportHeight = ownerDocument.defaultView?.innerHeight;
+  return typeof viewportHeight === 'number' && Number.isFinite(viewportHeight)
+    ? Math.max(0, viewportHeight)
+    : null;
+}
+
+/** Returns a CSS height cap that keeps a tooltip inside its viewport margin. */
+function getTooltipMaxHeight(ownerDocument: Document): string | undefined {
+  const viewportHeight = getTooltipViewportHeight(ownerDocument);
+  return viewportHeight === null
+    ? undefined
+    : `${Math.max(0, viewportHeight - TOOLTIP_VIEWPORT_MARGIN * 2)}px`;
+}
+
+/** Clamps a measured tooltip midpoint so its visible box stays inside the viewport. */
+function clampTooltipTop(anchorTop: number, tooltipHeight: number, viewportHeight: number): number {
+  const availableHeight = Math.max(0, viewportHeight - TOOLTIP_VIEWPORT_MARGIN * 2);
+  const visibleHeight = Math.min(Math.max(0, tooltipHeight), availableHeight);
+  const minTop = TOOLTIP_VIEWPORT_MARGIN + visibleHeight / 2;
+  const maxTop = Math.max(minTop, viewportHeight - TOOLTIP_VIEWPORT_MARGIN - visibleHeight / 2);
+  return Math.min(maxTop, Math.max(minTop, anchorTop));
+}
+
 /** Renders one vertical continuous gradient and its high-to-low labels. */
 function ContinuousSectionView({section}: ContinuousSectionViewProps) {
+  const [singleStop] = section.stops;
   return (
     <div style={{display: 'flex', alignItems: 'stretch', gap: '8px'}}>
       <div
@@ -636,7 +699,12 @@ function ContinuousSectionView({section}: ContinuousSectionViewProps) {
           minHeight: '64px',
           flexShrink: 0,
           borderRadius: '9999px',
-          backgroundImage: formatColorScaleGradient(section.stops)
+          backgroundColor:
+            section.stops.length === 1 && singleStop
+              ? formatLegendColor(singleStop.color)
+              : undefined,
+          backgroundImage:
+            section.stops.length > 1 ? formatColorScaleGradient(section.stops) : undefined
         }}
       />
       <div

--- a/modules/widgets/src/widgets/color-legend-widget.tsx
+++ b/modules/widgets/src/widgets/color-legend-widget.tsx
@@ -304,6 +304,14 @@ type ColorLegendHoveredEntry = {
   readonly ownerDocument: Document;
 };
 
+/** Measured tooltip position retained with the hover state that produced it. */
+type ColorLegendMeasuredTooltipTop = {
+  /** Hover state whose rendered tooltip height produced this clamped position. */
+  readonly hoveredEntry: ColorLegendHoveredEntry;
+  /** Viewport-relative vertical midpoint after measuring and clamping the tooltip. */
+  readonly top: number;
+};
+
 type ContinuousSectionViewProps = {
   /** Continuous scale to render. */
   readonly section: ColorLegendContinuousSection;
@@ -418,9 +426,15 @@ function CategoricalSectionView({
   onExpandedChange
 }: CategoricalSectionViewProps) {
   const [hoveredEntry, setHoveredEntry] = useState<ColorLegendHoveredEntry | null>(null);
+  const [measuredTooltipTop, setMeasuredTooltipTop] =
+    useState<ColorLegendMeasuredTooltipTop | null>(null);
   const tooltipElementRef = useRef<HTMLSpanElement | null>(null);
   const tooltipId = useId();
   const activeHoveredEntry = hoveredEntry?.section === section ? hoveredEntry : null;
+  const activeTooltipTop =
+    measuredTooltipTop?.hoveredEntry === activeHoveredEntry
+      ? measuredTooltipTop.top
+      : activeHoveredEntry?.top;
 
   useEffect(() => {
     const ownerWindow = activeHoveredEntry?.ownerDocument.defaultView;
@@ -439,7 +453,11 @@ function CategoricalSectionView({
 
   useLayoutEffect(() => {
     const tooltipElement = tooltipElementRef.current;
-    if (!tooltipElement || !activeHoveredEntry) {
+    if (!activeHoveredEntry) {
+      setMeasuredTooltipTop(null);
+      return;
+    }
+    if (!tooltipElement) {
       return;
     }
 
@@ -449,11 +467,12 @@ function CategoricalSectionView({
     }
 
     const measuredHeight = tooltipElement.getBoundingClientRect().height;
-    tooltipElement.style.top = `${clampTooltipTop(
-      activeHoveredEntry.top,
-      measuredHeight,
-      viewportHeight
-    )}px`;
+    const top = clampTooltipTop(activeHoveredEntry.top, measuredHeight, viewportHeight);
+    setMeasuredTooltipTop(previousTop =>
+      previousTop?.hoveredEntry === activeHoveredEntry && previousTop.top === top
+        ? previousTop
+        : {hoveredEntry: activeHoveredEntry, top}
+    );
   }, [activeHoveredEntry]);
 
   const visibleLimit = normalizeEntryLimit(
@@ -589,7 +608,7 @@ function CategoricalSectionView({
                 borderRadius: activeHoveredEntry.borderRadius,
                 boxShadow: activeHoveredEntry.boxShadow,
                 left: `${activeHoveredEntry.left}px`,
-                top: `${activeHoveredEntry.top}px`,
+                top: `${activeTooltipTop ?? activeHoveredEntry.top}px`,
                 maxWidth: `${activeHoveredEntry.maxWidth}px`,
                 maxHeight: getTooltipMaxHeight(activeHoveredEntry.ownerDocument),
                 overflow: 'hidden',


### PR DESCRIPTION
## Summary

- add a JSON-safe `ColorLegendWidget` for categorical lists, continuous gradients, and compact palettes
- keep large category sets bounded while supporting accessible expansion, dismissal, and entry details
- add viewport-clamped portaled tooltips for longer categorical entry descriptions
- export the public payload types and document the widget in the API reference and release notes

## Why

Applications often need a reusable color key without coupling a deck.gl widget to their data model. This adds a declarative, serializable legend surface that callers can prepare independently and render consistently with deck.gl widget themes.

## Validation

- `yarn lint-fix`
- `yarn vitest run modules/widgets/src/widgets/color-legend-widget.test.tsx --project headless` (11 passed)
- `yarn test` (612 passed, 9 skipped)
- `yarn --cwd website build`
- `git diff --check`
- changed-file size sweep
- `yarn build` compiled the widgets package; repo-wide Lerna graph completion is blocked locally by duplicate unrelated `data` projects in sibling worktrees
