### PR TITLE
Add async search lifecycle controls to OmniBoxWidget

### DIFF
--- a/docs/modules/widgets/api-reference/omni-box-widget.md
+++ b/docs/modules/widgets/api-reference/omni-box-widget.md
@@ -17,8 +17,10 @@ import {
   OmniBoxWidget,
   type OmniBoxOption,
   type OmniBoxOptionProvider,
+  type OmniBoxOptionSorter,
   type OmniBoxRenderOptionArgs,
-  type OmniBoxResultsSummaryArgs
+  type OmniBoxResultsSummaryArgs,
+  type OmniBoxResultsState
 } from '@deck.gl-community/widgets';
 ```
 
@@ -37,6 +39,10 @@ export type OmniBoxOptionProvider =
   | ((query: string) => Promise<ReadonlyArray<OmniBoxOption>>)
   | ((query: string) => ReadonlyArray<OmniBoxOption>);
 
+export type OmniBoxOptionSorter = (
+  options: ReadonlyArray<OmniBoxOption>
+) => ReadonlyArray<OmniBoxOption>;
+
 export type OmniBoxRenderOptionArgs = {
   option: OmniBoxOption;
   index: number;
@@ -49,6 +55,14 @@ export type OmniBoxResultsSummaryArgs = {
   readonly options: ReadonlyArray<OmniBoxOption>;
   readonly mode: 'search' | 'command' | 'history';
 };
+
+export type OmniBoxResultsState = {
+  readonly query: string;
+  readonly options: ReadonlyArray<OmniBoxOption>;
+  readonly mode: 'search' | 'command' | 'history';
+  readonly isLoading: boolean;
+  readonly isOpen: boolean;
+};
 ```
 
 ## Props
@@ -58,6 +72,8 @@ type OmniBoxWidgetProps = WidgetProps & {
   placement?: WidgetPlacement;
   placeholder?: string;
   minQueryLength?: number;
+  searchDebounceMs?: number;
+  searchRefreshKey?: unknown;
   defaultOpen?: boolean;
   closeOnSelect?: boolean;
   rememberQueries?: boolean;
@@ -66,12 +82,14 @@ type OmniBoxWidgetProps = WidgetProps & {
   showAnchorButton?: boolean;
   topOffsetPx?: number;
   getOptions?: OmniBoxOptionProvider;
+  sortOptions?: OmniBoxOptionSorter;
   renderOption?: (args: OmniBoxRenderOptionArgs) => ComponentChildren;
   renderResultsSummary?: (args: OmniBoxResultsSummaryArgs) => ComponentChildren;
   onSelectOption?: (option: OmniBoxOption) => void;
   onActiveOptionChange?: (option: OmniBoxOption | null) => void;
   onNavigateOption?: (option: OmniBoxOption) => void;
   onQueryChange?: (query: string) => void;
+  onResultsStateChange?: (state: OmniBoxResultsState) => void;
 };
 ```
 
@@ -85,10 +103,14 @@ const widget = new OmniBoxWidget({
   rememberQueries: true,
   queryHistoryStorageKey: 'example-search-history',
   minQueryLength: 1,
+  searchDebounceMs: 120,
+  searchRefreshKey: itemCatalogVersion,
   getOptions: (query) => searchItems(query),
+  sortOptions: (options) => options.slice(0, 20),
   renderResultsSummary: ({options}) => `${options.length} matches`,
   onSelectOption: (option) => selectItem((option.data as any).id),
-  onNavigateOption: (option) => previewItem((option.data as any).id)
+  onNavigateOption: (option) => previewItem((option.data as any).id),
+  onResultsStateChange: (state) => updateSearchStatus(state)
 });
 ```
 
@@ -100,6 +122,11 @@ This widget is intentionally generic. Callers provide search options, selection 
 
 - Renders a floating search input centered near the top of the deck canvas.
 - Supports sync or async option providers.
+- Can debounce ordinary option providers while command suggestions remain immediate.
+- Rejects late async results after the query changes.
+- Can rerun the current query when `searchRefreshKey` changes.
+- Can reorder or bound ordinary results with `sortOptions`.
+- Can publish the current dropdown/loading state through `onResultsStateChange`.
 - Caps the dropdown to 4 visible rows and makes it scrollable beyond that.
 - Includes built-in `<` and `>` navigation controls for cycling the active option.
 - Opens and focuses from `/` when focus is not already inside an editable element.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -98,6 +98,7 @@ Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community
   and toast components without duplicating panel rendering logic.
 - `OmniBoxWidget` now accepts `renderResultsSummary` for rendering a compact caller-provided summary above dropdown results.
 - `OmniBoxWidget` now accepts shared command manager search prefixes for command-mode integrations.
+- `OmniBoxWidget` now supports debounced async search, refresh-key reruns, caller-managed result ordering, and result-state callbacks.
 - `ModalPanelWidget` inherits floating, draggable, custom-styled modal support from `ModalPanelContainer`.
 - `createStudioSettingsWidget` and `updateStudioSettingsWidget` now host the shared Studio settings panel through deck widget chrome.
 

--- a/modules/widgets/src/index.ts
+++ b/modules/widgets/src/index.ts
@@ -32,8 +32,10 @@ export {
   OmniBoxWidget,
   type OmniBoxOption,
   type OmniBoxOptionProvider,
+  type OmniBoxOptionSorter,
   type OmniBoxRenderOptionArgs,
   type OmniBoxResultsSummaryArgs,
+  type OmniBoxResultsState,
   type OmniBoxWidgetProps
 } from './widgets/omni-box-widget';
 export {

--- a/modules/widgets/src/widgets/omni-box-widget.test.tsx
+++ b/modules/widgets/src/widgets/omni-box-widget.test.tsx
@@ -5,7 +5,7 @@ import {CommandManager, toastManager} from '@deck.gl-community/panels';
 
 import {OmniBoxWidget} from './omni-box-widget';
 
-import type {OmniBoxWidgetProps} from './omni-box-widget';
+import type {OmniBoxOption, OmniBoxWidgetProps} from './omni-box-widget';
 
 function renderWidget(props: OmniBoxWidgetProps = {}) {
   const root = document.createElement('div');
@@ -36,6 +36,7 @@ function renderWidget(props: OmniBoxWidgetProps = {}) {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   toastManager.clear();
   document.body.innerHTML = '';
   window.localStorage.clear();
@@ -329,6 +330,292 @@ describe('OmniBoxWidget', () => {
 
     expect(getOptions).toHaveBeenCalledWith('alpha');
     expect(root.querySelector('button[role="option"]')?.textContent).toContain('Alpha item');
+
+    cleanup();
+  });
+
+  it('allows callers to sort and bound ordinary search results', async () => {
+    const {root, cleanup} = renderWidget({
+      minQueryLength: 1,
+      getOptions: () => [
+        {id: 'short', label: 'Short item', data: {duration: 5}},
+        {id: 'long', label: 'Long item', data: {duration: 125}}
+      ],
+      sortOptions: options =>
+        [...options]
+          .sort(
+            (left, right) =>
+              (right.data as {duration: number}).duration -
+              (left.data as {duration: number}).duration
+          )
+          .slice(0, 1)
+    });
+
+    const input = root.querySelector('input[aria-label="OmniBox"]') as HTMLInputElement;
+    await act(async () => {
+      input.focus();
+      input.dispatchEvent(new FocusEvent('focus', {bubbles: false}));
+      input.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
+      input.value = 'item';
+      input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    });
+    await act(async () => {
+      await new Promise(resolve => window.setTimeout(resolve, 0));
+    });
+
+    const options = root.querySelectorAll<HTMLButtonElement>('button[role="option"]');
+    expect(options).toHaveLength(1);
+    expect(options[0]?.textContent).toContain('Long item');
+
+    cleanup();
+  });
+
+  it('reruns the current query when its search refresh key changes', async () => {
+    let loadCount = 0;
+    const getOptions = vi.fn(() => {
+      loadCount += 1;
+      return [{id: `result-${loadCount}`, label: `Result ${loadCount}`}];
+    });
+    const {root, widget, cleanup} = renderWidget({
+      minQueryLength: 1,
+      searchRefreshKey: 0,
+      getOptions
+    });
+
+    const input = root.querySelector('input[aria-label="OmniBox"]') as HTMLInputElement;
+    await act(async () => {
+      input.focus();
+      input.dispatchEvent(new FocusEvent('focus', {bubbles: false}));
+      input.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
+      input.value = 'alpha';
+      input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    });
+    await act(async () => {
+      await new Promise(resolve => window.setTimeout(resolve, 0));
+    });
+
+    expect(getOptions).toHaveBeenCalledOnce();
+    expect(root.querySelector('button[role="option"]')?.textContent).toContain('Result 1');
+
+    await act(async () => {
+      widget.setProps({searchRefreshKey: 1});
+      widget.onRenderHTML(root);
+    });
+    await act(async () => {
+      await new Promise(resolve => window.setTimeout(resolve, 0));
+    });
+
+    expect(getOptions).toHaveBeenCalledTimes(2);
+    expect(getOptions).toHaveBeenLastCalledWith('alpha');
+    expect(root.querySelector('button[role="option"]')?.textContent).toContain('Result 2');
+
+    cleanup();
+  });
+
+  it('rejects stale asynchronous results after the query changes', async () => {
+    const resolvers = new Map<
+      string,
+      (options: ReadonlyArray<{id: string; label: string}>) => void
+    >();
+    const getOptions = vi.fn(
+      (query: string) =>
+        new Promise<ReadonlyArray<{id: string; label: string}>>(resolve => {
+          resolvers.set(query, resolve);
+        })
+    );
+    const onResultsStateChange = vi.fn();
+    const {root, cleanup} = renderWidget({
+      minQueryLength: 1,
+      getOptions,
+      onResultsStateChange
+    });
+
+    const input = root.querySelector('input[aria-label="OmniBox"]') as HTMLInputElement;
+    await act(async () => {
+      input.focus();
+      input.dispatchEvent(new FocusEvent('focus', {bubbles: false}));
+      input.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
+      input.value = 'alpha';
+      input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      input.value = 'beta';
+      input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      resolvers.get('alpha')?.([{id: 'alpha', label: 'Alpha item'}]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(root.querySelector('button[role="option"]')).toBeNull();
+    expect(onResultsStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: 'beta',
+        options: [],
+        isLoading: true
+      })
+    );
+
+    await act(async () => {
+      resolvers.get('beta')?.([{id: 'beta', label: 'Beta item'}]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(root.querySelector('button[role="option"]')?.textContent).toContain('Beta item');
+    expect(onResultsStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: 'beta',
+        options: [expect.objectContaining({id: 'beta'})],
+        isLoading: false
+      })
+    );
+
+    cleanup();
+  });
+
+  it('debounces ordinary searches and reports loading state while typing', async () => {
+    vi.useFakeTimers();
+    const getOptions = vi.fn((query: string) => [{id: query, label: query + ' item'}]);
+    const onResultsStateChange = vi.fn();
+    const {root, cleanup} = renderWidget({
+      minQueryLength: 1,
+      searchDebounceMs: 150,
+      getOptions,
+      onResultsStateChange
+    });
+
+    const input = root.querySelector('input[aria-label="OmniBox"]') as HTMLInputElement;
+    await act(async () => {
+      input.focus();
+      input.dispatchEvent(new FocusEvent('focus', {bubbles: false}));
+      input.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
+      input.value = 'a';
+      input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    });
+    await act(async () => {
+      input.value = 'ab';
+      input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    });
+    await act(async () => {
+      input.value = 'abc';
+      input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    });
+
+    expect(getOptions).not.toHaveBeenCalled();
+    expect(onResultsStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: 'abc',
+        options: [],
+        isLoading: true
+      })
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(149);
+    });
+    expect(getOptions).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getOptions).toHaveBeenCalledOnce();
+    expect(getOptions).toHaveBeenCalledWith('abc');
+    expect(onResultsStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: 'abc',
+        options: [expect.objectContaining({id: 'abc'})],
+        isLoading: false
+      })
+    );
+
+    cleanup();
+  });
+
+  it('reschedules a cancelled debounced search when the input is focused again', async () => {
+    vi.useFakeTimers();
+    const getOptions = vi.fn((query: string) => [{id: query, label: query + ' item'}]);
+    const {root, cleanup} = renderWidget({
+      minQueryLength: 1,
+      searchDebounceMs: 150,
+      getOptions
+    });
+
+    const input = root.querySelector('input[aria-label="OmniBox"]') as HTMLInputElement;
+    await act(async () => {
+      input.focus();
+      input.dispatchEvent(new FocusEvent('focus', {bubbles: false}));
+      input.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
+      input.value = 'alpha';
+      input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    });
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape', bubbles: true}));
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(getOptions).not.toHaveBeenCalled();
+
+    await act(async () => {
+      input.focus();
+      input.dispatchEvent(new FocusEvent('focus', {bubbles: false}));
+      input.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getOptions).toHaveBeenCalledOnce();
+    expect(getOptions).toHaveBeenCalledWith('alpha');
+
+    cleanup();
+  });
+
+  it('keeps command suggestions immediate when search debouncing is enabled', async () => {
+    const commandManager = new CommandManager();
+    commandManager.registerCommand({
+      id: 'view.toggleOverview',
+      label: 'Toggle overview',
+      do: vi.fn()
+    });
+    const getOptions = vi.fn(() => []);
+    const sortOptions = vi.fn((options: ReadonlyArray<OmniBoxOption>) => options);
+    const {root, cleanup} = renderWidget({
+      commandManager,
+      minQueryLength: 1,
+      searchDebounceMs: 150,
+      getOptions,
+      sortOptions
+    });
+
+    const input = root.querySelector('input[aria-label="OmniBox"]') as HTMLInputElement;
+    await act(async () => {
+      input.focus();
+      input.dispatchEvent(new FocusEvent('focus', {bubbles: false}));
+      input.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
+      input.value = '>toggle';
+      input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    });
+    await act(async () => {
+      await new Promise(resolve => window.setTimeout(resolve, 0));
+    });
+
+    expect(getOptions).not.toHaveBeenCalled();
+    expect(sortOptions).not.toHaveBeenCalled();
+    expect(root.querySelector('button[role="option"]')?.textContent).toContain('Toggle overview');
 
     cleanup();
   });

--- a/modules/widgets/src/widgets/omni-box-widget.test.tsx
+++ b/modules/widgets/src/widgets/omni-box-widget.test.tsx
@@ -566,11 +566,10 @@ describe('OmniBoxWidget', () => {
     });
 
     expect(getOptions).not.toHaveBeenCalled();
+    expect(document.activeElement).not.toBe(input);
 
     await act(async () => {
       input.focus();
-      input.dispatchEvent(new FocusEvent('focus', {bubbles: false}));
-      input.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
     });
     await act(async () => {
       vi.advanceTimersByTime(150);

--- a/modules/widgets/src/widgets/omni-box-widget.tsx
+++ b/modules/widgets/src/widgets/omni-box-widget.tsx
@@ -1069,6 +1069,7 @@ function OmniBoxWidgetView({
           requestVersionRef.current += 1;
           setIsLoading(false);
           setIsFocused(false);
+          inputRef.current?.blur();
           setIsQueryHistoryOpen(false);
           setActiveOptionIndex(-1);
           return;

--- a/modules/widgets/src/widgets/omni-box-widget.tsx
+++ b/modules/widgets/src/widgets/omni-box-widget.tsx
@@ -283,6 +283,11 @@ export type OmniBoxOptionProvider =
   | ((query: string) => Promise<ReadonlyArray<OmniBoxOption>>)
   | ((query: string) => ReadonlyArray<OmniBoxOption>);
 
+/** Reorders or bounds caller-provided search options before they are displayed. */
+export type OmniBoxOptionSorter = (
+  options: ReadonlyArray<OmniBoxOption>
+) => ReadonlyArray<OmniBoxOption>;
+
 export type OmniBoxRenderOptionArgs = {
   option: OmniBoxOption;
   index: number;
@@ -299,10 +304,28 @@ export type OmniBoxResultsSummaryArgs = {
   readonly mode: 'search' | 'command' | 'history';
 };
 
+/** Current result/dropdown state emitted to callers that coordinate external UI. */
+export type OmniBoxResultsState = {
+  /** Current trimmed query used to produce the visible dropdown options. */
+  readonly query: string;
+  /** Options currently rendered in the dropdown. */
+  readonly options: ReadonlyArray<OmniBoxOption>;
+  /** Dropdown mode that produced the visible options. */
+  readonly mode: 'search' | 'command' | 'history';
+  /** Whether async option loading is still in progress for the current query. */
+  readonly isLoading: boolean;
+  /** Whether the result dropdown is currently visible. */
+  readonly isOpen: boolean;
+};
+
 export type OmniBoxWidgetProps = WidgetProps & {
   placement?: WidgetPlacement;
   placeholder?: string;
   minQueryLength?: number;
+  /** Idle delay before loading non-command search options. */
+  searchDebounceMs?: number;
+  /** Stable identity that reruns the current query when its backing search data changes. */
+  searchRefreshKey?: unknown;
   defaultOpen?: boolean;
   /** Whether selecting a suggestion should close the dropdown and copy the selected label into the input. */
   closeOnSelect?: boolean;
@@ -320,6 +343,8 @@ export type OmniBoxWidgetProps = WidgetProps & {
   /** Query prefix that switches the omnibox from search mode into command mode. */
   commandSearchPrefix?: string;
   getOptions?: OmniBoxOptionProvider;
+  /** Reorders or bounds ordinary search results without affecting command or history options. */
+  sortOptions?: OmniBoxOptionSorter;
   renderOption?: (args: OmniBoxRenderOptionArgs) => ComponentChildren;
   /** Optional renderer for a compact row above the current dropdown results. */
   renderResultsSummary?: (args: OmniBoxResultsSummaryArgs) => ComponentChildren;
@@ -327,6 +352,8 @@ export type OmniBoxWidgetProps = WidgetProps & {
   onActiveOptionChange?: (option: OmniBoxOption | null) => void;
   onNavigateOption?: (option: OmniBoxOption) => void;
   onQueryChange?: (query: string) => void;
+  /** Called when the visible dropdown result state changes. */
+  onResultsStateChange?: (state: OmniBoxResultsState) => void;
 };
 
 type OmniBoxWidgetViewProps = {
@@ -334,6 +361,10 @@ type OmniBoxWidgetViewProps = {
   placeholder: string;
   /** Minimum trimmed query length required before suggestions are loaded. */
   minQueryLength: number;
+  /** Idle delay before loading non-command search options. */
+  searchDebounceMs: number;
+  /** Stable identity that reruns the current query when its backing search data changes. */
+  searchRefreshKey?: unknown;
   /** Whether the input row is open when the widget first renders. */
   defaultOpen: boolean;
   /** Whether selecting a suggestion should close the dropdown and copy the selected label into the input. */
@@ -352,6 +383,8 @@ type OmniBoxWidgetViewProps = {
   commandSearchPrefix: string;
   /** Provides suggestion options for the current trimmed query. */
   getOptions: OmniBoxOptionProvider;
+  /** Reorders or bounds ordinary search results without affecting command or history options. */
+  sortOptions?: OmniBoxOptionSorter;
   /** Custom renderer for a suggestion row. */
   renderOption?: (args: OmniBoxRenderOptionArgs) => ComponentChildren;
   /** Optional renderer for a compact row above the current dropdown results. */
@@ -364,6 +397,8 @@ type OmniBoxWidgetViewProps = {
   onNavigateOption?: (option: OmniBoxOption) => void;
   /** Called whenever the input query changes. */
   onQueryChange?: (query: string) => void;
+  /** Called when the visible dropdown result state changes. */
+  onResultsStateChange?: (state: OmniBoxResultsState) => void;
 };
 
 /** Returns whether an omnibox query should use command suggestions. */
@@ -478,6 +513,11 @@ function getCommandOptions(
     }));
 }
 
+/** Returns a safe non-negative search debounce delay. */
+function normalizeSearchDebounceMs(searchDebounceMs: number): number {
+  return Number.isFinite(searchDebounceMs) ? Math.max(0, searchDebounceMs) : 0;
+}
+
 function DefaultOptionContent({option}: {option: OmniBoxOption}) {
   return (
     <div style={DEFAULT_OPTION_CONTENT_STYLE}>
@@ -559,6 +599,8 @@ function OmniBoxWidgetStyles() {
 function OmniBoxWidgetView({
   placeholder,
   minQueryLength,
+  searchDebounceMs,
+  searchRefreshKey,
   defaultOpen,
   closeOnSelect,
   rememberQueries,
@@ -568,17 +610,21 @@ function OmniBoxWidgetView({
   commandManager,
   commandSearchPrefix,
   getOptions,
+  sortOptions,
   renderOption,
   renderResultsSummary,
   onSelectOption,
   onActiveOptionChange,
   onNavigateOption,
-  onQueryChange
+  onQueryChange,
+  onResultsStateChange
 }: OmniBoxWidgetViewProps) {
   const [query, setQuery] = useState('');
   const [options, setOptions] = useState<ReadonlyArray<OmniBoxOption>>([]);
+  const [resolvedOptionsQuery, setResolvedOptionsQuery] = useState<string | null>('');
   const [activeOptionIndex, setActiveOptionIndex] = useState<number>(-1);
   const [isLoading, setIsLoading] = useState(false);
+  const [searchRefreshVersion, setSearchRefreshVersion] = useState(0);
   const [isFocused, setIsFocused] = useState(false);
   const [isHidden, setIsHidden] = useState(() => !defaultOpen);
   const [isQueryHistoryOpen, setIsQueryHistoryOpen] = useState(false);
@@ -590,7 +636,16 @@ function OmniBoxWidgetView({
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   const optionElementRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const requestVersionRef = useRef(0);
+  const searchDebounceTimeoutRef = useRef<number | null>(null);
   const blurTimeoutRef = useRef<number | null>(null);
+  const normalizedQuery = query.trim();
+
+  const clearSearchDebounceTimeout = useCallback(() => {
+    if (searchDebounceTimeoutRef.current !== null) {
+      window.clearTimeout(searchDebounceTimeoutRef.current);
+      searchDebounceTimeoutRef.current = null;
+    }
+  }, []);
 
   const clearBlurTimeout = useCallback(() => {
     if (blurTimeoutRef.current !== null) {
@@ -599,11 +654,24 @@ function OmniBoxWidgetView({
     }
   }, []);
 
+  const refreshCurrentQuery = useCallback(() => {
+    if (
+      normalizedQuery.length >= minQueryLength &&
+      resolvedOptionsQuery !== normalizedQuery &&
+      !isLoading &&
+      searchDebounceTimeoutRef.current === null
+    ) {
+      setSearchRefreshVersion(version => version + 1);
+    }
+  }, [isLoading, minQueryLength, normalizedQuery, resolvedOptionsQuery]);
+
   useEffect(() => {
     return () => {
       clearBlurTimeout();
+      clearSearchDebounceTimeout();
+      requestVersionRef.current += 1;
     };
-  }, [clearBlurTimeout]);
+  }, [clearBlurTimeout, clearSearchDebounceTimeout]);
 
   const handleShow = useCallback(
     (event?: Event) => {
@@ -652,10 +720,14 @@ function OmniBoxWidgetView({
 
   useEffect(() => {
     onQueryChange?.(query);
+  }, [onQueryChange, query]);
 
-    const normalizedQuery = query.trim();
+  useEffect(() => {
+    clearSearchDebounceTimeout();
     if (normalizedQuery.length < minQueryLength) {
+      requestVersionRef.current += 1;
       setOptions([]);
+      setResolvedOptionsQuery(normalizedQuery);
       setActiveOptionIndex(-1);
       setIsLoading(false);
       return;
@@ -663,34 +735,82 @@ function OmniBoxWidgetView({
 
     const requestVersion = requestVersionRef.current + 1;
     requestVersionRef.current = requestVersion;
+    setOptions([]);
+    setResolvedOptionsQuery(null);
+    setActiveOptionIndex(-1);
     setIsLoading(true);
 
-    const nextOptions =
+    const isCommandSearch = Boolean(
       commandManager && isCommandQuery(normalizedQuery, commandManager, commandSearchPrefix)
-        ? getCommandOptions(commandManager, normalizedQuery, commandSearchPrefix)
-        : getOptions(normalizedQuery);
-
-    Promise.resolve(nextOptions)
-      .then(nextOptions => {
-        if (requestVersionRef.current !== requestVersion) {
-          return;
-        }
-        setOptions(nextOptions);
-        setActiveOptionIndex(nextOptions.length > 0 ? 0 : -1);
-      })
-      .catch(() => {
-        if (requestVersionRef.current !== requestVersion) {
-          return;
-        }
-        setOptions([]);
-        setActiveOptionIndex(-1);
-      })
-      .finally(() => {
+    );
+    const loadOptions = () => {
+      let nextOptions: ReadonlyArray<OmniBoxOption> | Promise<ReadonlyArray<OmniBoxOption>>;
+      try {
+        nextOptions =
+          isCommandSearch && commandManager
+            ? getCommandOptions(commandManager, normalizedQuery, commandSearchPrefix)
+            : getOptions(normalizedQuery);
+      } catch {
         if (requestVersionRef.current === requestVersion) {
+          setOptions([]);
+          setResolvedOptionsQuery(normalizedQuery);
+          setActiveOptionIndex(-1);
           setIsLoading(false);
         }
-      });
-  }, [commandManager, commandSearchPrefix, getOptions, minQueryLength, onQueryChange, query]);
+        return;
+      }
+
+      Promise.resolve(nextOptions)
+        .then(nextOptions => {
+          if (requestVersionRef.current !== requestVersion) {
+            return;
+          }
+          const visibleOptions =
+            isCommandSearch || !sortOptions ? nextOptions : sortOptions(nextOptions);
+          setOptions(visibleOptions);
+          setResolvedOptionsQuery(normalizedQuery);
+          setActiveOptionIndex(visibleOptions.length > 0 ? 0 : -1);
+        })
+        .catch(() => {
+          if (requestVersionRef.current !== requestVersion) {
+            return;
+          }
+          setOptions([]);
+          setResolvedOptionsQuery(normalizedQuery);
+          setActiveOptionIndex(-1);
+        })
+        .finally(() => {
+          if (requestVersionRef.current === requestVersion) {
+            setIsLoading(false);
+          }
+        });
+    };
+
+    const normalizedSearchDebounceMs = normalizeSearchDebounceMs(searchDebounceMs);
+    if (isCommandSearch || normalizedSearchDebounceMs === 0) {
+      loadOptions();
+      return;
+    }
+
+    searchDebounceTimeoutRef.current = window.setTimeout(() => {
+      searchDebounceTimeoutRef.current = null;
+      loadOptions();
+    }, normalizedSearchDebounceMs);
+
+    return clearSearchDebounceTimeout;
+  }, [
+    clearSearchDebounceTimeout,
+    commandManager,
+    commandSearchPrefix,
+    getOptions,
+    minQueryLength,
+    normalizedQuery,
+    query,
+    searchDebounceMs,
+    searchRefreshKey,
+    searchRefreshVersion,
+    sortOptions
+  ]);
 
   useEffect(() => {
     if (isQueryHistoryOpen) {
@@ -839,16 +959,18 @@ function OmniBoxWidgetView({
 
       clearBlurTimeout();
       rememberQuery(query);
+      clearSearchDebounceTimeout();
       requestVersionRef.current += 1;
       setQuery('');
       setOptions([]);
+      setResolvedOptionsQuery('');
       setActiveOptionIndex(-1);
       setIsLoading(false);
       setIsFocused(false);
       setIsQueryHistoryOpen(false);
       setIsHidden(true);
     },
-    [clearBlurTimeout, query, rememberQuery]
+    [clearBlurTimeout, clearSearchDebounceTimeout, query, rememberQuery]
   );
 
   const handleInput: JSX.GenericEventHandler<HTMLInputElement> = useCallback(event => {
@@ -861,7 +983,8 @@ function OmniBoxWidgetView({
   const handleFocus: JSX.FocusEventHandler<HTMLInputElement> = useCallback(() => {
     clearBlurTimeout();
     setIsFocused(true);
-  }, [clearBlurTimeout]);
+    refreshCurrentQuery();
+  }, [clearBlurTimeout, refreshCurrentQuery]);
 
   const handleBlur: JSX.FocusEventHandler<HTMLInputElement> = useCallback(() => {
     clearBlurTimeout();
@@ -873,7 +996,6 @@ function OmniBoxWidgetView({
 
   const hasMatches = options.length > 0;
   const hasQueryHistory = queryHistoryOptions.length > 0;
-  const normalizedQuery = query.trim();
   const dropdownMode: OmniBoxResultsSummaryArgs['mode'] = isShowingQueryHistory
     ? 'history'
     : isCommandQuery(normalizedQuery, commandManager, commandSearchPrefix)
@@ -891,6 +1013,23 @@ function OmniBoxWidgetView({
     !isHidden &&
     (isShowingQueryHistory ||
       (isFocused && normalizedQuery.length >= minQueryLength && (isLoading || options.length > 0)));
+
+  useEffect(() => {
+    onResultsStateChange?.({
+      query: normalizedQuery,
+      options: visibleOptions,
+      mode: dropdownMode,
+      isLoading,
+      isOpen: shouldShowDropdown
+    });
+  }, [
+    dropdownMode,
+    isLoading,
+    normalizedQuery,
+    onResultsStateChange,
+    shouldShowDropdown,
+    visibleOptions
+  ]);
 
   const handleKeyDown: JSX.KeyboardEventHandler<HTMLInputElement> = useCallback(
     event => {
@@ -926,6 +1065,7 @@ function OmniBoxWidgetView({
       if (event.key === 'Escape') {
         event.preventDefault();
         if (isShowingQueryHistory || shouldShowDropdown) {
+          clearSearchDebounceTimeout();
           requestVersionRef.current += 1;
           setIsLoading(false);
           setIsFocused(false);
@@ -938,6 +1078,7 @@ function OmniBoxWidgetView({
     },
     [
       activeOptionIndex,
+      clearSearchDebounceTimeout,
       handleHide,
       isShowingQueryHistory,
       moveActiveOptionBy,
@@ -1252,6 +1393,8 @@ export class OmniBoxWidget extends Widget<OmniBoxWidgetProps> {
     placement: 'top-left',
     placeholder: 'Search…',
     minQueryLength: 1,
+    searchDebounceMs: 0,
+    searchRefreshKey: undefined,
     defaultOpen: true,
     closeOnSelect: true,
     rememberQueries: false,
@@ -1262,12 +1405,14 @@ export class OmniBoxWidget extends Widget<OmniBoxWidgetProps> {
     commandManager: undefined,
     commandSearchPrefix: DEFAULT_COMMAND_SEARCH_PREFIX,
     getOptions: (() => []) as OmniBoxOptionProvider,
+    sortOptions: undefined,
     renderOption: undefined,
     renderResultsSummary: undefined,
     onSelectOption: undefined,
     onActiveOptionChange: undefined,
     onNavigateOption: undefined,
-    onQueryChange: undefined
+    onQueryChange: undefined,
+    onResultsStateChange: undefined
   } satisfies Required<WidgetProps> &
     Required<Pick<OmniBoxWidgetProps, 'placeholder' | 'minQueryLength' | 'placement'>> &
     OmniBoxWidgetProps;
@@ -1311,6 +1456,10 @@ export class OmniBoxWidget extends Widget<OmniBoxWidgetProps> {
       <OmniBoxWidgetView
         placeholder={this.props.placeholder ?? OmniBoxWidget.defaultProps.placeholder}
         minQueryLength={this.props.minQueryLength ?? OmniBoxWidget.defaultProps.minQueryLength}
+        searchDebounceMs={
+          this.props.searchDebounceMs ?? OmniBoxWidget.defaultProps.searchDebounceMs
+        }
+        searchRefreshKey={this.props.searchRefreshKey}
         defaultOpen={this.props.defaultOpen ?? OmniBoxWidget.defaultProps.defaultOpen}
         closeOnSelect={this.props.closeOnSelect ?? OmniBoxWidget.defaultProps.closeOnSelect}
         rememberQueries={this.props.rememberQueries ?? OmniBoxWidget.defaultProps.rememberQueries}
@@ -1326,12 +1475,14 @@ export class OmniBoxWidget extends Widget<OmniBoxWidgetProps> {
           this.props.commandSearchPrefix ?? OmniBoxWidget.defaultProps.commandSearchPrefix
         }
         getOptions={this.props.getOptions ?? OmniBoxWidget.defaultProps.getOptions}
+        sortOptions={this.props.sortOptions}
         renderOption={this.props.renderOption}
         renderResultsSummary={this.props.renderResultsSummary}
         onSelectOption={this.props.onSelectOption}
         onActiveOptionChange={this.props.onActiveOptionChange}
         onNavigateOption={this.props.onNavigateOption}
         onQueryChange={this.props.onQueryChange}
+        onResultsStateChange={this.props.onResultsStateChange}
       />,
       rootElement
     );


### PR DESCRIPTION
## Summary

- add debounced async option loading for ordinary OmniBox searches
- reject stale async results and rerun active searches when backing data changes
- let callers sort or bound ordinary results and observe dropdown/loading state

## Behavior

- `searchDebounceMs` delays ordinary search providers, while command-mode suggestions remain immediate
- `searchRefreshKey` reruns the current eligible query when caller-owned search data changes
- `sortOptions` transforms only ordinary search results, so command and history options keep their existing behavior
- `onResultsStateChange` reports query, visible options, mode, loading state, and dropdown visibility
- cancelled debounced searches resume when the input is focused again

## Validation

- `yarn lint-fix`
- `yarn vitest run --project headless modules/widgets/src/widgets/omni-box-widget.test.tsx` (17 passed)
- `npx tspc --noEmit --project modules/widgets/tsconfig.json`
- `yarn test` (612 passed, 9 skipped)
- `git diff --check`

## Notes

- Repository-wide `yarn build` compiled the widgets package, then the existing trailing Lerna project-graph step stalled in this local environment.
- The website build is blocked by the current website lockfile missing its workspace entry; this PR does not change dependencies or lockfiles.
