### PR TITLE
Edit completed ranges in TimeMeasureWidget

### DIFF
--- a/docs/modules/widgets/api-reference/time-measure-widget.md
+++ b/docs/modules/widgets/api-reference/time-measure-widget.md
@@ -4,7 +4,7 @@
   <img src="https://img.shields.io/badge/from-v9.3-green.svg?style=flat-square" alt="from v9.3" />
 </p>
 
-`TimeMeasureWidget` is an interactive measurement widget for selecting a time range directly from a deck trace view.
+`TimeMeasureWidget` is an interactive measurement widget for selecting a time range directly from a time-oriented deck view.
 
 ## Import
 
@@ -22,6 +22,8 @@ type TimeMeasureSelectionState = {
   cursorTimeMs: number | null;
   draftStartTimeMs: number | null;
   range: TimeMeasureRange | null;
+  hoveredBoundary?: 'start' | 'end' | null;
+  adjustingBoundary?: 'start' | 'end' | null;
 };
 ```
 
@@ -67,6 +69,9 @@ The selected range can be rendered or visualized further with `TimeMeasureLayer`
 - Renders a toolbar button for entering measurement mode.
 - Supports click-based two-step range selection.
 - Supports Shift-drag selection directly in the target view.
-- Emits incremental selection state updates while the user is dragging or hovering.
-- Cancels on `Escape`.
+- Supports dragging either boundary of a completed range without a modifier key.
+- Emits incremental selection state updates while the user is dragging or hovering; `onRangeChange`
+  fires only when a completed range is committed or cleared.
+- Cancels new selections on `Escape` and restores the previous range when boundary adjustment is
+  canceled.
 - Tracks separate event and projection views so input and coordinate projection can be decoupled.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -100,6 +100,8 @@ Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community
 - `OmniBoxWidget` now accepts shared command manager search prefixes for command-mode integrations.
 - `ModalPanelWidget` inherits floating, draggable, custom-styled modal support from `ModalPanelContainer`.
 - `createStudioSettingsWidget` and `updateStudioSettingsWidget` now host the shared Studio settings panel through deck widget chrome.
+- `TimeMeasureWidget` now lets users hover and drag either boundary of a completed range, with
+  provisional selection updates and cancellation that restores the previous range.
 
 ### `@deck.gl-community/panels` (NEW module)
 

--- a/modules/widgets/src/widgets/time-measure-widget.test.tsx
+++ b/modules/widgets/src/widgets/time-measure-widget.test.tsx
@@ -222,13 +222,13 @@ describe('TimeMeasureWidget boundary editing', () => {
     selectRange(widget, 100, 250);
     onSelectionChange.mockClear();
 
-    const leftPanStart = createGestureEvent({}, {x: 100, y: 100});
-    eventManager.handlers.get('panstart')?.(leftPanStart);
+    const pointerMovePanStart = createGestureEvent({button: -1, buttons: 1}, {x: 100, y: 100});
+    eventManager.handlers.get('panstart')?.(pointerMovePanStart);
 
     expect(eventManager.handlerOptions.get('panstart')?.priority).toBeGreaterThan(0);
-    expect(leftPanStart.preventDefault).toHaveBeenCalledTimes(1);
-    expect(leftPanStart.stopImmediatePropagation).toHaveBeenCalledTimes(1);
-    expect(leftPanStart.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(pointerMovePanStart.preventDefault).toHaveBeenCalledTimes(1);
+    expect(pointerMovePanStart.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    expect(pointerMovePanStart.stopPropagation).toHaveBeenCalledTimes(1);
 
     widget.onDragEnd(createPickingInfo(100), createGestureEvent({}, {x: 100, y: 100}) as never);
     onSelectionChange.mockClear();

--- a/modules/widgets/src/widgets/time-measure-widget.test.tsx
+++ b/modules/widgets/src/widgets/time-measure-widget.test.tsx
@@ -1,0 +1,277 @@
+import {describe, expect, it, vi} from 'vitest';
+
+import {TimeMeasureWidget} from './time-measure-widget';
+
+import type {PickingInfo, Viewport} from '@deck.gl/core';
+import type {EventManager} from 'mjolnir.js';
+
+type EventManagerHandler = (event: ReturnType<typeof createGestureEvent>) => void;
+type EventHandlerOptions = {priority?: number; srcElement?: 'root' | HTMLElement};
+
+/** Minimal event manager used to exercise widget-owned gesture listeners. */
+class TestEventManager {
+  handlers = new Map<string, EventManagerHandler>();
+  handlerOptions = new Map<string, EventHandlerOptions>();
+
+  /** Creates an event manager with the supplied root element. */
+  constructor(private readonly element: HTMLElement) {}
+
+  /** Returns the root element used by gesture registration. */
+  getElement(): HTMLElement {
+    return this.element;
+  }
+
+  /** Registers one event handler and its options. */
+  on(eventName: string, handler: EventManagerHandler, options: EventHandlerOptions = {}) {
+    this.handlers.set(eventName, handler);
+    this.handlerOptions.set(eventName, options);
+  }
+
+  /** Unregisters one event handler. */
+  off(eventName: string, handler: EventManagerHandler) {
+    if (this.handlers.get(eventName) === handler) {
+      this.handlers.delete(eventName);
+      this.handlerOptions.delete(eventName);
+    }
+  }
+}
+
+/** Returns a linear viewport whose x coordinate is the measured time. */
+function createViewport(): Viewport {
+  return {
+    id: 'main',
+    x: 0,
+    project: ([x]: number[]) => [x, 0],
+    unproject: ([x]: number[]) => [x, 0],
+    containsPixel: ({x, y}: {x: number; y: number}) => x >= 0 && x <= 1000 && y >= 0 && y <= 1000
+  } as unknown as Viewport;
+}
+
+/** Returns picking data at one time coordinate. */
+function createPickingInfo(timeMs: number): PickingInfo {
+  return {
+    coordinate: [timeMs, 0, 0],
+    viewport: createViewport()
+  } as PickingInfo;
+}
+
+/** Returns a minimal pointer gesture for widget interaction tests. */
+function createGestureEvent(
+  pointerState: Partial<
+    Pick<MouseEvent, 'altKey' | 'button' | 'buttons' | 'ctrlKey' | 'metaKey' | 'shiftKey'>
+  > = {},
+  position = {x: 0, y: 0}
+) {
+  return {
+    preventDefault: vi.fn(),
+    stopImmediatePropagation: vi.fn(),
+    stopPropagation: vi.fn(),
+    srcEvent: {
+      button: 0,
+      buttons: 0,
+      shiftKey: false,
+      ...pointerState
+    },
+    center: position,
+    offsetCenter: position
+  };
+}
+
+/** Creates a mounted widget with observable callbacks and a fake deck root. */
+function createWidget() {
+  const canvas = document.createElement('canvas');
+  const eventRoot = document.createElement('div');
+  eventRoot.appendChild(canvas);
+  const eventManager = new TestEventManager(eventRoot);
+  const viewport = createViewport();
+  const onActivate = vi.fn();
+  const onDeactivate = vi.fn();
+  const onRangeChange = vi.fn();
+  const onSelectionChange = vi.fn();
+  const widget = new TimeMeasureWidget({
+    eventViewId: 'main',
+    projectionViewId: 'main',
+    onActivate,
+    onDeactivate,
+    onRangeChange,
+    onSelectionChange
+  });
+  const deck = {
+    eventManager,
+    getCanvas: () => canvas,
+    getViewports: () => [viewport],
+    isInitialized: true
+  } as unknown as {eventManager: EventManager};
+  (widget as unknown as {deck: typeof deck}).deck = deck;
+  const root = widget.onAdd({deck: deck as never, viewId: null}) as HTMLDivElement;
+  document.body.appendChild(root);
+
+  return {
+    eventManager,
+    onActivate,
+    onDeactivate,
+    onRangeChange,
+    onSelectionChange,
+    widget,
+    cleanup() {
+      widget.onRemove();
+      root.remove();
+    }
+  };
+}
+
+/** Selects and commits one initial time range. */
+function selectRange(widget: TimeMeasureWidget, startTimeMs: number, endTimeMs: number) {
+  TimeMeasureWidget.performAction({widget});
+  widget.onClick(createPickingInfo(startTimeMs), createGestureEvent() as never);
+  widget.onClick(createPickingInfo(endTimeMs), createGestureEvent() as never);
+}
+
+describe('TimeMeasureWidget boundary editing', () => {
+  it('reports nearby completed boundaries without changing activation callbacks', () => {
+    const {onActivate, onDeactivate, onSelectionChange, widget, cleanup} = createWidget();
+    selectRange(widget, 100, 250);
+    onActivate.mockClear();
+    onDeactivate.mockClear();
+    onSelectionChange.mockClear();
+
+    widget.onHover(createPickingInfo(102), createGestureEvent() as never);
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({hoveredBoundary: 'start', adjustingBoundary: null})
+    );
+    expect(onActivate).not.toHaveBeenCalled();
+    expect(onDeactivate).not.toHaveBeenCalled();
+
+    widget.onHover(createPickingInfo(180), createGestureEvent() as never);
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({hoveredBoundary: null, adjustingBoundary: null})
+    );
+
+    cleanup();
+  });
+
+  it('remeasures either completed boundary and commits only after drag end', () => {
+    const {onRangeChange, widget, cleanup} = createWidget();
+    selectRange(widget, 100, 250);
+    onRangeChange.mockClear();
+
+    widget.onDragStart(createPickingInfo(100), createGestureEvent() as never);
+    widget.onDrag(createPickingInfo(125), createGestureEvent({}, {x: 125, y: 0}) as never);
+
+    expect(onRangeChange).not.toHaveBeenCalled();
+
+    widget.onDragEnd(createPickingInfo(125), createGestureEvent({}, {x: 125, y: 0}) as never);
+
+    expect(onRangeChange).toHaveBeenLastCalledWith({startTimeMs: 125, endTimeMs: 250});
+
+    widget.onDragStart(createPickingInfo(250), createGestureEvent() as never);
+    widget.onDragEnd(createPickingInfo(300), createGestureEvent({}, {x: 300, y: 0}) as never);
+
+    expect(onRangeChange).toHaveBeenLastCalledWith({startTimeMs: 125, endTimeMs: 300});
+
+    cleanup();
+  });
+
+  it('uses current gesture positions when picking data is stale', () => {
+    const {onRangeChange, onSelectionChange, widget, cleanup} = createWidget();
+    selectRange(widget, 100, 250);
+    const pointerDownPickingInfo = createPickingInfo(100);
+
+    widget.onDragStart(pointerDownPickingInfo, createGestureEvent() as never);
+    widget.onDrag(pointerDownPickingInfo, createGestureEvent({}, {x: 125, y: 0}) as never);
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({adjustingBoundary: 'start', cursorTimeMs: 125})
+    );
+
+    widget.onDragEnd(pointerDownPickingInfo, createGestureEvent({}, {x: 160, y: 0}) as never);
+
+    expect(onRangeChange).toHaveBeenLastCalledWith({startTimeMs: 160, endTimeMs: 250});
+
+    cleanup();
+  });
+
+  it('restores the completed range when boundary adjustment is cancelled', () => {
+    const {eventManager, onRangeChange, onSelectionChange, widget, cleanup} = createWidget();
+    selectRange(widget, 100, 250);
+    onRangeChange.mockClear();
+
+    widget.onDragStart(createPickingInfo(250), createGestureEvent() as never);
+    widget.onDrag(createPickingInfo(300), createGestureEvent({}, {x: 300, y: 0}) as never);
+    eventManager.handlers.get('keydown')?.({
+      ...createGestureEvent(),
+      srcEvent: {key: 'Escape'}
+    } as never);
+
+    expect(onRangeChange).not.toHaveBeenCalled();
+    expect(onSelectionChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        phase: 'selected',
+        range: {startTimeMs: 100, endTimeMs: 250},
+        adjustingBoundary: null
+      })
+    );
+
+    cleanup();
+  });
+
+  it('intercepts primary boundary pans and preserves modified or alternate-button pans', () => {
+    const {eventManager, onSelectionChange, widget, cleanup} = createWidget();
+    selectRange(widget, 100, 250);
+    onSelectionChange.mockClear();
+
+    const leftPanStart = createGestureEvent({}, {x: 100, y: 100});
+    eventManager.handlers.get('panstart')?.(leftPanStart);
+
+    expect(eventManager.handlerOptions.get('panstart')?.priority).toBeGreaterThan(0);
+    expect(leftPanStart.preventDefault).toHaveBeenCalledTimes(1);
+    expect(leftPanStart.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    expect(leftPanStart.stopPropagation).toHaveBeenCalledTimes(1);
+
+    widget.onDragEnd(createPickingInfo(100), createGestureEvent({}, {x: 100, y: 100}) as never);
+    onSelectionChange.mockClear();
+
+    const rightPanStart = {
+      ...createGestureEvent({button: 2}, {x: 100, y: 100}),
+      rightButton: true
+    };
+    eventManager.handlers.get('panstart')?.(rightPanStart);
+
+    expect(rightPanStart.preventDefault).not.toHaveBeenCalled();
+    expect(rightPanStart.stopImmediatePropagation).not.toHaveBeenCalled();
+    expect(onSelectionChange).not.toHaveBeenCalled();
+
+    for (const pointerState of [
+      {button: 1, buttons: 4},
+      {altKey: true},
+      {ctrlKey: true},
+      {metaKey: true}
+    ]) {
+      const panStart = createGestureEvent(pointerState, {x: 100, y: 100});
+      eventManager.handlers.get('panstart')?.(panStart);
+
+      expect(panStart.preventDefault).not.toHaveBeenCalled();
+      expect(panStart.stopImmediatePropagation).not.toHaveBeenCalled();
+
+      widget.onDragStart(createPickingInfo(100), panStart as never);
+
+      expect(onSelectionChange).not.toHaveBeenCalled();
+    }
+
+    const shiftPanStart = createGestureEvent({shiftKey: true}, {x: 100, y: 100});
+    eventManager.handlers.get('panstart')?.(shiftPanStart);
+
+    expect(shiftPanStart.preventDefault).not.toHaveBeenCalled();
+    expect(shiftPanStart.stopImmediatePropagation).not.toHaveBeenCalled();
+
+    widget.onDragStart(createPickingInfo(100), shiftPanStart as never);
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({phase: 'selecting-end', adjustingBoundary: null, range: null})
+    );
+
+    cleanup();
+  });
+});

--- a/modules/widgets/src/widgets/time-measure-widget.tsx
+++ b/modules/widgets/src/widgets/time-measure-widget.tsx
@@ -516,12 +516,16 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     ) {
       return false;
     }
-    const button = srcEvent && 'button' in srcEvent ? srcEvent.button : null;
-    if (typeof button === 'number' && button !== 0) {
+    const buttons = srcEvent && 'buttons' in srcEvent ? srcEvent.buttons : null;
+    if (typeof buttons === 'number' && (buttons & ~1) !== 0) {
       return false;
     }
-    const buttons = srcEvent && 'buttons' in srcEvent ? srcEvent.buttons : null;
-    return typeof buttons !== 'number' || (buttons & ~1) === 0;
+    const button = srcEvent && 'button' in srcEvent ? srcEvent.button : null;
+    if (typeof button !== 'number' || button === 0) {
+      return true;
+    }
+    // PointerEvent panstart may originate from pointermove, where button is -1.
+    return button === -1 && buttons === 1;
   }
 
   #shouldHandleEvent(info: PickingInfo): boolean {

--- a/modules/widgets/src/widgets/time-measure-widget.tsx
+++ b/modules/widgets/src/widgets/time-measure-widget.tsx
@@ -12,6 +12,9 @@ import type {
   MjolnirPointerEvent
 } from 'mjolnir.js';
 
+const RANGE_BOUNDARY_DRAG_RADIUS_PX = 8;
+const RANGE_BOUNDARY_PAN_INTERCEPT_PRIORITY = 100;
+
 /** Absolute time range selected by the time-measure widget. */
 export type TimeMeasureRange = {
   /** Start timestamp of the measured range in milliseconds. */
@@ -58,9 +61,13 @@ export type TimeMeasureSelectionState = {
   draftStartTimeMs: number | null;
   /** Completed selected time range, or null when none is selected. */
   range: TimeMeasureRange | null;
+  /** Completed range boundary currently under the pointer. */
+  hoveredBoundary?: 'start' | 'end' | null;
+  /** Completed range boundary currently being repositioned. */
+  adjustingBoundary?: 'start' | 'end' | null;
 };
 
-/** Deck widget that lets users measure a time range by interacting with a trace view. */
+/** Deck widget that lets users measure a time range by interacting with a time-oriented view. */
 export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
   static defaultProps: Required<TimeMeasureWidgetProps> = {
     ...Widget.defaultProps,
@@ -96,6 +103,12 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
   #projectionViewId: string | null = null;
   #eventManager?: EventManager | null;
   #dragSelecting = false;
+  /** Completed boundary currently under the pointer. */
+  #hoveredBoundary: 'start' | 'end' | null = null;
+  /** Completed boundary currently being repositioned. */
+  #adjustingBoundary: 'start' | 'end' | null = null;
+  /** Completed range to restore when adjusting one boundary is cancelled. */
+  #rangeBeforeAdjustment: TimeMeasureRange | null = null;
   /** Command id registered for toggling the measure-time interaction. */
   commandId = TimeMeasureWidget.defaultProps.commandId;
 
@@ -127,7 +140,7 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     // @ts-expect-error accessing protected member
     // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
     const eventManager = deck?.eventManager!;
-    this.#attachEventListeners(eventManager);
+    this.#attachEventListeners(eventManager, deck.getCanvas());
     return this.onCreateRootElement();
   }
 
@@ -153,7 +166,18 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
   }
 
   onHover(info: PickingInfo, event: MjolnirPointerEvent | MjolnirGestureEvent): void {
-    if (!this.#isSelecting() || !this.#shouldHandleEvent(info)) {
+    if (!this.#matchesEventView(info)) {
+      this.#setHoveredBoundary(null);
+      return;
+    }
+
+    if (this.#phase === 'selected') {
+      const timeMs = this.#eventToTimeMs(info, event);
+      this.#setHoveredBoundary(timeMs === null ? null : this.#getAdjustedBoundary(info, timeMs));
+      return;
+    }
+
+    if (!this.#isSelecting()) {
       return;
     }
     const timeMs = this.#eventToTimeMs(info, event);
@@ -208,27 +232,41 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
       return;
     }
     const srcEvent = event?.srcEvent as MouseEvent | PointerEvent | undefined;
-    if (!srcEvent?.shiftKey) {
-      return;
-    }
-    if (srcEvent.button === 2 || event.rightButton) {
+    if (this.#isRightButtonEvent(event)) {
       return;
     }
     const timeMs = this.#eventToTimeMs(info, event);
     if (timeMs === null) {
       return;
     }
-    srcEvent.preventDefault?.();
-    srcEvent.stopPropagation?.();
+
+    const adjustedBoundary = this.#isUnmodifiedPrimaryButtonEvent(event)
+      ? this.#getAdjustedBoundary(info, timeMs)
+      : null;
+    if (adjustedBoundary && this.#timeMeasureRange) {
+      this.#consumeDragEvent(event);
+      this.#dragSelecting = true;
+      this.#beginRangeAdjustment(adjustedBoundary, timeMs);
+      return;
+    }
+
+    if (!srcEvent?.shiftKey) {
+      return;
+    }
+    this.#consumeDragEvent(event);
     this.#dragSelecting = true;
     this.#beginDragSelection(timeMs);
   }
 
   onDrag(info: PickingInfo, event: MjolnirGestureEvent): void {
-    if (!this.#dragSelecting || !this.#matchesEventView(info)) {
+    if (!this.#dragSelecting) {
       return;
     }
-    const timeMs = this.#eventToTimeMs(info, event);
+    this.#consumeDragEvent(event);
+    if (!this.#matchesEventView(info)) {
+      return;
+    }
+    const timeMs = this.#eventToTimeMs(info, event, {preferEventPosition: true});
     if (timeMs === null) {
       return;
     }
@@ -240,12 +278,13 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     if (!this.#dragSelecting) {
       return;
     }
+    this.#consumeDragEvent(event);
     this.#dragSelecting = false;
     if (!this.#matchesEventView(info)) {
       this.#cancelSelection();
       return;
     }
-    const timeMs = this.#eventToTimeMs(info, event);
+    const timeMs = this.#eventToTimeMs(info, event, {preferEventPosition: true});
     if (timeMs === null || this.#draftStartTimeMs === null) {
       this.#cancelSelection();
       return;
@@ -280,7 +319,44 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     }
   };
 
-  #attachEventListeners(eventManager?: EventManager | null) {
+  /** Stops the view controller before async picking dispatches the matching boundary drag. */
+  #handlePanStart = (event: MjolnirGestureEvent) => {
+    if (
+      this.#phase !== 'selected' ||
+      !this.#timeMeasureRange ||
+      !this.#isUnmodifiedPrimaryButtonEvent(event)
+    ) {
+      return;
+    }
+    const center = event.offsetCenter ?? event.center;
+    if (!center || !this.#isEventPointInConfiguredView(center.x, center.y)) {
+      return;
+    }
+    const viewport = this.#getProjectionViewport({} as PickingInfo);
+    if (!viewport) {
+      return;
+    }
+    const cursorX = center.x - viewport.x;
+    const startX = viewport.project([this.#timeMeasureRange.startTimeMs, 0])[0];
+    const endX = viewport.project([this.#timeMeasureRange.endTimeMs, 0])[0];
+    const startDistance = Math.abs(cursorX - startX);
+    const endDistance = Math.abs(cursorX - endX);
+    if (Math.min(startDistance, endDistance) > RANGE_BOUNDARY_DRAG_RADIUS_PX) {
+      return;
+    }
+    const [cursorTimeMs] = viewport.unproject([cursorX, 0]);
+    if (!Number.isFinite(cursorTimeMs)) {
+      return;
+    }
+    this.#consumeDragEvent(event, {stopImmediatePropagation: true});
+    this.#dragSelecting = true;
+    this.#beginRangeAdjustment(startDistance <= endDistance ? 'start' : 'end', cursorTimeMs);
+  };
+
+  #attachEventListeners(
+    eventManager?: EventManager | null,
+    eventSourceElement?: HTMLElement | null
+  ) {
     if (!eventManager) {
       return;
     }
@@ -288,6 +364,13 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     this.#eventManager = eventManager;
     eventManager.on('keydown', this.#handleKeyDown);
     eventManager.on('keyup', this.#handleKeyUp);
+    eventManager.on('panstart', this.#handlePanStart, {
+      priority: RANGE_BOUNDARY_PAN_INTERCEPT_PRIORITY,
+      srcElement:
+        !eventSourceElement || eventManager.getElement() === eventSourceElement
+          ? 'root'
+          : eventSourceElement
+    });
   }
 
   #detachEventListeners() {
@@ -296,6 +379,7 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     }
     this.#eventManager.off('keydown', this.#handleKeyDown);
     this.#eventManager.off('keyup', this.#handleKeyUp);
+    this.#eventManager.off('panstart', this.#handlePanStart);
     this.#eventManager = null;
   }
 
@@ -321,19 +405,123 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     this.#draftStartTimeMs = null;
     this.#cursorTimeMs = null;
     this.#dragSelecting = false;
+    this.#hoveredBoundary = null;
+    this.#adjustingBoundary = null;
+    this.#rangeBeforeAdjustment = null;
     this.props.onActivate?.();
     this.#emitSelectionChange();
     this.updateHTML();
   }
 
   #beginDragSelection(startTimeMs: number) {
+    this.#rangeBeforeAdjustment = null;
     this.#updateRange(null, {suppressEmit: false});
     this.#phase = 'selecting-end';
     this.#draftStartTimeMs = startTimeMs;
     this.#cursorTimeMs = startTimeMs;
+    this.#hoveredBoundary = null;
+    this.#adjustingBoundary = null;
     this.props.onActivate?.();
     this.#emitSelectionChange();
     this.updateHTML();
+  }
+
+  /** Starts a live adjustment while preserving the completed range for cancellation. */
+  #beginRangeAdjustment(boundary: 'start' | 'end', cursorTimeMs: number) {
+    const range = this.#timeMeasureRange;
+    if (!range) {
+      return;
+    }
+    this.#rangeBeforeAdjustment = {...range};
+    this.#phase = 'selecting-end';
+    this.#draftStartTimeMs = boundary === 'start' ? range.endTimeMs : range.startTimeMs;
+    this.#cursorTimeMs = cursorTimeMs;
+    this.#hoveredBoundary = boundary;
+    this.#adjustingBoundary = boundary;
+    this.props.onActivate?.();
+    this.#emitSelectionChange();
+    this.updateHTML();
+  }
+
+  /** Returns the nearest completed range boundary within the fixed screen-space drag radius. */
+  #getAdjustedBoundary(info: PickingInfo, cursorTimeMs: number): 'start' | 'end' | null {
+    const range = this.#timeMeasureRange;
+    const viewport = this.#getProjectionViewport(info);
+    if (!range || !viewport) {
+      return null;
+    }
+    const cursorX = viewport.project([cursorTimeMs, 0])[0];
+    const startX = viewport.project([range.startTimeMs, 0])[0];
+    const endX = viewport.project([range.endTimeMs, 0])[0];
+    const startDistance = Math.abs(cursorX - startX);
+    const endDistance = Math.abs(cursorX - endX);
+    if (Math.min(startDistance, endDistance) > RANGE_BOUNDARY_DRAG_RADIUS_PX) {
+      return null;
+    }
+    return startDistance <= endDistance ? 'start' : 'end';
+  }
+
+  /** Returns whether a root-relative event point belongs to a configured interaction view. */
+  #isEventPointInConfiguredView(x: number, y: number): boolean {
+    const eventViewId = this.#eventViewId;
+    if (!eventViewId) {
+      return true;
+    }
+    const deck = this.deck;
+    if (!deck?.isInitialized) {
+      return false;
+    }
+    const allowedViewIds = Array.isArray(eventViewId) ? eventViewId : [eventViewId];
+    return deck
+      .getViewports()
+      .some(viewport => allowedViewIds.includes(viewport.id) && viewport.containsPixel({x, y}));
+  }
+
+  /** Emits completed-boundary hover changes without affecting ordinary selection callbacks. */
+  #setHoveredBoundary(boundary: 'start' | 'end' | null) {
+    if (boundary === this.#hoveredBoundary || this.#adjustingBoundary) {
+      return;
+    }
+    this.#hoveredBoundary = boundary;
+    this.#emitSelectionChange();
+  }
+
+  /** Consumes a measurement drag before deck.gl's pan controller handles the gesture. */
+  #consumeDragEvent(
+    event: MjolnirGestureEvent,
+    {stopImmediatePropagation = false}: {stopImmediatePropagation?: boolean} = {}
+  ) {
+    event.preventDefault();
+    if (stopImmediatePropagation) {
+      event.stopImmediatePropagation?.();
+    }
+    event.stopPropagation();
+  }
+
+  /** Returns whether a gesture is driven by the secondary pointer button. */
+  #isRightButtonEvent(event: MjolnirGestureEvent): boolean {
+    const srcEvent = event.srcEvent as MouseEvent | PointerEvent | undefined;
+    return Boolean(event.rightButton || srcEvent?.button === 2 || (srcEvent?.buttons ?? 0) & 2);
+  }
+
+  /** Returns whether a gesture is an unmodified primary-button or touch interaction. */
+  #isUnmodifiedPrimaryButtonEvent(event: MjolnirGestureEvent): boolean {
+    const srcEvent = event.srcEvent as MouseEvent | PointerEvent | TouchEvent | undefined;
+    if (
+      this.#isRightButtonEvent(event) ||
+      srcEvent?.altKey ||
+      srcEvent?.ctrlKey ||
+      srcEvent?.metaKey ||
+      srcEvent?.shiftKey
+    ) {
+      return false;
+    }
+    const button = srcEvent && 'button' in srcEvent ? srcEvent.button : null;
+    if (typeof button === 'number' && button !== 0) {
+      return false;
+    }
+    const buttons = srcEvent && 'buttons' in srcEvent ? srcEvent.buttons : null;
+    return typeof buttons !== 'number' || (buttons & ~1) === 0;
   }
 
   #shouldHandleEvent(info: PickingInfo): boolean {
@@ -360,20 +548,25 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
 
   #eventToTimeMs(
     info: PickingInfo,
-    event: MjolnirGestureEvent | MjolnirPointerEvent
+    event: MjolnirGestureEvent | MjolnirPointerEvent,
+    {preferEventPosition = false}: {preferEventPosition?: boolean} = {}
   ): number | null {
     const projectionViewport = this.#getProjectionViewport(info);
     if (!projectionViewport) {
       return null;
     }
-    if (info.coordinate && Number.isFinite(info.coordinate[0])) {
-      if (!projectionViewport.id || info.viewport?.id === projectionViewport.id) {
-        return info.coordinate[0] as number;
-      }
+    const pickingCoordinate =
+      info.coordinate &&
+      Number.isFinite(info.coordinate[0]) &&
+      (!projectionViewport.id || info.viewport?.id === projectionViewport.id)
+        ? (info.coordinate[0] as number)
+        : null;
+    if (!preferEventPosition && pickingCoordinate !== null) {
+      return pickingCoordinate;
     }
     const center = (event as any).offsetCenter ?? (event as any).center;
     if (!center) {
-      return null;
+      return pickingCoordinate;
     }
     const x = 'x' in center ? center.x : Array.isArray(center) ? center[0] : null;
     if (typeof x !== 'number') {
@@ -381,7 +574,7 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     }
     const offsetX: number = x - projectionViewport.x;
     const [timeMs] = projectionViewport.unproject([offsetX, 0]);
-    return timeMs ?? null;
+    return Number.isFinite(timeMs) ? timeMs : null;
   }
 
   #getProjectionViewport(info: PickingInfo): Viewport | null {
@@ -407,6 +600,9 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     this.#draftStartTimeMs = null;
     this.#cursorTimeMs = null;
     this.#dragSelecting = false;
+    this.#hoveredBoundary = null;
+    this.#adjustingBoundary = null;
+    this.#rangeBeforeAdjustment = null;
     this.props.onDeactivate?.();
     this.#emitSelectionChange();
     this.updateHTML();
@@ -423,11 +619,15 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
   }
 
   #cancelSelection() {
-    this.#updateRange(null);
-    this.#phase = 'idle';
+    const restoredRange = this.#rangeBeforeAdjustment;
+    this.#updateRange(restoredRange, {suppressEmit: restoredRange !== null});
+    this.#phase = restoredRange ? 'selected' : 'idle';
     this.#draftStartTimeMs = null;
     this.#cursorTimeMs = null;
     this.#dragSelecting = false;
+    this.#hoveredBoundary = null;
+    this.#adjustingBoundary = null;
+    this.#rangeBeforeAdjustment = null;
     this.props.onDeactivate?.();
     this.#emitSelectionChange();
     this.updateHTML();
@@ -450,7 +650,9 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
       phase: this.#phase,
       cursorTimeMs: this.#cursorTimeMs,
       draftStartTimeMs: this.#draftStartTimeMs,
-      range: this.#timeMeasureRange
+      range: this.#timeMeasureRange,
+      hoveredBoundary: this.#hoveredBoundary,
+      adjustingBoundary: this.#adjustingBoundary
     });
   }
 


### PR DESCRIPTION
## Summary

- let users hover and drag either boundary of a completed time range
- publish provisional adjustment state while committing `onRangeChange` only at drag end
- restore the prior completed range when an adjustment is cancelled
- preserve ordinary pan gestures for modifier keys, middle button, and right button

## Behavior

- completed endpoints use an 8px screen-space hit target
- unmodified primary-button or touch drags adjust the nearest endpoint
- drag updates use the current gesture position even when picking data is stale
- `hoveredBoundary` and `adjustingBoundary` expose the interaction state to callers
- existing Shift-drag range creation and right-button behavior remain intact

## Validation

- `yarn lint-fix`
- focused headless TimeMeasureWidget tests (5 passed)
- widgets package type check
- `yarn test` (612 passed, 9 skipped)
- `git diff --check`
- `yarn build` compiled the widgets package; repo-wide Lerna graph completion stalled in the local multi-worktree environment
- website build is blocked by the current nested website lockfile resolution and this PR does not change dependencies or lockfiles
