### PR TITLE
backport: Add dense BlockLayer controls to 9.3

### DIFF
--- a/docs/modules/infovis-layers/api-reference/block-layer.md
+++ b/docs/modules/infovis-layers/api-reference/block-layer.md
@@ -22,7 +22,9 @@ const layer = new BlockLayer({
   getSize: d => d.size,
   getFillColor: d => d.fillColor,
   getLineColor: d => d.lineColor,
-  getLineWidth: 1
+  getLineWidth: 1,
+  widthCutoffPixels: 0.5,
+  getOpacity: d => d.opacity
 });
 ```
 
@@ -58,9 +60,30 @@ Outline width. Default: `1`.
 
 Units used by `getLineWidth`. Default: `'pixels'`.
 
-### `widthMinPixels` / `heightMinPixels` / `sizeMaxPixels` (Number, optional)
+### `widthMinPixels` / `widthMaxPixels` / `heightMinPixels` / `sizeMaxPixels` (Number, optional)
 
 Pixel clamps applied after projecting block size.
+
+### `widthCutoffPixels` (Number, optional)
+
+Hides a block when its projected source width is below this threshold. The cutoff is applied before
+`widthMinPixels`, so very small intervals can be omitted instead of expanded to the minimum width.
+Default: `0`.
+
+### `strokeOffset` (Number, optional)
+
+Aligns the outline relative to the block bounds: `0` keeps the outline inside, `0.5` centers it on
+the boundary, and `1` places it outside. Default: `0`.
+
+### `getOpacity` (`Accessor<number>`, optional)
+
+Per-block multiplier applied after the fill and outline alpha channels. Default: `1`.
+
+### `overrideColor` / `getColorOverride` (`Color` / `Accessor<number>`, optional)
+
+`getColorOverride` selects whether an instance keeps its original RGB colors (`0`) or uses
+`overrideColor` (`1`). Fill and outline alpha channels are preserved. Defaults: `[0, 0, 0, 255]`
+and `0`.
 
 ## Source
 

--- a/modules/infovis-layers/src/layers/block-layer/block-layer-uniforms.ts
+++ b/modules/infovis-layers/src/layers/block-layer/block-layer-uniforms.ts
@@ -8,9 +8,13 @@ const glslUniformBlock = `\
 uniform blockUniforms {
   highp int sizeUnits;
   highp float widthMinPixels;
+  highp float widthMaxPixels;
+  highp float widthCutoffPixels;
   highp float heightMinPixels;
   highp float sizeMaxPixels;
   highp int lineWidthUnits;
+  highp float strokeOffset;
+  highp vec4 overrideColor;
 } block;
 `;
 
@@ -20,12 +24,20 @@ export type BlockProps = {
   sizeUnits: number;
   /** Minimum rendered block width in pixels. */
   widthMinPixels: number;
+  /** Maximum rendered block width in pixels. */
+  widthMaxPixels: number;
+  /** Minimum projected source width in pixels required to render the block. */
+  widthCutoffPixels: number;
   /** Minimum rendered block height in pixels. */
   heightMinPixels: number;
   /** Maximum rendered block width or height in pixels. */
   sizeMaxPixels: number;
   /** Numeric deck.gl unit for block outline width. */
   lineWidthUnits: number;
+  /** Stroke alignment relative to the block bounds. */
+  strokeOffset: number;
+  /** Normalized replacement color used by instances with an enabled color override. */
+  overrideColor: [number, number, number, number];
 };
 
 /** Shader module that defines uniforms consumed by {@link BlockLayer}. */
@@ -36,8 +48,12 @@ export const blockUniforms = {
   uniformTypes: {
     sizeUnits: 'i32',
     widthMinPixels: 'f32',
+    widthMaxPixels: 'f32',
+    widthCutoffPixels: 'f32',
     heightMinPixels: 'f32',
     sizeMaxPixels: 'f32',
-    lineWidthUnits: 'i32'
+    lineWidthUnits: 'i32',
+    strokeOffset: 'f32',
+    overrideColor: 'vec4<f32>'
   }
 } as const satisfies ShaderModule<BlockProps>;

--- a/modules/infovis-layers/src/layers/block-layer/block-layer-vertex.glsl.ts
+++ b/modules/infovis-layers/src/layers/block-layer/block-layer-vertex.glsl.ts
@@ -13,6 +13,8 @@ in vec2 instanceSizes;
 in float instanceLineWidths;
 in vec4 instanceFillColors;
 in vec4 instanceLineColors;
+in float instanceOpacities;
+in float instanceColorOverrides;
 in vec3 instancePickingColors;
 
 out vec2 unitPosition;
@@ -44,24 +46,33 @@ void main(void) {
   geometry.uv = positions.xy;
 
   vec2 pixelSize = project_size_to_pixel(instanceSizes, block.sizeUnits);
-  pixelSize.x = clamp_signed_size(pixelSize.x, block.widthMinPixels, block.sizeMaxPixels);
+  bool widthBelowCutoff = abs(pixelSize.x) < block.widthCutoffPixels;
+  float effectiveWidthMaxPixels = min(block.widthMaxPixels, block.sizeMaxPixels);
+  pixelSize.x = clamp_signed_size(pixelSize.x, block.widthMinPixels, effectiveWidthMaxPixels);
   pixelSize.y = clamp_signed_size(pixelSize.y, block.heightMinPixels, block.sizeMaxPixels);
+  lineWidth = project_size_to_pixel(vec2(instanceLineWidths, 0.0), block.lineWidthUnits).x;
+  vec2 strokePadding = vec2(lineWidth * block.strokeOffset);
+  pixelSize += 2.0 * strokePadding;
+  if (widthBelowCutoff) {
+    pixelSize = vec2(0.0);
+  }
   unitPosition = positions.xy;
   size = pixelSize;
-  lineWidth = project_size_to_pixel(vec2(instanceLineWidths, 0.0), block.lineWidthUnits).x;
 
   // Find the center of the point and add the current vertex
-  vec3 offset = vec3(unitPosition * project_pixel_size(pixelSize), 0.0);
+  vec3 offset = vec3(project_pixel_size(unitPosition * pixelSize - strokePadding), 0.0);
   DECKGL_FILTER_SIZE(offset, geometry);
 
   gl_Position = project_position_to_clipspace(instancePositions, instancePositions64Low, offset, geometry.position);
   DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
 
   // Apply opacity to instance color, or return instance picking color
-  vFillColor = vec4(instanceFillColors.rgb, instanceFillColors.a * layer.opacity);
+  vec3 fillColor = mix(instanceFillColors.rgb, block.overrideColor.rgb, instanceColorOverrides);
+  vFillColor = vec4(fillColor, instanceFillColors.a * instanceOpacities * layer.opacity);
   DECKGL_FILTER_COLOR(vFillColor, geometry);
 
-  vLineColor = vec4(instanceLineColors.rgb, instanceLineColors.a * layer.opacity);
+  vec3 lineColor = mix(instanceLineColors.rgb, block.overrideColor.rgb, instanceColorOverrides);
+  vLineColor = vec4(lineColor, instanceLineColors.a * instanceOpacities * layer.opacity);
   DECKGL_FILTER_COLOR(vLineColor, geometry);
 }
 `;

--- a/modules/infovis-layers/src/layers/block-layer/block-layer-vertex.glsl.ts
+++ b/modules/infovis-layers/src/layers/block-layer/block-layer-vertex.glsl.ts
@@ -51,7 +51,11 @@ void main(void) {
   pixelSize.x = clamp_signed_size(pixelSize.x, block.widthMinPixels, effectiveWidthMaxPixels);
   pixelSize.y = clamp_signed_size(pixelSize.y, block.heightMinPixels, block.sizeMaxPixels);
   lineWidth = project_size_to_pixel(vec2(instanceLineWidths, 0.0), block.lineWidthUnits).x;
-  vec2 strokePadding = vec2(lineWidth * block.strokeOffset);
+  vec2 strokeDirection = vec2(
+    pixelSize.x < 0.0 ? -1.0 : 1.0,
+    pixelSize.y < 0.0 ? -1.0 : 1.0
+  );
+  vec2 strokePadding = strokeDirection * lineWidth * block.strokeOffset;
   pixelSize += 2.0 * strokePadding;
   if (widthBelowCutoff) {
     pixelSize = vec2(0.0);

--- a/modules/infovis-layers/src/layers/block-layer/block-layer.ts
+++ b/modules/infovis-layers/src/layers/block-layer/block-layer.ts
@@ -29,16 +29,22 @@ const DEFAULT_COLOR: [number, number, number, number] = [0, 0, 0, 255];
 const defaultProps: DefaultProps<BlockLayerProps> = {
   sizeUnits: 'meters',
   widthMinPixels: {type: 'number', min: 0, value: 0},
+  widthMaxPixels: {type: 'number', min: 0, value: Number.MAX_SAFE_INTEGER},
+  widthCutoffPixels: {type: 'number', min: 0, value: 0},
   heightMinPixels: {type: 'number', min: 0, value: 0},
   sizeMaxPixels: {type: 'number', min: 0, value: Number.MAX_SAFE_INTEGER},
 
   lineWidthUnits: 'pixels',
+  strokeOffset: {type: 'number', min: 0, max: 1, value: 0},
 
   getPosition: {type: 'accessor', value: (x: any) => x.position},
   getSize: {type: 'accessor', value: [10, 10]},
   getLineWidth: {type: 'accessor', value: 1},
   getFillColor: {type: 'accessor', value: DEFAULT_COLOR},
-  getLineColor: {type: 'accessor', value: DEFAULT_COLOR}
+  getLineColor: {type: 'accessor', value: DEFAULT_COLOR},
+  getOpacity: {type: 'accessor', value: 1},
+  overrideColor: {type: 'color', value: DEFAULT_COLOR},
+  getColorOverride: {type: 'accessor', value: 0}
 };
 
 /** Properties supported by {@link BlockLayer}. */
@@ -60,6 +66,17 @@ type _BlockLayerProps<DataT> = {
    */
   widthMinPixels?: number;
   /**
+   * The maximum width in pixels. This prop can be used to prevent a wide block from covering the
+   * complete viewport when zoomed in.
+   * @defaultValue Number.MAX_SAFE_INTEGER
+   */
+  widthMaxPixels?: number;
+  /**
+   * Hides a block when its projected source width is below this pixel threshold.
+   * @defaultValue 0
+   */
+  widthCutoffPixels?: number;
+  /**
    * The minimum height in pixels. This prop can be used to prevent the block from getting too small when zoomed out.
    * @defaultValue 0
    */
@@ -75,6 +92,13 @@ type _BlockLayerProps<DataT> = {
    * @defaultValue 'pixels'
    */
   lineWidthUnits?: Unit;
+
+  /**
+   * The alignment of the stroke relative to the block bounds. `0` keeps the stroke inside the
+   * block, `0.5` centers it on the boundary, and `1` places it outside.
+   * @defaultValue 0
+   */
+  strokeOffset?: number;
 
   /**
    * The outline width of each object.
@@ -99,6 +123,23 @@ type _BlockLayerProps<DataT> = {
    * @defaultValue [0, 0, 0, 255]
    */
   getFillColor?: Accessor<DataT, Color>;
+  /**
+   * Per-block opacity multiplier applied after the fill and line color alpha channels.
+   * @defaultValue 1
+   */
+  getOpacity?: Accessor<DataT, number>;
+  /**
+   * Replacement RGB color applied to instances selected by `getColorOverride`. The original fill
+   * and line alpha channels are preserved.
+   * @defaultValue [0, 0, 0, 255]
+   */
+  overrideColor?: Color;
+  /**
+   * Per-block replacement-color selector. `0` preserves the original colors and `1` applies
+   * `overrideColor`.
+   * @defaultValue 0
+   */
+  getColorOverride?: Accessor<DataT, number>;
 };
 
 /** Renders axis-aligned rectangular blocks with fill and outline colors. */
@@ -152,6 +193,18 @@ export class BlockLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
         transition: true,
         accessor: 'getFillColor',
         defaultValue: DEFAULT_COLOR
+      },
+      instanceOpacities: {
+        size: 1,
+        transition: true,
+        accessor: 'getOpacity',
+        defaultValue: 1
+      },
+      instanceColorOverrides: {
+        size: 1,
+        type: 'uint8',
+        accessor: 'getColorOverride',
+        defaultValue: 0
       }
     });
   }
@@ -167,14 +220,33 @@ export class BlockLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
   }
 
   override draw() {
-    const {sizeUnits, widthMinPixels, heightMinPixels, sizeMaxPixels, lineWidthUnits} = this.props;
+    const {
+      sizeUnits,
+      widthMinPixels,
+      widthMaxPixels,
+      widthCutoffPixels,
+      heightMinPixels,
+      sizeMaxPixels,
+      lineWidthUnits,
+      strokeOffset,
+      overrideColor
+    } = this.props;
     const model = this.state.model!;
     const blockProps: BlockProps = {
       sizeUnits: UNIT[sizeUnits],
       widthMinPixels,
+      widthMaxPixels,
+      widthCutoffPixels,
       heightMinPixels,
       sizeMaxPixels,
-      lineWidthUnits: UNIT[lineWidthUnits]
+      lineWidthUnits: UNIT[lineWidthUnits],
+      strokeOffset: Math.min(1, Math.max(0, strokeOffset)),
+      overrideColor: [
+        overrideColor[0] / 255,
+        overrideColor[1] / 255,
+        overrideColor[2] / 255,
+        (overrideColor[3] ?? 255) / 255
+      ]
     };
     model.shaderInputs.setProps({block: blockProps});
     model.draw(this.context.renderPass);

--- a/modules/infovis-layers/test/block-layer.spec.ts
+++ b/modules/infovis-layers/test/block-layer.spec.ts
@@ -1,0 +1,48 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, it} from 'vitest';
+
+import {BlockLayer} from '../src/layers/block-layer/block-layer';
+import blockLayerVertexShader from '../src/layers/block-layer/block-layer-vertex.glsl';
+
+describe('BlockLayer dense rectangle controls', () => {
+  it('defaults to the existing visual behavior', () => {
+    const defaults = BlockLayer.defaultProps as Record<string, unknown>;
+
+    expect(defaults.widthMaxPixels).toMatchObject({value: Number.MAX_SAFE_INTEGER});
+    expect(defaults.widthCutoffPixels).toMatchObject({value: 0});
+    expect(defaults.strokeOffset).toMatchObject({value: 0});
+    expect(defaults.getOpacity).toMatchObject({value: 1});
+    expect(defaults.getColorOverride).toMatchObject({value: 0});
+    expect(defaults.overrideColor).toMatchObject({value: [0, 0, 0, 255]});
+  });
+
+  it('applies width clamps and cutoff behavior in WebGL2', () => {
+    expect(blockLayerVertexShader).toContain(
+      'float effectiveWidthMaxPixels = min(block.widthMaxPixels, block.sizeMaxPixels);'
+    );
+    expect(blockLayerVertexShader).toContain(
+      'bool widthBelowCutoff = abs(pixelSize.x) < block.widthCutoffPixels;'
+    );
+  });
+
+  it('applies stroke alignment behavior in WebGL2', () => {
+    expect(blockLayerVertexShader).toContain(
+      'vec2 strokePadding = vec2(lineWidth * block.strokeOffset);'
+    );
+    expect(blockLayerVertexShader).toContain(
+      'project_pixel_size(unitPosition * pixelSize - strokePadding)'
+    );
+  });
+
+  it('applies opacity and replacement-color behavior in WebGL2', () => {
+    expect(blockLayerVertexShader).toContain(
+      'instanceFillColors.a * instanceOpacities * layer.opacity'
+    );
+    expect(blockLayerVertexShader).toContain(
+      'mix(instanceFillColors.rgb, block.overrideColor.rgb, instanceColorOverrides)'
+    );
+  });
+});

--- a/modules/infovis-layers/test/block-layer.spec.ts
+++ b/modules/infovis-layers/test/block-layer.spec.ts
@@ -29,8 +29,10 @@ describe('BlockLayer dense rectangle controls', () => {
   });
 
   it('applies stroke alignment behavior in WebGL2', () => {
+    expect(blockLayerVertexShader).toContain('pixelSize.x < 0.0 ? -1.0 : 1.0');
+    expect(blockLayerVertexShader).toContain('pixelSize.y < 0.0 ? -1.0 : 1.0');
     expect(blockLayerVertexShader).toContain(
-      'vec2 strokePadding = vec2(lineWidth * block.strokeOffset);'
+      'vec2 strokePadding = strokeDirection * lineWidth * block.strokeOffset;'
     );
     expect(blockLayerVertexShader).toContain(
       'project_pixel_size(unitPosition * pixelSize - strokePadding)'


### PR DESCRIPTION
## Summary

Backports the WebGL2-compatible subset of #721 to the 9.3 line.

- Adds independent width maximum and cutoff controls for dense interval views.
- Adds stroke alignment, per-instance opacity, and replacement-color controls.
- Keeps the 9.3 `block` uniform contract.
- Intentionally omits the 9.4-only WGSL path.

## Why

Consumers pinned to deck.gl and luma.gl 9.3 need these dense interval controls without taking the 9.4 WebGPU work.

## Validation

- `yarn vitest run modules/infovis-layers/test/block-layer.spec.ts --project node`
- `yarn lint`
- `yarn build`

## Backport notes

API docs are included. Release notes can be added in the eventual 9.3.9 release-prep PR.