### PR TITLE
backport: Bring widget improvements to 9.3

### DIFF
--- a/docs/modules/widgets/README.md
+++ b/docs/modules/widgets/README.md
@@ -8,6 +8,8 @@ Alongside classic navigation and overlay widgets, the package exports
 
 For renderer selection and reusable luma device lifecycle, the package also exports `DeviceManager` and `DeviceTabsWidget`.
 
+For data-driven presentation, `ColorLegendWidget` renders JSON-safe categorical, continuous, and palette color keys without coupling the widget to an application's data model.
+
 Panel definitions, panel containers, specialized toolbar/toast components, and
 standalone mounting live in [`@deck.gl-community/panels`](/docs/modules/panels).
 Import components from `panels`, then pass them through `PanelWidget` or one of
@@ -58,6 +60,8 @@ See the [Panels developer guide](/docs/modules/panels/developer-guide/using-pane
 
 Use [`DeviceManager`](./api-reference/device-manager.md) when an application needs one reusable WebGPU or WebGL device that can be shared across UI surfaces and reparented into different DOM hosts. Use [`DeviceTabsWidget`](./api-reference/device-tabs-widget.md) when you want a built-in widget for switching the active backend.
 
+Use [`ColorLegendWidget`](./api-reference/color-legend-widget.md) when a view needs a serializable, bounded color key that can combine categories, gradients, and compact palettes.
+
 The [SharedTile2DLayer example](/examples/geo-layers/shared-tile-2d-layer) uses panel widgets to combine markdown and live probe.gl stats in one collapsible `BoxPanelWidget`.
 
 ### HTML overlays
@@ -96,6 +100,7 @@ map positions via the widget lifecycle.
 
 ## Advanced UI Widgets
 
+- [ColorLegendWidget](./api-reference/color-legend-widget.md)
 - [DeviceManager](./api-reference/device-manager.md)
 - [DeviceTabsWidget](./api-reference/device-tabs-widget.md)
 - [OmniBoxWidget](./api-reference/omni-box-widget.md)

--- a/docs/modules/widgets/api-reference/color-legend-widget.md
+++ b/docs/modules/widgets/api-reference/color-legend-widget.md
@@ -1,7 +1,7 @@
 # ColorLegendWidget
 
 <p className="badges">
-  <img src="https://img.shields.io/badge/from-v9.4-green.svg?style=flat-square" alt="from v9.4" />
+  <img src="https://img.shields.io/badge/from-v9.3-green.svg?style=flat-square" alt="from v9.3" />
 </p>
 
 `ColorLegendWidget` renders declarative color keys in a deck.gl HTML widget. Its payload is JSON-safe, so applications can prepare legend content outside the rendering layer and pass it through unchanged.

--- a/docs/modules/widgets/api-reference/color-legend-widget.md
+++ b/docs/modules/widgets/api-reference/color-legend-widget.md
@@ -1,0 +1,141 @@
+# ColorLegendWidget
+
+<p className="badges">
+  <img src="https://img.shields.io/badge/from-v9.4-green.svg?style=flat-square" alt="from v9.4" />
+</p>
+
+`ColorLegendWidget` renders declarative color keys in a deck.gl HTML widget. Its payload is JSON-safe, so applications can prepare legend content outside the rendering layer and pass it through unchanged.
+
+The widget supports categorical lists, continuous gradients, and compact palettes in one ordered legend. Large categorical lists stay bounded by default and can expose a bounded expanded view. Categorical entries with a `title` expose that text through a keyboard-accessible, viewport-clamped tooltip that stays visible outside an expanded list's scroll container.
+
+## Import
+
+```ts
+import {
+  ColorLegendWidget,
+  type ColorLegendPayload,
+  type ColorLegendWidgetProps
+} from '@deck.gl-community/widgets';
+```
+
+## Types
+
+```ts
+type ColorLegendColor =
+  | string
+  | readonly [red: number, green: number, blue: number]
+  | readonly [red: number, green: number, blue: number, alpha: number];
+
+type ColorLegendPayload = {
+  readonly id: string;
+  readonly title: string;
+  readonly description?: string;
+  readonly ariaLabel?: string;
+  readonly sections: readonly ColorLegendSection[];
+};
+
+type ColorLegendSection =
+  | ColorLegendCategoricalSection
+  | ColorLegendContinuousSection
+  | ColorLegendPaletteSection;
+
+type ColorLegendWidgetProps = WidgetProps & {
+  readonly payload: ColorLegendPayload;
+  readonly placement?: WidgetPlacement;
+  readonly viewId?: string | null;
+  readonly onClose?: () => void;
+};
+```
+
+Categorical sections contain labeled swatches:
+
+```ts
+type ColorLegendCategoricalSection = {
+  readonly type: 'categorical';
+  readonly id: string;
+  readonly title?: string;
+  readonly entries: readonly {
+    readonly color: ColorLegendColor;
+    readonly label: string;
+    readonly description?: string;
+    readonly title?: string;
+  }[];
+  readonly totalCount?: number;
+  readonly maxVisibleEntries?: number;
+  readonly maxExpandedEntries?: number;
+};
+```
+
+Continuous sections contain low-to-high stops, and palette sections contain a compact row of colors:
+
+```ts
+type ColorLegendContinuousSection = {
+  readonly type: 'continuous';
+  readonly id: string;
+  readonly title?: string;
+  readonly stops: readonly {
+    readonly color: ColorLegendColor;
+    readonly label: string;
+  }[];
+};
+
+type ColorLegendPaletteSection = {
+  readonly type: 'palette';
+  readonly id: string;
+  readonly title?: string;
+  readonly label?: string;
+  readonly colors: readonly {
+    readonly color: ColorLegendColor;
+    readonly label?: string;
+  }[];
+};
+```
+
+## Usage
+
+```ts
+import {ColorLegendWidget} from '@deck.gl-community/widgets';
+
+const colorLegend = new ColorLegendWidget({
+  placement: 'bottom-right',
+  payload: {
+    id: 'latency',
+    title: 'Latency',
+    description: 'P95 duration by operation',
+    sections: [
+      {
+        id: 'duration',
+        type: 'continuous',
+        title: 'Duration',
+        stops: [
+          {label: 'Fast', color: '#22c55e'},
+          {label: 'Slow', color: '#ef4444'}
+        ]
+      },
+      {
+        id: 'operation',
+        type: 'categorical',
+        entries: [
+          {label: 'Read', description: 'Cached and local', color: [33, 150, 243]},
+          {label: 'Write', color: [156, 39, 176, 255]}
+        ]
+      },
+      {
+        id: 'fallback',
+        type: 'palette',
+        label: 'Hash-derived operations',
+        colors: [{color: '#ffc107'}, {color: [128, 128, 128, 128], label: 'Fallback'}]
+      }
+    ]
+  }
+});
+```
+
+## Remarks
+
+- The payload uses only strings, numbers, arrays, and objects; it can be serialized, stored, or transferred between application layers.
+- Categorical sections render at most 10 entries initially and 100 after expansion unless the section overrides `maxVisibleEntries` or `maxExpandedEntries`.
+- `totalCount` can report categories that are intentionally omitted from the prepared payload.
+- A categorical entry's optional `title` is available on its row, label, and swatch, and opens a focusable/hoverable tooltip that is portaled outside clipped widget content.
+- Supplying `onClose` adds an accessible dismiss button to the header.
+- CSS follows deck.gl widget theme tokens such as `--menu-background`, `--menu-text`, `--button-background`, `--button-text`, and `--button-stroke`.

--- a/docs/modules/widgets/api-reference/omni-box-widget.md
+++ b/docs/modules/widgets/api-reference/omni-box-widget.md
@@ -17,8 +17,10 @@ import {
   OmniBoxWidget,
   type OmniBoxOption,
   type OmniBoxOptionProvider,
+  type OmniBoxOptionSorter,
   type OmniBoxRenderOptionArgs,
-  type OmniBoxResultsSummaryArgs
+  type OmniBoxResultsSummaryArgs,
+  type OmniBoxResultsState
 } from '@deck.gl-community/widgets';
 ```
 
@@ -37,6 +39,10 @@ export type OmniBoxOptionProvider =
   | ((query: string) => Promise<ReadonlyArray<OmniBoxOption>>)
   | ((query: string) => ReadonlyArray<OmniBoxOption>);
 
+export type OmniBoxOptionSorter = (
+  options: ReadonlyArray<OmniBoxOption>
+) => ReadonlyArray<OmniBoxOption>;
+
 export type OmniBoxRenderOptionArgs = {
   option: OmniBoxOption;
   index: number;
@@ -49,6 +55,14 @@ export type OmniBoxResultsSummaryArgs = {
   readonly options: ReadonlyArray<OmniBoxOption>;
   readonly mode: 'search' | 'command' | 'history';
 };
+
+export type OmniBoxResultsState = {
+  readonly query: string;
+  readonly options: ReadonlyArray<OmniBoxOption>;
+  readonly mode: 'search' | 'command' | 'history';
+  readonly isLoading: boolean;
+  readonly isOpen: boolean;
+};
 ```
 
 ## Props
@@ -58,6 +72,8 @@ type OmniBoxWidgetProps = WidgetProps & {
   placement?: WidgetPlacement;
   placeholder?: string;
   minQueryLength?: number;
+  searchDebounceMs?: number;
+  searchRefreshKey?: unknown;
   defaultOpen?: boolean;
   closeOnSelect?: boolean;
   rememberQueries?: boolean;
@@ -66,12 +82,14 @@ type OmniBoxWidgetProps = WidgetProps & {
   showAnchorButton?: boolean;
   topOffsetPx?: number;
   getOptions?: OmniBoxOptionProvider;
+  sortOptions?: OmniBoxOptionSorter;
   renderOption?: (args: OmniBoxRenderOptionArgs) => ComponentChildren;
   renderResultsSummary?: (args: OmniBoxResultsSummaryArgs) => ComponentChildren;
   onSelectOption?: (option: OmniBoxOption) => void;
   onActiveOptionChange?: (option: OmniBoxOption | null) => void;
   onNavigateOption?: (option: OmniBoxOption) => void;
   onQueryChange?: (query: string) => void;
+  onResultsStateChange?: (state: OmniBoxResultsState) => void;
 };
 ```
 
@@ -85,10 +103,14 @@ const widget = new OmniBoxWidget({
   rememberQueries: true,
   queryHistoryStorageKey: 'example-search-history',
   minQueryLength: 1,
+  searchDebounceMs: 120,
+  searchRefreshKey: itemCatalogVersion,
   getOptions: (query) => searchItems(query),
+  sortOptions: (options) => options.slice(0, 20),
   renderResultsSummary: ({options}) => `${options.length} matches`,
   onSelectOption: (option) => selectItem((option.data as any).id),
-  onNavigateOption: (option) => previewItem((option.data as any).id)
+  onNavigateOption: (option) => previewItem((option.data as any).id),
+  onResultsStateChange: (state) => updateSearchStatus(state)
 });
 ```
 
@@ -100,6 +122,11 @@ This widget is intentionally generic. Callers provide search options, selection 
 
 - Renders a floating search input centered near the top of the deck canvas.
 - Supports sync or async option providers.
+- Can debounce ordinary option providers while command suggestions remain immediate.
+- Rejects late async results after the query changes.
+- Can rerun the current query when `searchRefreshKey` changes.
+- Can reorder or bound ordinary results with `sortOptions`.
+- Can publish the current dropdown/loading state through `onResultsStateChange`.
 - Caps the dropdown to 4 visible rows and makes it scrollable beyond that.
 - Includes built-in `<` and `>` navigation controls for cycling the active option.
 - Opens and focuses from `/` when focus is not already inside an editable element.

--- a/docs/modules/widgets/api-reference/time-measure-widget.md
+++ b/docs/modules/widgets/api-reference/time-measure-widget.md
@@ -4,7 +4,7 @@
   <img src="https://img.shields.io/badge/from-v9.3-green.svg?style=flat-square" alt="from v9.3" />
 </p>
 
-`TimeMeasureWidget` is an interactive measurement widget for selecting a time range directly from a deck trace view.
+`TimeMeasureWidget` is an interactive measurement widget for selecting a time range directly from a time-oriented deck view.
 
 ## Import
 
@@ -22,6 +22,8 @@ type TimeMeasureSelectionState = {
   cursorTimeMs: number | null;
   draftStartTimeMs: number | null;
   range: TimeMeasureRange | null;
+  hoveredBoundary?: 'start' | 'end' | null;
+  adjustingBoundary?: 'start' | 'end' | null;
 };
 ```
 
@@ -67,6 +69,9 @@ The selected range can be rendered or visualized further with `TimeMeasureLayer`
 - Renders a toolbar button for entering measurement mode.
 - Supports click-based two-step range selection.
 - Supports Shift-drag selection directly in the target view.
-- Emits incremental selection state updates while the user is dragging or hovering.
-- Cancels on `Escape`.
+- Supports dragging either boundary of a completed range without a modifier key.
+- Emits incremental selection state updates while the user is dragging or hovering; `onRangeChange`
+  fires only when a completed range is committed or cleared.
+- Cancels new selections on `Escape` and restores the previous range when boundary adjustment is
+  canceled.
 - Tracks separate event and projection views so input and coordinate projection can be decoupled.

--- a/docs/modules/widgets/sidebar.json
+++ b/docs/modules/widgets/sidebar.json
@@ -41,6 +41,7 @@
           "type": "category",
           "label": "Advanced UI Widgets",
           "items": [
+            "modules/widgets/api-reference/color-legend-widget",
             "modules/widgets/api-reference/device-manager",
             "modules/widgets/api-reference/device-tabs-widget",
             "modules/widgets/api-reference/omni-box-widget",

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -31,6 +31,7 @@ Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community
 
 ### `@deck.gl-community/widgets`
 
+- `ColorLegendWidget` - NEW JSON-safe color legend for categorical lists, continuous gradients, and compact palettes, with bounded expansion, accessible controls, and deck.gl theme-token styling.
 - `PanelWidget` - NEW generic deck adapter for any panel-owned `PanelComponent`.
 - Thin named adapters now cover real panel containers plus specialized toolbar
   and toast components without duplicating panel rendering logic.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -38,6 +38,8 @@ Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community
 - `OmniBoxWidget` now accepts shared command manager search prefixes for command-mode Tracevis integrations.
 - `ModalPanelWidget` inherits floating, draggable, custom-styled modal support from `ModalPanelContainer`.
 - `createStudioSettingsWidget` and `updateStudioSettingsWidget` now host the shared Studio settings panel through deck widget chrome.
+- `TimeMeasureWidget` now lets users hover and drag either boundary of a completed range, with
+  provisional selection updates and cancellation that restores the previous range.
 
 ### `@deck.gl-community/panels` (NEW module)
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -31,7 +31,6 @@ Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community
 
 ### `@deck.gl-community/widgets`
 
-- `ColorLegendWidget` - NEW JSON-safe color legend for categorical lists, continuous gradients, and compact palettes, with bounded expansion, accessible controls, and deck.gl theme-token styling.
 - `PanelWidget` - NEW generic deck adapter for any panel-owned `PanelComponent`.
 - Thin named adapters now cover real panel containers plus specialized toolbar
   and toast components without duplicating panel rendering logic.
@@ -39,8 +38,6 @@ Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community
 - `OmniBoxWidget` now accepts shared command manager search prefixes for command-mode Tracevis integrations.
 - `ModalPanelWidget` inherits floating, draggable, custom-styled modal support from `ModalPanelContainer`.
 - `createStudioSettingsWidget` and `updateStudioSettingsWidget` now host the shared Studio settings panel through deck widget chrome.
-- `TimeMeasureWidget` now lets users hover and drag either boundary of a completed range, with
-  provisional selection updates and cancellation that restores the previous range.
 
 ### `@deck.gl-community/panels` (NEW module)
 

--- a/modules/widgets/README.md
+++ b/modules/widgets/README.md
@@ -13,6 +13,8 @@ This module packages UI widgets that integrate with [deck.gl](https://deck.gl) v
 
 For renderer lifecycle management, the package also exports `DeviceManager` and `DeviceTabsWidget`. Together they let applications choose WebGPU or WebGL, reuse one cached luma device per backend, and reparent the managed canvas between host elements.
 
+`ColorLegendWidget` renders caller-supplied JSON-safe categorical, continuous, and palette color keys while keeping large categorical lists bounded.
+
 Panel definitions, panel containers, specialized toolbar/toast components, and
 standalone mounting live in `@deck.gl-community/panels`. Import components from
 `panels`, then pass them through `PanelWidget` or one of the thin named
@@ -61,6 +63,8 @@ For the deck-facing panel widget APIs, see the [Widget Panels example](../../exa
 - reusable panel definitions imported from `@deck.gl-community/panels`
 
 Use `DeviceManager` directly when your application wants custom backend-selection UI or needs to move the managed canvas between containers. Use `DeviceTabsWidget` when you want a ready-made widget for switching between `webgpu` and `webgl2`.
+
+Use `ColorLegendWidget` when a view needs a serializable color key that can be prepared independently from its deck.gl rendering lifecycle.
 
 Standalone UI such as `ToolbarComponent`, `ToastComponent`, and `toastManager`
 is exported from `@deck.gl-community/panels`. The widgets package exports

--- a/modules/widgets/src/index.ts
+++ b/modules/widgets/src/index.ts
@@ -29,6 +29,19 @@ export {
   type DeviceTabsWidgetProps
 } from './widgets/device-tabs-widget';
 export {
+  ColorLegendWidget,
+  type ColorLegendCategoricalEntry,
+  type ColorLegendCategoricalSection,
+  type ColorLegendColor,
+  type ColorLegendContinuousSection,
+  type ColorLegendContinuousStop,
+  type ColorLegendPaletteColor,
+  type ColorLegendPaletteSection,
+  type ColorLegendPayload,
+  type ColorLegendSection,
+  type ColorLegendWidgetProps
+} from './widgets/color-legend-widget';
+export {
   OmniBoxWidget,
   type OmniBoxOption,
   type OmniBoxOptionProvider,

--- a/modules/widgets/src/index.ts
+++ b/modules/widgets/src/index.ts
@@ -45,8 +45,10 @@ export {
   OmniBoxWidget,
   type OmniBoxOption,
   type OmniBoxOptionProvider,
+  type OmniBoxOptionSorter,
   type OmniBoxRenderOptionArgs,
   type OmniBoxResultsSummaryArgs,
+  type OmniBoxResultsState,
   type OmniBoxWidgetProps
 } from './widgets/omni-box-widget';
 export {

--- a/modules/widgets/src/widgets/color-legend-widget.test.tsx
+++ b/modules/widgets/src/widgets/color-legend-widget.test.tsx
@@ -1,0 +1,562 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {act} from 'preact/test-utils';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {ColorLegendWidget} from './color-legend-widget';
+
+import type {ColorLegendPayload} from './color-legend-widget';
+import type {Deck} from '@deck.gl/core';
+
+type MountedColorLegendWidget = {
+  /** Mounted widget instance. */
+  readonly widget: ColorLegendWidget;
+  /** DOM root created through the deck.gl lifecycle. */
+  readonly root: HTMLDivElement;
+};
+
+const mountedWidgets: MountedColorLegendWidget[] = [];
+
+afterEach(() => {
+  for (const {widget, root} of mountedWidgets.splice(0)) {
+    act(() => widget.onRemove());
+    root.remove();
+  }
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('ColorLegendWidget', () => {
+  it('renders a rich JSON round trip with continuous, categorical, and palette sections', () => {
+    const payload = JSON.parse(JSON.stringify(RICH_PAYLOAD)) as ColorLegendPayload;
+    const {widget, root} = mountWidget({payload, viewId: 'main'});
+
+    expect(widget.id).toBe('color-legend');
+    expect(widget.placement).toBe('bottom-right');
+    expect(widget.viewId).toBe('main');
+    expect(root.style.pointerEvents).toBe('none');
+    expect(root.textContent).toContain('Latency');
+    expect(root.textContent).toContain('P95 duration by operation');
+    expect(root.textContent).toContain('Slow');
+    expect(root.textContent).toContain('Fast');
+    expect(root.textContent).toContain('Read');
+    expect(root.textContent).toContain('Cached and local');
+    expect(root.textContent).toContain('Hash-derived operations');
+    expect(root.querySelectorAll('[data-testid="color-legend-gradient"]')).toHaveLength(1);
+    expect(root.querySelectorAll('[data-testid="color-legend-swatch"]')).toHaveLength(5);
+    expect(
+      root.querySelector<HTMLElement>('[data-testid="color-legend-swatch"]')?.style.backgroundColor
+    ).toBe('rgb(33, 150, 243)');
+    expect(root.querySelector<HTMLElement>('[title="Fallback"]')?.style.backgroundColor).toBe(
+      'rgba(128, 128, 128, 0.5)'
+    );
+  });
+
+  it('renders a one-stop continuous scale as a solid color', () => {
+    const {root} = mountWidget({
+      payload: {
+        id: 'single-stop',
+        title: 'Status',
+        sections: [
+          {
+            id: 'status',
+            type: 'continuous',
+            stops: [{label: 'Only value', color: '#ef4444'}]
+          }
+        ]
+      }
+    });
+
+    const scale = root.querySelector<HTMLElement>('[data-testid="color-legend-gradient"]');
+    expect(scale?.style.backgroundImage).toBe('');
+    expect(scale?.style.backgroundColor).toBe('rgb(239, 68, 68)');
+  });
+
+  it('bounds categorical DOM while preserving exact overflow through expansion', () => {
+    const payload: ColorLegendPayload = {
+      id: 'many-categories',
+      title: 'Components',
+      sections: [
+        {
+          id: 'components',
+          type: 'categorical',
+          entries: Array.from({length: 150}, (_, index) => ({
+            label: `Component ${index}`,
+            color: [index, 64, 128, 255]
+          })),
+          totalCount: 1_000
+        }
+      ]
+    };
+    const {root} = mountWidget({payload});
+
+    expect(root.querySelectorAll('[data-testid="color-legend-swatch"]')).toHaveLength(10);
+    expect(root.textContent).toContain('+990 more');
+
+    act(() =>
+      root
+        .querySelector<HTMLButtonElement>('button[aria-label="Show all color categories"]')
+        ?.click()
+    );
+
+    expect(root.querySelectorAll('[data-testid="color-legend-swatch"]')).toHaveLength(100);
+    expect(root.textContent).toContain('Component 99');
+    expect(root.textContent).toContain('+900 more');
+    expect(root.textContent).not.toContain('Component 100');
+
+    act(() =>
+      root
+        .querySelector<HTMLButtonElement>('button[aria-label="Collapse color categories"]')
+        ?.click()
+    );
+    expect(root.querySelectorAll('[data-testid="color-legend-swatch"]')).toHaveLength(10);
+  });
+
+  it('exposes optional entry hover text on its row, label, and swatch without blocking the canvas', () => {
+    vi.stubGlobal('innerWidth', 1_024);
+    const title = 'Keyword: WRITE · Source: save_data';
+    const {root} = mountWidget({
+      payload: {
+        id: 'operations',
+        title: 'Operations',
+        sections: [
+          {
+            id: 'operations',
+            type: 'categorical',
+            entries: [
+              {label: 'Save data', color: '#22c55e', title},
+              {label: 'Read data', color: '#3b82f6'}
+            ]
+          }
+        ]
+      }
+    });
+    const [titledRow, plainRow] = Array.from(root.querySelectorAll('li'));
+
+    expect(root.style.pointerEvents).toBe('none');
+    expect(
+      root.querySelector<HTMLElement>('[data-testid="color-legend"]')?.style.pointerEvents
+    ).toBe('none');
+    expect(titledRow?.title).toBe(title);
+    expect(titledRow?.style.pointerEvents).toBe('auto');
+    expect(
+      titledRow?.querySelector('[data-testid="color-legend-swatch"]')?.getAttribute('title')
+    ).toBe(title);
+    expect(titledRow?.querySelector('span > span')?.getAttribute('title')).toBe(title);
+    expect(plainRow?.title).toBe('');
+    expect(plainRow?.style.pointerEvents).toBe('');
+    expect(plainRow?.querySelector('span > span')?.getAttribute('title')).toBe('Read data');
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).toBeNull();
+
+    vi.spyOn(titledRow!, 'getBoundingClientRect').mockReturnValue(new DOMRect(700, 120, 160, 16));
+    act(() => {
+      titledRow?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+
+    const tooltip = document.querySelector<HTMLElement>(
+      '[data-testid="color-legend-entry-tooltip"]'
+    );
+    expect(tooltip?.getAttribute('role')).toBe('tooltip');
+    expect(tooltip?.textContent).toBe(title);
+    expect(tooltip?.parentElement).toBe(document.body);
+    expect(root.contains(tooltip)).toBe(false);
+    expect(tooltip?.style.position).toBe('fixed');
+    expect(tooltip?.style.pointerEvents).toBe('none');
+    expect(tooltip?.style.left).toBe('692px');
+    expect(tooltip?.style.top).toBe('128px');
+    expect(tooltip?.style.transform).toBe('translate(-100%, -50%)');
+
+    act(() => {
+      titledRow?.dispatchEvent(new MouseEvent('mouseleave', {bubbles: true}));
+    });
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).toBeNull();
+  });
+
+  it('keeps expanded-row tooltips visible outside the scrollable legend and clears them on scroll', () => {
+    const {root} = mountWidget({
+      payload: {
+        id: 'expanded-operations',
+        title: 'Operations',
+        sections: [
+          {
+            id: 'operations',
+            type: 'categorical',
+            entries: Array.from({length: 12}, (_, index) => ({
+              label: `Operation ${index}`,
+              color: '#22c55e',
+              title: `Keyword: OP_${index} · Source: operation_${index}`
+            }))
+          }
+        ]
+      }
+    });
+
+    act(() =>
+      root
+        .querySelector<HTMLButtonElement>('button[aria-label="Show all color categories"]')
+        ?.click()
+    );
+    const expandedList = root.querySelector('ul');
+    const finalRow = Array.from(root.querySelectorAll('li')).find(row =>
+      row.textContent?.includes('Operation 11')
+    );
+    expect(expandedList?.style.overflowY).toBe('auto');
+
+    act(() => {
+      finalRow?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+
+    const tooltip = document.querySelector('[data-testid="color-legend-entry-tooltip"]');
+    expect(tooltip?.textContent).toBe('Keyword: OP_11 · Source: operation_11');
+    expect(tooltip?.parentElement).toBe(document.body);
+    expect(expandedList?.contains(tooltip)).toBe(false);
+
+    act(() => {
+      expandedList?.dispatchEvent(new Event('scroll'));
+    });
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).toBeNull();
+  });
+
+  it('preserves the resolved deck theme after portaling a tooltip outside the legend', () => {
+    const {root} = mountWidget({
+      payload: {
+        id: 'dark-operations',
+        title: 'Operations',
+        sections: [
+          {
+            id: 'operations',
+            type: 'categorical',
+            entries: [{label: 'Save data', color: '#22c55e', title: 'Keyword: WRITE'}]
+          }
+        ]
+      }
+    });
+    const legend = root.querySelector<HTMLElement>('[data-testid="color-legend"]');
+    expect(legend).not.toBeNull();
+    legend!.style.background = 'rgb(17, 24, 39)';
+    legend!.style.color = 'rgb(243, 244, 246)';
+    legend!.style.borderColor = 'rgb(75, 85, 99)';
+    legend!.style.borderRadius = '9px';
+    legend!.style.boxShadow = 'rgb(0, 0, 0) 0px 2px 4px';
+
+    act(() => {
+      root.querySelector('li')?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+
+    const tooltip = document.querySelector<HTMLElement>(
+      '[data-testid="color-legend-entry-tooltip"]'
+    );
+    expect(tooltip?.style.backgroundColor).toBe('rgb(17, 24, 39)');
+    expect(tooltip?.style.color).toBe('rgb(243, 244, 246)');
+    expect(tooltip?.style.borderColor).toBe('rgb(75, 85, 99)');
+    expect(tooltip?.style.borderRadius).toBe('9px');
+    expect(tooltip?.style.boxShadow).toBe('rgb(0, 0, 0) 0px 2px 4px 0px');
+  });
+
+  it('keeps long tooltip text inside narrow viewport boundaries', () => {
+    vi.stubGlobal('innerWidth', 400);
+    const {root} = mountWidget({
+      payload: {
+        id: 'narrow-operations',
+        title: 'Operations',
+        sections: [
+          {
+            id: 'operations',
+            type: 'categorical',
+            entries: [{label: 'Pipeline send', color: '#22c55e', title: 'Keyword: PIPE_SEND'}]
+          }
+        ]
+      }
+    });
+    const row = root.querySelector('li');
+    vi.spyOn(row!, 'getBoundingClientRect').mockReturnValue(new DOMRect(176, 120, 224, 16));
+
+    act(() => {
+      row?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+
+    const tooltip = document.querySelector<HTMLElement>(
+      '[data-testid="color-legend-entry-tooltip"]'
+    );
+    expect(tooltip?.style.maxWidth).toBe('320px');
+    expect(tooltip?.style.left).toBe('328px');
+    expect(tooltip?.style.transform).toBe('translate(-100%, -50%)');
+    expect(Number.parseInt(tooltip?.style.left ?? '0', 10) - 320).toBe(8);
+  });
+
+  it('vertically clamps a measured wrapped tooltip inside the viewport', () => {
+    vi.stubGlobal('innerWidth', 240);
+    vi.stubGlobal('innerHeight', 160);
+    const {root} = mountWidget({
+      payload: {
+        id: 'vertical-clamp',
+        title: 'Operations',
+        sections: [
+          {
+            id: 'operations',
+            type: 'categorical',
+            entries: [
+              {
+                label: 'Pipeline send',
+                color: '#22c55e',
+                title:
+                  'A long descriptive entry title that wraps across several lines in the tooltip'
+              }
+            ]
+          }
+        ]
+      }
+    });
+    const row = root.querySelector('li');
+    let rowBounds = new DOMRect(20, 140, 160, 16);
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+      this: HTMLElement
+    ) {
+      return this === row ? rowBounds : new DOMRect(0, 0, 224, 80);
+    });
+
+    act(() => {
+      row?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+
+    let tooltip = document.querySelector<HTMLElement>('[data-testid="color-legend-entry-tooltip"]');
+    expect(tooltip?.style.maxHeight).toBe('144px');
+    expect(tooltip?.style.top).toBe('112px');
+
+    rowBounds = new DOMRect(20, 0, 160, 16);
+    act(() => {
+      row?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+
+    tooltip = document.querySelector<HTMLElement>('[data-testid="color-legend-entry-tooltip"]');
+    expect(tooltip?.style.top).toBe('48px');
+  });
+
+  it('opens an accessible tooltip when a titled legend entry receives keyboard focus', () => {
+    const {root} = mountWidget({
+      payload: {
+        id: 'keyboard-operations',
+        title: 'Operations',
+        sections: [
+          {
+            id: 'operations',
+            type: 'categorical',
+            entries: [
+              {label: 'Save data', color: '#22c55e', title: 'Keyword: WRITE'},
+              {label: 'Read data', color: '#3b82f6'}
+            ]
+          }
+        ]
+      }
+    });
+    const [titledRow, plainRow] = Array.from(root.querySelectorAll('li'));
+    expect(titledRow?.tabIndex).toBe(0);
+    expect(plainRow?.hasAttribute('tabindex')).toBe(false);
+
+    act(() => {
+      titledRow?.focus();
+    });
+
+    const tooltip = document.querySelector<HTMLElement>(
+      '[data-testid="color-legend-entry-tooltip"]'
+    );
+    expect(tooltip?.getAttribute('role')).toBe('tooltip');
+    expect(tooltip?.textContent).toBe('Keyword: WRITE');
+    expect(titledRow?.getAttribute('aria-describedby')).toBe(tooltip?.id);
+
+    act(() => {
+      titledRow?.blur();
+    });
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).toBeNull();
+    expect(titledRow?.hasAttribute('aria-describedby')).toBe(false);
+  });
+
+  it('clears tooltips when a scrollable ancestor moves or the viewport resizes', () => {
+    const {root} = mountWidget({
+      payload: {
+        id: 'ancestor-operations',
+        title: 'Operations',
+        sections: [
+          {
+            id: 'operations',
+            type: 'categorical',
+            entries: [{label: 'Save data', color: '#22c55e', title: 'Keyword: WRITE'}]
+          }
+        ]
+      }
+    });
+    const ancestor = document.createElement('section');
+    document.body.append(ancestor);
+    ancestor.append(root);
+    const row = root.querySelector('li');
+
+    act(() => {
+      row?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).not.toBeNull();
+
+    act(() => {
+      ancestor.dispatchEvent(new Event('scroll'));
+    });
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).toBeNull();
+
+    act(() => {
+      row?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).toBeNull();
+
+    document.body.append(root);
+    ancestor.remove();
+  });
+
+  it('removes stale hover text when the section payload changes without replacing its widget', () => {
+    const {root, widget} = mountWidget({
+      payload: {
+        id: 'block-types',
+        title: 'Operations',
+        sections: [
+          {
+            id: 'block-types',
+            type: 'categorical',
+            entries: [{label: 'Parameter fetch', color: '#22c55e', title: 'Keyword: PARAM_FETCH'}]
+          }
+        ]
+      }
+    });
+
+    act(() => {
+      root.querySelector('li')?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).not.toBeNull();
+
+    act(() =>
+      widget.setProps({
+        payload: {
+          id: 'block-types',
+          title: 'Traditional operations',
+          sections: [
+            {
+              id: 'block-types',
+              type: 'categorical',
+              entries: [{label: 'ATTENTION', color: '#3b82f6'}]
+            }
+          ]
+        }
+      })
+    );
+
+    expect(root.textContent).toContain('ATTENTION');
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).toBeNull();
+  });
+
+  it('removes a visible portaled tooltip when the owning legend widget is removed', () => {
+    const {root, widget} = mountWidget({
+      payload: {
+        id: 'removal',
+        title: 'Operations',
+        sections: [
+          {
+            id: 'operations',
+            type: 'categorical',
+            entries: [{label: 'Save data', color: '#22c55e', title: 'Keyword: WRITE'}]
+          }
+        ]
+      }
+    });
+    const row = root.querySelector('li');
+    act(() => {
+      row?.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
+    });
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).not.toBeNull();
+
+    act(() => widget.onRemove());
+
+    expect(document.querySelector('[data-testid="color-legend-entry-tooltip"]')).toBeNull();
+  });
+
+  it('updates its payload, placement, view, and close action without replacing the widget', () => {
+    const onClose = vi.fn();
+    const {widget, root} = mountWidget({payload: RICH_PAYLOAD, onClose});
+
+    act(() =>
+      root.querySelector<HTMLButtonElement>('button[aria-label="Close color legend"]')?.click()
+    );
+    expect(onClose).toHaveBeenCalledOnce();
+
+    act(() =>
+      widget.setProps({
+        placement: 'top-left',
+        viewId: 'overview',
+        payload: {
+          id: 'status',
+          title: 'Status',
+          sections: [
+            {
+              id: 'status-values',
+              type: 'categorical',
+              entries: [{label: 'Healthy', color: '#22c55e'}]
+            }
+          ]
+        }
+      })
+    );
+
+    expect(widget.placement).toBe('top-left');
+    expect(widget.viewId).toBe('overview');
+    expect(root.textContent).toContain('Healthy');
+    expect(root.textContent).not.toContain('Latency');
+  });
+});
+
+const RICH_PAYLOAD: ColorLegendPayload = {
+  id: 'latency',
+  title: 'Latency',
+  description: 'P95 duration by operation',
+  sections: [
+    {
+      id: 'duration',
+      type: 'continuous',
+      title: 'Duration',
+      stops: [
+        {label: 'Fast', color: '#22c55e'},
+        {label: 'Slow', color: '#ef4444'}
+      ]
+    },
+    {
+      id: 'operation',
+      type: 'categorical',
+      entries: [
+        {label: 'Read', description: 'Cached and local', color: [33, 150, 243]},
+        {label: 'Write', color: [156, 39, 176, 255]}
+      ]
+    },
+    {
+      id: 'fallback',
+      type: 'palette',
+      label: 'Hash-derived operations',
+      colors: [
+        {color: '#ffc107'},
+        {color: [128, 128, 128, 128], label: 'Fallback'},
+        {color: 'rebeccapurple'}
+      ]
+    }
+  ]
+};
+
+/** Mounts one widget through the same lifecycle hooks deck.gl calls. */
+function mountWidget(
+  props: ConstructorParameters<typeof ColorLegendWidget>[0]
+): MountedColorLegendWidget {
+  const widget = new ColorLegendWidget(props);
+  const root = widget._onAdd({deck: {} as Deck, viewId: props.viewId ?? null});
+  widget.rootElement = root;
+  document.body.append(root);
+  act(() => widget.updateHTML());
+  mountedWidgets.push({widget, root});
+  return {widget, root};
+}

--- a/modules/widgets/src/widgets/color-legend-widget.tsx
+++ b/modules/widgets/src/widgets/color-legend-widget.tsx
@@ -1,0 +1,803 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** @jsxImportSource preact */
+import {Widget} from '@deck.gl/core';
+import {render} from 'preact';
+import {createPortal} from 'preact/compat';
+import {useEffect, useId, useLayoutEffect, useRef, useState} from 'preact/hooks';
+
+import type {WidgetPlacement, WidgetProps} from '@deck.gl/core';
+import type {JSX} from 'preact';
+
+/** JSON-safe CSS color or deck.gl-style RGB(A) tuple. Tuple channels use the 0-255 range. */
+export type ColorLegendColor =
+  | string
+  | readonly [red: number, green: number, blue: number]
+  | readonly [red: number, green: number, blue: number, alpha: number];
+
+/** One labeled swatch in a categorical legend section. */
+export type ColorLegendCategoricalEntry = {
+  /** Color rendered by the swatch. */
+  readonly color: ColorLegendColor;
+  /** Primary category label. */
+  readonly label: string;
+  /** Optional secondary explanation rendered below the label. */
+  readonly description?: string;
+  /** Optional accessible hover text shared by the complete row, its label, and its swatch. */
+  readonly title?: string;
+};
+
+/** One low-to-high stop in a continuous color scale. */
+export type ColorLegendContinuousStop = {
+  /** Color at this point in the scale. */
+  readonly color: ColorLegendColor;
+  /** Human-readable value rendered beside the stop. */
+  readonly label: string;
+};
+
+/** One color in a compact palette strip. */
+export type ColorLegendPaletteColor = {
+  /** Color rendered in the palette. */
+  readonly color: ColorLegendColor;
+  /** Optional accessible and hover label for this individual color. */
+  readonly label?: string;
+};
+
+/** Expandable list of discrete categories. */
+export type ColorLegendCategoricalSection = {
+  /** Discriminator for a categorical section. */
+  readonly type: 'categorical';
+  /** Stable JSON identifier used to preserve this section's interaction state. */
+  readonly id: string;
+  /** Optional heading above this section. */
+  readonly title?: string;
+  /** Prepared entries, ordered as they should appear. */
+  readonly entries: readonly ColorLegendCategoricalEntry[];
+  /** Exact category count, including entries omitted from this bounded payload. */
+  readonly totalCount?: number;
+  /** Number of entries shown before expansion. Defaults to 10. */
+  readonly maxVisibleEntries?: number;
+  /** Number of prepared entries shown after expansion. Defaults to 100. */
+  readonly maxExpandedEntries?: number;
+};
+
+/** Vertical gradient with labeled stops. Stops are ordered from low to high. */
+export type ColorLegendContinuousSection = {
+  /** Discriminator for a continuous section. */
+  readonly type: 'continuous';
+  /** Stable JSON identifier for this section. */
+  readonly id: string;
+  /** Optional heading above this section. */
+  readonly title?: string;
+  /** Gradient stops ordered from the smallest value to the largest value. */
+  readonly stops: readonly ColorLegendContinuousStop[];
+};
+
+/** Compact row of colors used when individual categories are intentionally not enumerated. */
+export type ColorLegendPaletteSection = {
+  /** Discriminator for a palette section. */
+  readonly type: 'palette';
+  /** Stable JSON identifier for this section. */
+  readonly id: string;
+  /** Optional heading above this section. */
+  readonly title?: string;
+  /** Optional explanation rendered beside the palette strip. */
+  readonly label?: string;
+  /** Colors shown from left to right. */
+  readonly colors: readonly ColorLegendPaletteColor[];
+};
+
+/** One declarative section in a color legend payload. */
+export type ColorLegendSection =
+  | ColorLegendCategoricalSection
+  | ColorLegendContinuousSection
+  | ColorLegendPaletteSection;
+
+/** Serializable content rendered by {@link ColorLegendWidget}. */
+export type ColorLegendPayload = {
+  /** Stable identifier for the selected scheme and its local interaction state. */
+  readonly id: string;
+  /** Visible legend heading. */
+  readonly title: string;
+  /** Optional short explanation below the heading. */
+  readonly description?: string;
+  /** Optional accessible label. Defaults to "{title} legend". */
+  readonly ariaLabel?: string;
+  /** Ordered categorical, continuous, and palette sections. */
+  readonly sections: readonly ColorLegendSection[];
+};
+
+/** Props for a deck.gl widget driven by a JSON-safe color legend payload. */
+export type ColorLegendWidgetProps = WidgetProps & {
+  /** Serializable legend definition prepared by the caller. */
+  readonly payload: ColorLegendPayload;
+  /** Deck widget placement within the selected view. Defaults to bottom-right. */
+  readonly placement?: WidgetPlacement;
+  /** Deck view that owns the widget. */
+  readonly viewId?: string | null;
+  /** Optional action shown as a dismiss button in the legend header. */
+  readonly onClose?: () => void;
+};
+
+/** Deck.gl widget that renders categorical, continuous, and palette color keys from JSON. */
+export class ColorLegendWidget extends Widget<ColorLegendWidgetProps> {
+  /** Theme-owned deck widget class attached to the legend host. */
+  override className = 'deck-widget-color-legend';
+  /** Default corner for floating color legends. */
+  override placement: WidgetPlacement = 'bottom-right';
+
+  /** Latest element owned by Preact so it can be cleanly unmounted. */
+  #rootElement: HTMLElement | null = null;
+
+  /** Creates a color legend widget from a JSON-safe payload. */
+  constructor(props: ColorLegendWidgetProps) {
+    super({id: 'color-legend', ...props});
+    this.placement = props.placement ?? this.placement;
+    this.viewId = props.viewId ?? this.viewId;
+  }
+
+  /** Keeps placement and view ownership synchronized with deck-managed prop updates. */
+  override setProps(props: Partial<ColorLegendWidgetProps>): void {
+    this.placement = props.placement ?? this.placement;
+    if (props.viewId !== undefined) {
+      this.viewId = props.viewId;
+    }
+    super.setProps(props);
+  }
+
+  /** Renders the latest declarative payload without inspecting application data. */
+  override onRenderHTML(rootElement: HTMLElement): void {
+    this.#rootElement = rootElement;
+    rootElement.style.pointerEvents = 'none';
+    render(
+      <ColorLegendView payload={this.props.payload} onClose={this.props.onClose} />,
+      rootElement
+    );
+  }
+
+  /** Releases the Preact tree when deck.gl removes the widget. */
+  override onRemove(): void {
+    if (this.#rootElement) {
+      render(null, this.#rootElement);
+      this.#rootElement = null;
+    }
+  }
+}
+
+const DEFAULT_VISIBLE_ENTRY_COUNT = 10;
+const DEFAULT_EXPANDED_ENTRY_COUNT = 100;
+const TOOLTIP_VIEWPORT_MARGIN = 8;
+const TOOLTIP_MAX_WIDTH = 320;
+
+const LEGEND_STYLE: JSX.CSSProperties = {
+  pointerEvents: 'none',
+  maxWidth: '224px',
+  boxSizing: 'border-box',
+  padding: '6px 8px',
+  border: '1px solid var(--button-stroke, rgba(148, 163, 184, 0.35))',
+  borderRadius: 'var(--button-corner-radius, 6px)',
+  background: 'var(--menu-background, var(--button-background, rgba(255, 255, 255, 0.95)))',
+  color: 'var(--menu-text, var(--button-text, currentColor))',
+  boxShadow: 'var(--button-shadow, 0 1px 3px rgba(0, 0, 0, 0.15))',
+  fontSize: '12px',
+  lineHeight: 1.25,
+  transform: 'scale(0.9)',
+  transformOrigin: 'bottom right'
+};
+
+const HEADER_STYLE: JSX.CSSProperties = {
+  pointerEvents: 'auto',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '8px',
+  marginBottom: '6px',
+  fontWeight: 500
+};
+
+const MUTED_TEXT_STYLE: JSX.CSSProperties = {
+  color: 'var(--menu-text-muted, var(--button-icon-idle, currentColor))',
+  opacity: 0.78
+};
+
+const CLOSE_BUTTON_STYLE: JSX.CSSProperties = {
+  pointerEvents: 'auto',
+  appearance: 'none',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '16px',
+  height: '16px',
+  padding: 0,
+  border: 0,
+  borderRadius: '3px',
+  background: 'transparent',
+  color: 'var(--button-icon-idle, currentColor)',
+  cursor: 'pointer',
+  opacity: 0,
+  transition: 'opacity 120ms ease'
+};
+
+const ACTION_BUTTON_STYLE: JSX.CSSProperties = {
+  pointerEvents: 'auto',
+  appearance: 'none',
+  padding: 0,
+  border: 0,
+  background: 'transparent',
+  color: 'var(--button-icon-idle, currentColor)',
+  font: 'inherit',
+  cursor: 'pointer'
+};
+
+const ENTRY_TOOLTIP_STYLE: JSX.CSSProperties = {
+  position: 'fixed',
+  zIndex: 2_147_483_647,
+  width: 'max-content',
+  boxSizing: 'border-box',
+  padding: '6px 8px',
+  border: '1px solid CanvasText',
+  borderRadius: '6px',
+  background: 'Canvas',
+  color: 'CanvasText',
+  boxShadow: 'none',
+  fontSize: '12px',
+  lineHeight: 1.35,
+  whiteSpace: 'normal',
+  overflowWrap: 'anywhere',
+  pointerEvents: 'none'
+};
+
+type ColorLegendViewProps = {
+  /** Serializable content to render. */
+  readonly payload: ColorLegendPayload;
+  /** Optional dismiss action for the legend header. */
+  readonly onClose?: () => void;
+};
+
+type ColorLegendSectionViewProps = {
+  /** Discriminated section to render. */
+  readonly section: ColorLegendSection;
+  /** Whether this section's complete prepared entry set is visible. */
+  readonly isExpanded: boolean;
+  /** Updates this section's expansion state. */
+  readonly onExpandedChange: (isExpanded: boolean) => void;
+};
+
+type CategoricalSectionViewProps = {
+  /** Categorical section to render. */
+  readonly section: ColorLegendCategoricalSection;
+  /** Whether the expanded prepared entry prefix is visible. */
+  readonly isExpanded: boolean;
+  /** Updates this section's expansion state. */
+  readonly onExpandedChange: (isExpanded: boolean) => void;
+};
+
+/** Viewport-positioned tooltip state for the single currently hovered legend row. */
+type ColorLegendHoveredEntry = {
+  /** Immutable categorical section that owned the row when its tooltip opened. */
+  readonly section: ColorLegendCategoricalSection;
+  /** Immutable legend entry associated with the visible tooltip and focus target. */
+  readonly entry: ColorLegendCategoricalEntry;
+  /** Full prepared hover text supplied by the categorical legend entry. */
+  readonly title: string;
+  /** Viewport-relative tooltip anchor position on the horizontal axis. */
+  readonly left: number;
+  /** Viewport-relative vertical midpoint of the hovered legend row. */
+  readonly top: number;
+  /** Whether the tooltip should open to the left or right of its anchor. */
+  readonly placement: 'left' | 'right';
+  /** Maximum tooltip width that still fits inside the current viewport. */
+  readonly maxWidth: number;
+  /** Resolved legend surface color retained outside the deck theme's DOM scope. */
+  readonly backgroundColor: string;
+  /** Resolved legend foreground color retained outside the deck theme's DOM scope. */
+  readonly color: string;
+  /** Resolved legend border color retained outside the deck theme's DOM scope. */
+  readonly borderColor: string;
+  /** Resolved legend corner radius retained outside the deck theme's DOM scope. */
+  readonly borderRadius: string;
+  /** Resolved legend shadow retained outside the deck theme's DOM scope. */
+  readonly boxShadow: string;
+  /** Document that owns the legend row and its clipping-independent portal. */
+  readonly ownerDocument: Document;
+};
+
+/** Measured tooltip position retained with the hover state that produced it. */
+type ColorLegendMeasuredTooltipTop = {
+  /** Hover state whose rendered tooltip height produced this clamped position. */
+  readonly hoveredEntry: ColorLegendHoveredEntry;
+  /** Viewport-relative vertical midpoint after measuring and clamping the tooltip. */
+  readonly top: number;
+};
+
+type ContinuousSectionViewProps = {
+  /** Continuous scale to render. */
+  readonly section: ColorLegendContinuousSection;
+};
+
+type PaletteSectionViewProps = {
+  /** Compact palette to render. */
+  readonly section: ColorLegendPaletteSection;
+};
+
+type ColorSwatchProps = {
+  /** Color rendered by the swatch. */
+  readonly color: ColorLegendColor;
+  /** CSS width and height for the square. */
+  readonly size?: string;
+  /** Optional accessible and hover label. */
+  readonly title?: string;
+};
+
+/** Preact view for one serializable color legend. */
+function ColorLegendView({payload, onClose}: ColorLegendViewProps) {
+  const [expandedSectionKey, setExpandedSectionKey] = useState<string | null>(null);
+  const [isHeaderHovered, setIsHeaderHovered] = useState(false);
+  const [isCloseFocused, setIsCloseFocused] = useState(false);
+
+  if (payload.sections.length === 0) {
+    return null;
+  }
+
+  return (
+    <aside
+      aria-label={payload.ariaLabel ?? `${payload.title} legend`}
+      className="deck-widget-color-legend-content"
+      data-testid="color-legend"
+      style={LEGEND_STYLE}
+    >
+      <div
+        style={HEADER_STYLE}
+        onMouseEnter={() => setIsHeaderHovered(true)}
+        onMouseLeave={() => setIsHeaderHovered(false)}
+      >
+        <span>{payload.title}</span>
+        {onClose ? (
+          <button
+            aria-label="Close color legend"
+            className="deck-widget-color-legend-close"
+            style={{
+              ...CLOSE_BUTTON_STYLE,
+              opacity: isHeaderHovered || isCloseFocused ? 1 : 0
+            }}
+            type="button"
+            onBlur={() => setIsCloseFocused(false)}
+            onClick={onClose}
+            onFocus={() => setIsCloseFocused(true)}
+          >
+            <svg aria-hidden="true" height="12" viewBox="0 0 12 12" width="12">
+              <path d="M2 2l8 8M10 2l-8 8" fill="none" stroke="currentColor" stroke-width="1.5" />
+            </svg>
+          </button>
+        ) : null}
+      </div>
+      {payload.description ? (
+        <div style={{...MUTED_TEXT_STYLE, marginBottom: '7px'}}>{payload.description}</div>
+      ) : null}
+      <div style={{display: 'flex', flexDirection: 'column', gap: '7px'}}>
+        {payload.sections.map(section => {
+          const sectionKey = `${payload.id}:${section.id}`;
+          return (
+            <ColorLegendSectionView
+              key={section.id}
+              section={section}
+              isExpanded={expandedSectionKey === sectionKey}
+              onExpandedChange={isExpanded => setExpandedSectionKey(isExpanded ? sectionKey : null)}
+            />
+          );
+        })}
+      </div>
+    </aside>
+  );
+}
+
+/** Renders one discriminated legend section. */
+function ColorLegendSectionView({
+  section,
+  isExpanded,
+  onExpandedChange
+}: ColorLegendSectionViewProps) {
+  return (
+    <section>
+      {section.title ? (
+        <div style={{marginBottom: '4px', fontWeight: 500}}>{section.title}</div>
+      ) : null}
+      {section.type === 'categorical' ? (
+        <CategoricalSectionView
+          section={section}
+          isExpanded={isExpanded}
+          onExpandedChange={onExpandedChange}
+        />
+      ) : section.type === 'continuous' ? (
+        <ContinuousSectionView section={section} />
+      ) : (
+        <PaletteSectionView section={section} />
+      )}
+    </section>
+  );
+}
+
+/** Renders a bounded categorical list with optional expansion. */
+function CategoricalSectionView({
+  section,
+  isExpanded,
+  onExpandedChange
+}: CategoricalSectionViewProps) {
+  const [hoveredEntry, setHoveredEntry] = useState<ColorLegendHoveredEntry | null>(null);
+  const [measuredTooltipTop, setMeasuredTooltipTop] =
+    useState<ColorLegendMeasuredTooltipTop | null>(null);
+  const tooltipElementRef = useRef<HTMLSpanElement | null>(null);
+  const tooltipId = useId();
+  const activeHoveredEntry = hoveredEntry?.section === section ? hoveredEntry : null;
+  const activeTooltipTop =
+    measuredTooltipTop?.hoveredEntry === activeHoveredEntry
+      ? measuredTooltipTop.top
+      : activeHoveredEntry?.top;
+
+  useEffect(() => {
+    const ownerWindow = activeHoveredEntry?.ownerDocument.defaultView;
+    if (!ownerWindow) {
+      return undefined;
+    }
+
+    const dismissTooltip = () => setHoveredEntry(null);
+    ownerWindow.addEventListener('scroll', dismissTooltip, true);
+    ownerWindow.addEventListener('resize', dismissTooltip);
+    return () => {
+      ownerWindow.removeEventListener('scroll', dismissTooltip, true);
+      ownerWindow.removeEventListener('resize', dismissTooltip);
+    };
+  }, [activeHoveredEntry]);
+
+  useLayoutEffect(() => {
+    const tooltipElement = tooltipElementRef.current;
+    if (!activeHoveredEntry) {
+      setMeasuredTooltipTop(null);
+      return;
+    }
+    if (!tooltipElement) {
+      return;
+    }
+
+    const viewportHeight = getTooltipViewportHeight(activeHoveredEntry.ownerDocument);
+    if (viewportHeight === null) {
+      return;
+    }
+
+    const measuredHeight = tooltipElement.getBoundingClientRect().height;
+    const top = clampTooltipTop(activeHoveredEntry.top, measuredHeight, viewportHeight);
+    setMeasuredTooltipTop(previousTop =>
+      previousTop?.hoveredEntry === activeHoveredEntry && previousTop.top === top
+        ? previousTop
+        : {hoveredEntry: activeHoveredEntry, top}
+    );
+  }, [activeHoveredEntry]);
+
+  const visibleLimit = normalizeEntryLimit(
+    isExpanded ? section.maxExpandedEntries : section.maxVisibleEntries,
+    isExpanded ? DEFAULT_EXPANDED_ENTRY_COUNT : DEFAULT_VISIBLE_ENTRY_COUNT
+  );
+  const visibleEntries = section.entries.slice(0, visibleLimit);
+  const totalCount = Math.max(section.totalCount ?? section.entries.length, section.entries.length);
+  const hiddenCount = Math.max(0, totalCount - visibleEntries.length);
+  const canExpand = !isExpanded && section.entries.length > visibleEntries.length;
+
+  return (
+    <>
+      <ul
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '2px',
+          maxHeight: isExpanded ? '288px' : undefined,
+          margin: 0,
+          padding: 0,
+          overflowY: isExpanded ? 'auto' : undefined,
+          listStyle: 'none',
+          pointerEvents: isExpanded ? 'auto' : undefined
+        }}
+        onScroll={() => setHoveredEntry(null)}
+      >
+        {visibleEntries.map((entry, index) => (
+          <li
+            key={`${entry.label}:${index}`}
+            style={{
+              display: 'flex',
+              minWidth: 0,
+              alignItems: 'center',
+              gap: '6px',
+              pointerEvents: entry.title ? 'auto' : undefined
+            }}
+            aria-describedby={activeHoveredEntry?.entry === entry ? tooltipId : undefined}
+            tabIndex={entry.title ? 0 : undefined}
+            title={entry.title}
+            onMouseEnter={
+              entry.title
+                ? event =>
+                    showColorLegendEntryTooltip(
+                      event.currentTarget,
+                      entry,
+                      section,
+                      setHoveredEntry
+                    )
+                : undefined
+            }
+            onMouseLeave={entry.title ? () => setHoveredEntry(null) : undefined}
+            onFocus={
+              entry.title
+                ? event =>
+                    showColorLegendEntryTooltip(
+                      event.currentTarget,
+                      entry,
+                      section,
+                      setHoveredEntry
+                    )
+                : undefined
+            }
+            onBlur={entry.title ? () => setHoveredEntry(null) : undefined}
+          >
+            <ColorSwatch color={entry.color} title={entry.title} />
+            <span style={{minWidth: 0, overflow: 'hidden'}}>
+              <span
+                style={{
+                  ...MUTED_TEXT_STYLE,
+                  display: 'block',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap'
+                }}
+                title={entry.title ?? entry.label}
+              >
+                {entry.label}
+              </span>
+              {entry.description ? (
+                <span
+                  style={{...MUTED_TEXT_STYLE, display: 'block', fontSize: '11px', opacity: 0.65}}
+                >
+                  {entry.description}
+                </span>
+              ) : null}
+            </span>
+          </li>
+        ))}
+        {hiddenCount > 0 ? (
+          <li>
+            {canExpand ? (
+              <button
+                aria-label="Show all color categories"
+                className="deck-widget-color-legend-action"
+                style={ACTION_BUTTON_STYLE}
+                type="button"
+                onClick={() => onExpandedChange(true)}
+              >
+                {`+${hiddenCount.toLocaleString()} more`}
+              </button>
+            ) : (
+              <span style={MUTED_TEXT_STYLE}>{`+${hiddenCount.toLocaleString()} more`}</span>
+            )}
+          </li>
+        ) : null}
+        {isExpanded ? (
+          <li>
+            <button
+              aria-label="Collapse color categories"
+              className="deck-widget-color-legend-action"
+              style={ACTION_BUTTON_STYLE}
+              type="button"
+              onClick={() => onExpandedChange(false)}
+            >
+              Show less
+            </button>
+          </li>
+        ) : null}
+      </ul>
+      {activeHoveredEntry
+        ? createPortal(
+            <span
+              ref={tooltipElementRef}
+              id={tooltipId}
+              role="tooltip"
+              data-testid="color-legend-entry-tooltip"
+              style={{
+                ...ENTRY_TOOLTIP_STYLE,
+                background: activeHoveredEntry.backgroundColor,
+                color: activeHoveredEntry.color,
+                borderColor: activeHoveredEntry.borderColor,
+                borderRadius: activeHoveredEntry.borderRadius,
+                boxShadow: activeHoveredEntry.boxShadow,
+                left: `${activeHoveredEntry.left}px`,
+                top: `${activeTooltipTop ?? activeHoveredEntry.top}px`,
+                maxWidth: `${activeHoveredEntry.maxWidth}px`,
+                maxHeight: getTooltipMaxHeight(activeHoveredEntry.ownerDocument),
+                overflow: 'hidden',
+                transform:
+                  activeHoveredEntry.placement === 'left'
+                    ? 'translate(-100%, -50%)'
+                    : 'translate(0, -50%)'
+              }}
+            >
+              {activeHoveredEntry.title}
+            </span>,
+            activeHoveredEntry.ownerDocument.body
+          )
+        : null}
+    </>
+  );
+}
+
+/** Opens a viewport-clamped tooltip using the resolved theme of its owning legend. */
+function showColorLegendEntryTooltip(
+  row: HTMLElement,
+  entry: ColorLegendCategoricalEntry,
+  section: ColorLegendCategoricalSection,
+  onShow: (hoveredEntry: ColorLegendHoveredEntry) => void
+): void {
+  const title = entry.title;
+  if (!title) {
+    return;
+  }
+
+  const bounds = row.getBoundingClientRect();
+  const ownerWindow = row.ownerDocument.defaultView;
+  const viewportWidth = ownerWindow?.innerWidth ?? bounds.right;
+  const maxWidth = Math.min(
+    TOOLTIP_MAX_WIDTH,
+    Math.max(0, viewportWidth - TOOLTIP_VIEWPORT_MARGIN * 2)
+  );
+  const placement = bounds.left >= viewportWidth - bounds.right ? 'left' : 'right';
+  const left =
+    placement === 'left'
+      ? Math.min(
+          viewportWidth - TOOLTIP_VIEWPORT_MARGIN,
+          Math.max(maxWidth + TOOLTIP_VIEWPORT_MARGIN, bounds.left - TOOLTIP_VIEWPORT_MARGIN)
+        )
+      : Math.max(
+          TOOLTIP_VIEWPORT_MARGIN,
+          Math.min(
+            viewportWidth - maxWidth - TOOLTIP_VIEWPORT_MARGIN,
+            bounds.right + TOOLTIP_VIEWPORT_MARGIN
+          )
+        );
+  const legend = row.closest<HTMLElement>('[data-testid="color-legend"]') ?? row;
+  const theme = ownerWindow?.getComputedStyle(legend);
+
+  onShow({
+    section,
+    entry,
+    title,
+    left,
+    top: bounds.top + bounds.height / 2,
+    placement,
+    maxWidth,
+    backgroundColor: theme?.backgroundColor || 'Canvas',
+    color: theme?.color || 'CanvasText',
+    borderColor: theme?.borderColor || theme?.color || 'CanvasText',
+    borderRadius: theme?.borderRadius || '6px',
+    boxShadow: theme?.boxShadow || 'none',
+    ownerDocument: row.ownerDocument
+  });
+}
+
+/** Returns a finite viewport height when the tooltip's owning document has one. */
+function getTooltipViewportHeight(ownerDocument: Document): number | null {
+  const viewportHeight = ownerDocument.defaultView?.innerHeight;
+  return typeof viewportHeight === 'number' && Number.isFinite(viewportHeight)
+    ? Math.max(0, viewportHeight)
+    : null;
+}
+
+/** Returns a CSS height cap that keeps a tooltip inside its viewport margin. */
+function getTooltipMaxHeight(ownerDocument: Document): string | undefined {
+  const viewportHeight = getTooltipViewportHeight(ownerDocument);
+  return viewportHeight === null
+    ? undefined
+    : `${Math.max(0, viewportHeight - TOOLTIP_VIEWPORT_MARGIN * 2)}px`;
+}
+
+/** Clamps a measured tooltip midpoint so its visible box stays inside the viewport. */
+function clampTooltipTop(anchorTop: number, tooltipHeight: number, viewportHeight: number): number {
+  const availableHeight = Math.max(0, viewportHeight - TOOLTIP_VIEWPORT_MARGIN * 2);
+  const visibleHeight = Math.min(Math.max(0, tooltipHeight), availableHeight);
+  const minTop = TOOLTIP_VIEWPORT_MARGIN + visibleHeight / 2;
+  const maxTop = Math.max(minTop, viewportHeight - TOOLTIP_VIEWPORT_MARGIN - visibleHeight / 2);
+  return Math.min(maxTop, Math.max(minTop, anchorTop));
+}
+
+/** Renders one vertical continuous gradient and its high-to-low labels. */
+function ContinuousSectionView({section}: ContinuousSectionViewProps) {
+  const [singleStop] = section.stops;
+  return (
+    <div style={{display: 'flex', alignItems: 'stretch', gap: '8px'}}>
+      <div
+        aria-hidden="true"
+        data-testid="color-legend-gradient"
+        style={{
+          width: '8px',
+          minHeight: '64px',
+          flexShrink: 0,
+          borderRadius: '9999px',
+          backgroundColor:
+            section.stops.length === 1 && singleStop
+              ? formatLegendColor(singleStop.color)
+              : undefined,
+          backgroundImage:
+            section.stops.length > 1 ? formatColorScaleGradient(section.stops) : undefined
+        }}
+      />
+      <div
+        style={{
+          ...MUTED_TEXT_STYLE,
+          display: 'flex',
+          minHeight: '64px',
+          flexDirection: 'column-reverse',
+          justifyContent: 'space-between',
+          gap: '8px'
+        }}
+      >
+        {section.stops.map((stop, index) => (
+          <span key={`${stop.label}:${index}`}>{stop.label}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Renders a compact strip for palettes whose categories should not be enumerated. */
+function PaletteSectionView({section}: PaletteSectionViewProps) {
+  return (
+    <div style={{display: 'flex', alignItems: 'center', gap: '8px'}}>
+      <span style={{display: 'flex', flexShrink: 0, gap: '2px'}}>
+        {section.colors.map((entry, index) => (
+          <ColorSwatch
+            key={`${formatLegendColor(entry.color)}:${index}`}
+            color={entry.color}
+            size="10px"
+            title={entry.label}
+          />
+        ))}
+      </span>
+      {section.label ? <span style={MUTED_TEXT_STYLE}>{section.label}</span> : null}
+    </div>
+  );
+}
+
+/** Renders one small, non-interactive color sample. */
+function ColorSwatch({color, size = '8px', title}: ColorSwatchProps) {
+  return (
+    <span
+      aria-hidden={title ? undefined : true}
+      aria-label={title}
+      data-testid="color-legend-swatch"
+      role={title ? 'img' : undefined}
+      style={{
+        width: size,
+        height: size,
+        flexShrink: 0,
+        borderRadius: '2px',
+        backgroundColor: formatLegendColor(color)
+      }}
+      title={title}
+    />
+  );
+}
+
+/** Normalizes caller-provided entry limits to a safe non-negative integer. */
+function normalizeEntryLimit(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value ?? fallback)) : fallback;
+}
+
+/** Converts one JSON-safe color value into CSS. */
+function formatLegendColor(color: ColorLegendColor): string {
+  if (typeof color === 'string') {
+    return color;
+  }
+  const [red, green, blue, alpha = 255] = color;
+  return `rgba(${red}, ${green}, ${blue}, ${alpha / 255})`;
+}
+
+/** Creates a bottom-to-top gradient from low-to-high declarative stops. */
+function formatColorScaleGradient(stops: readonly ColorLegendContinuousStop[]): string {
+  return `linear-gradient(to top, ${stops.map(stop => formatLegendColor(stop.color)).join(', ')})`;
+}

--- a/modules/widgets/src/widgets/omni-box-widget.test.tsx
+++ b/modules/widgets/src/widgets/omni-box-widget.test.tsx
@@ -5,7 +5,7 @@ import {CommandManager, toastManager} from '@deck.gl-community/panels';
 
 import {OmniBoxWidget} from './omni-box-widget';
 
-import type {OmniBoxWidgetProps} from './omni-box-widget';
+import type {OmniBoxOption, OmniBoxWidgetProps} from './omni-box-widget';
 
 function renderWidget(props: OmniBoxWidgetProps = {}) {
   const root = document.createElement('div');
@@ -36,6 +36,7 @@ function renderWidget(props: OmniBoxWidgetProps = {}) {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   toastManager.clear();
   document.body.innerHTML = '';
   window.localStorage.clear();
@@ -329,6 +330,291 @@ describe('OmniBoxWidget', () => {
 
     expect(getOptions).toHaveBeenCalledWith('alpha');
     expect(root.querySelector('button[role="option"]')?.textContent).toContain('Alpha item');
+
+    cleanup();
+  });
+
+  it('allows callers to sort and bound ordinary search results', async () => {
+    const {root, cleanup} = renderWidget({
+      minQueryLength: 1,
+      getOptions: () => [
+        {id: 'short', label: 'Short item', data: {duration: 5}},
+        {id: 'long', label: 'Long item', data: {duration: 125}}
+      ],
+      sortOptions: options =>
+        [...options]
+          .sort(
+            (left, right) =>
+              (right.data as {duration: number}).duration -
+              (left.data as {duration: number}).duration
+          )
+          .slice(0, 1)
+    });
+
+    const input = root.querySelector('input[aria-label="OmniBox"]') as HTMLInputElement;
+    await act(async () => {
+      input.focus();
+      input.dispatchEvent(new FocusEvent('focus', {bubbles: false}));
+      input.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
+      input.value = 'item';
+      input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    });
+    await act(async () => {
+      await new Promise(resolve => window.setTimeout(resolve, 0));
+    });
+
+    const options = root.querySelectorAll<HTMLButtonElement>('button[role="option"]');
+    expect(options).toHaveLength(1);
+    expect(options[0]?.textContent).toContain('Long item');
+
+    cleanup();
+  });
+
+  it('reruns the current query when its search refresh key changes', async () => {
+    let loadCount = 0;
+    const getOptions = vi.fn(() => {
+      loadCount += 1;
+      return [{id: `result-${loadCount}`, label: `Result ${loadCount}`}];
+    });
+    const {root, widget, cleanup} = renderWidget({
+      minQueryLength: 1,
+      searchRefreshKey: 0,
+      getOptions
+    });
+
+    const input = root.querySelector('input[aria-label="OmniBox"]') as HTMLInputElement;
+    await act(async () => {
+      input.focus();
+      input.dispatchEvent(new FocusEvent('focus', {bubbles: false}));
+      input.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
+      input.value = 'alpha';
+      input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    });
+    await act(async () => {
+      await new Promise(resolve => window.setTimeout(resolve, 0));
+    });
+
+    expect(getOptions).toHaveBeenCalledOnce();
+    expect(root.querySelector('button[role="option"]')?.textContent).toContain('Result 1');
+
+    await act(async () => {
+      widget.setProps({searchRefreshKey: 1});
+      widget.onRenderHTML(root);
+    });
+    await act(async () => {
+      await new Promise(resolve => window.setTimeout(resolve, 0));
+    });
+
+    expect(getOptions).toHaveBeenCalledTimes(2);
+    expect(getOptions).toHaveBeenLastCalledWith('alpha');
+    expect(root.querySelector('button[role="option"]')?.textContent).toContain('Result 2');
+
+    cleanup();
+  });
+
+  it('rejects stale asynchronous results after the query changes', async () => {
+    const resolvers = new Map<
+      string,
+      (options: ReadonlyArray<{id: string; label: string}>) => void
+    >();
+    const getOptions = vi.fn(
+      (query: string) =>
+        new Promise<ReadonlyArray<{id: string; label: string}>>(resolve => {
+          resolvers.set(query, resolve);
+        })
+    );
+    const onResultsStateChange = vi.fn();
+    const {root, cleanup} = renderWidget({
+      minQueryLength: 1,
+      getOptions,
+      onResultsStateChange
+    });
+
+    const input = root.querySelector('input[aria-label="OmniBox"]') as HTMLInputElement;
+    await act(async () => {
+      input.focus();
+      input.dispatchEvent(new FocusEvent('focus', {bubbles: false}));
+      input.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
+      input.value = 'alpha';
+      input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      input.value = 'beta';
+      input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      resolvers.get('alpha')?.([{id: 'alpha', label: 'Alpha item'}]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(root.querySelector('button[role="option"]')).toBeNull();
+    expect(onResultsStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: 'beta',
+        options: [],
+        isLoading: true
+      })
+    );
+
+    await act(async () => {
+      resolvers.get('beta')?.([{id: 'beta', label: 'Beta item'}]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(root.querySelector('button[role="option"]')?.textContent).toContain('Beta item');
+    expect(onResultsStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: 'beta',
+        options: [expect.objectContaining({id: 'beta'})],
+        isLoading: false
+      })
+    );
+
+    cleanup();
+  });
+
+  it('debounces ordinary searches and reports loading state while typing', async () => {
+    vi.useFakeTimers();
+    const getOptions = vi.fn((query: string) => [{id: query, label: query + ' item'}]);
+    const onResultsStateChange = vi.fn();
+    const {root, cleanup} = renderWidget({
+      minQueryLength: 1,
+      searchDebounceMs: 150,
+      getOptions,
+      onResultsStateChange
+    });
+
+    const input = root.querySelector('input[aria-label="OmniBox"]') as HTMLInputElement;
+    await act(async () => {
+      input.focus();
+      input.dispatchEvent(new FocusEvent('focus', {bubbles: false}));
+      input.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
+      input.value = 'a';
+      input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    });
+    await act(async () => {
+      input.value = 'ab';
+      input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    });
+    await act(async () => {
+      input.value = 'abc';
+      input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    });
+
+    expect(getOptions).not.toHaveBeenCalled();
+    expect(onResultsStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: 'abc',
+        options: [],
+        isLoading: true
+      })
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(149);
+    });
+    expect(getOptions).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getOptions).toHaveBeenCalledOnce();
+    expect(getOptions).toHaveBeenCalledWith('abc');
+    expect(onResultsStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: 'abc',
+        options: [expect.objectContaining({id: 'abc'})],
+        isLoading: false
+      })
+    );
+
+    cleanup();
+  });
+
+  it('reschedules a cancelled debounced search when the input is focused again', async () => {
+    vi.useFakeTimers();
+    const getOptions = vi.fn((query: string) => [{id: query, label: query + ' item'}]);
+    const {root, cleanup} = renderWidget({
+      minQueryLength: 1,
+      searchDebounceMs: 150,
+      getOptions
+    });
+
+    const input = root.querySelector('input[aria-label="OmniBox"]') as HTMLInputElement;
+    await act(async () => {
+      input.focus();
+      input.dispatchEvent(new FocusEvent('focus', {bubbles: false}));
+      input.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
+      input.value = 'alpha';
+      input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    });
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape', bubbles: true}));
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(getOptions).not.toHaveBeenCalled();
+    expect(document.activeElement).not.toBe(input);
+
+    await act(async () => {
+      input.focus();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getOptions).toHaveBeenCalledOnce();
+    expect(getOptions).toHaveBeenCalledWith('alpha');
+
+    cleanup();
+  });
+
+  it('keeps command suggestions immediate when search debouncing is enabled', async () => {
+    const commandManager = new CommandManager();
+    commandManager.registerCommand({
+      id: 'view.toggleOverview',
+      label: 'Toggle overview',
+      do: vi.fn()
+    });
+    const getOptions = vi.fn(() => []);
+    const sortOptions = vi.fn((options: ReadonlyArray<OmniBoxOption>) => options);
+    const {root, cleanup} = renderWidget({
+      commandManager,
+      minQueryLength: 1,
+      searchDebounceMs: 150,
+      getOptions,
+      sortOptions
+    });
+
+    const input = root.querySelector('input[aria-label="OmniBox"]') as HTMLInputElement;
+    await act(async () => {
+      input.focus();
+      input.dispatchEvent(new FocusEvent('focus', {bubbles: false}));
+      input.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
+      input.value = '>toggle';
+      input.dispatchEvent(new InputEvent('input', {bubbles: true}));
+    });
+    await act(async () => {
+      await new Promise(resolve => window.setTimeout(resolve, 0));
+    });
+
+    expect(getOptions).not.toHaveBeenCalled();
+    expect(sortOptions).not.toHaveBeenCalled();
+    expect(root.querySelector('button[role="option"]')?.textContent).toContain('Toggle overview');
 
     cleanup();
   });

--- a/modules/widgets/src/widgets/omni-box-widget.tsx
+++ b/modules/widgets/src/widgets/omni-box-widget.tsx
@@ -283,6 +283,11 @@ export type OmniBoxOptionProvider =
   | ((query: string) => Promise<ReadonlyArray<OmniBoxOption>>)
   | ((query: string) => ReadonlyArray<OmniBoxOption>);
 
+/** Reorders or bounds caller-provided search options before they are displayed. */
+export type OmniBoxOptionSorter = (
+  options: ReadonlyArray<OmniBoxOption>
+) => ReadonlyArray<OmniBoxOption>;
+
 export type OmniBoxRenderOptionArgs = {
   option: OmniBoxOption;
   index: number;
@@ -299,10 +304,28 @@ export type OmniBoxResultsSummaryArgs = {
   readonly mode: 'search' | 'command' | 'history';
 };
 
+/** Current result/dropdown state emitted to callers that coordinate external UI. */
+export type OmniBoxResultsState = {
+  /** Current trimmed query used to produce the visible dropdown options. */
+  readonly query: string;
+  /** Options currently rendered in the dropdown. */
+  readonly options: ReadonlyArray<OmniBoxOption>;
+  /** Dropdown mode that produced the visible options. */
+  readonly mode: 'search' | 'command' | 'history';
+  /** Whether async option loading is still in progress for the current query. */
+  readonly isLoading: boolean;
+  /** Whether the result dropdown is currently visible. */
+  readonly isOpen: boolean;
+};
+
 export type OmniBoxWidgetProps = WidgetProps & {
   placement?: WidgetPlacement;
   placeholder?: string;
   minQueryLength?: number;
+  /** Idle delay before loading non-command search options. */
+  searchDebounceMs?: number;
+  /** Stable identity that reruns the current query when its backing search data changes. */
+  searchRefreshKey?: unknown;
   defaultOpen?: boolean;
   /** Whether selecting a suggestion should close the dropdown and copy the selected label into the input. */
   closeOnSelect?: boolean;
@@ -320,6 +343,8 @@ export type OmniBoxWidgetProps = WidgetProps & {
   /** Query prefix that switches the omnibox from search mode into command mode. */
   commandSearchPrefix?: string;
   getOptions?: OmniBoxOptionProvider;
+  /** Reorders or bounds ordinary search results without affecting command or history options. */
+  sortOptions?: OmniBoxOptionSorter;
   renderOption?: (args: OmniBoxRenderOptionArgs) => ComponentChildren;
   /** Optional renderer for a compact row above the current dropdown results. */
   renderResultsSummary?: (args: OmniBoxResultsSummaryArgs) => ComponentChildren;
@@ -327,6 +352,8 @@ export type OmniBoxWidgetProps = WidgetProps & {
   onActiveOptionChange?: (option: OmniBoxOption | null) => void;
   onNavigateOption?: (option: OmniBoxOption) => void;
   onQueryChange?: (query: string) => void;
+  /** Called when the visible dropdown result state changes. */
+  onResultsStateChange?: (state: OmniBoxResultsState) => void;
 };
 
 type OmniBoxWidgetViewProps = {
@@ -334,6 +361,10 @@ type OmniBoxWidgetViewProps = {
   placeholder: string;
   /** Minimum trimmed query length required before suggestions are loaded. */
   minQueryLength: number;
+  /** Idle delay before loading non-command search options. */
+  searchDebounceMs: number;
+  /** Stable identity that reruns the current query when its backing search data changes. */
+  searchRefreshKey?: unknown;
   /** Whether the input row is open when the widget first renders. */
   defaultOpen: boolean;
   /** Whether selecting a suggestion should close the dropdown and copy the selected label into the input. */
@@ -352,6 +383,8 @@ type OmniBoxWidgetViewProps = {
   commandSearchPrefix: string;
   /** Provides suggestion options for the current trimmed query. */
   getOptions: OmniBoxOptionProvider;
+  /** Reorders or bounds ordinary search results without affecting command or history options. */
+  sortOptions?: OmniBoxOptionSorter;
   /** Custom renderer for a suggestion row. */
   renderOption?: (args: OmniBoxRenderOptionArgs) => ComponentChildren;
   /** Optional renderer for a compact row above the current dropdown results. */
@@ -364,6 +397,8 @@ type OmniBoxWidgetViewProps = {
   onNavigateOption?: (option: OmniBoxOption) => void;
   /** Called whenever the input query changes. */
   onQueryChange?: (query: string) => void;
+  /** Called when the visible dropdown result state changes. */
+  onResultsStateChange?: (state: OmniBoxResultsState) => void;
 };
 
 /** Returns whether an omnibox query should use command suggestions. */
@@ -478,6 +513,11 @@ function getCommandOptions(
     }));
 }
 
+/** Returns a safe non-negative search debounce delay. */
+function normalizeSearchDebounceMs(searchDebounceMs: number): number {
+  return Number.isFinite(searchDebounceMs) ? Math.max(0, searchDebounceMs) : 0;
+}
+
 function DefaultOptionContent({option}: {option: OmniBoxOption}) {
   return (
     <div style={DEFAULT_OPTION_CONTENT_STYLE}>
@@ -559,6 +599,8 @@ function OmniBoxWidgetStyles() {
 function OmniBoxWidgetView({
   placeholder,
   minQueryLength,
+  searchDebounceMs,
+  searchRefreshKey,
   defaultOpen,
   closeOnSelect,
   rememberQueries,
@@ -568,17 +610,21 @@ function OmniBoxWidgetView({
   commandManager,
   commandSearchPrefix,
   getOptions,
+  sortOptions,
   renderOption,
   renderResultsSummary,
   onSelectOption,
   onActiveOptionChange,
   onNavigateOption,
-  onQueryChange
+  onQueryChange,
+  onResultsStateChange
 }: OmniBoxWidgetViewProps) {
   const [query, setQuery] = useState('');
   const [options, setOptions] = useState<ReadonlyArray<OmniBoxOption>>([]);
+  const [resolvedOptionsQuery, setResolvedOptionsQuery] = useState<string | null>('');
   const [activeOptionIndex, setActiveOptionIndex] = useState<number>(-1);
   const [isLoading, setIsLoading] = useState(false);
+  const [searchRefreshVersion, setSearchRefreshVersion] = useState(0);
   const [isFocused, setIsFocused] = useState(false);
   const [isHidden, setIsHidden] = useState(() => !defaultOpen);
   const [isQueryHistoryOpen, setIsQueryHistoryOpen] = useState(false);
@@ -590,7 +636,16 @@ function OmniBoxWidgetView({
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   const optionElementRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const requestVersionRef = useRef(0);
+  const searchDebounceTimeoutRef = useRef<number | null>(null);
   const blurTimeoutRef = useRef<number | null>(null);
+  const normalizedQuery = query.trim();
+
+  const clearSearchDebounceTimeout = useCallback(() => {
+    if (searchDebounceTimeoutRef.current !== null) {
+      window.clearTimeout(searchDebounceTimeoutRef.current);
+      searchDebounceTimeoutRef.current = null;
+    }
+  }, []);
 
   const clearBlurTimeout = useCallback(() => {
     if (blurTimeoutRef.current !== null) {
@@ -599,11 +654,24 @@ function OmniBoxWidgetView({
     }
   }, []);
 
+  const refreshCurrentQuery = useCallback(() => {
+    if (
+      normalizedQuery.length >= minQueryLength &&
+      resolvedOptionsQuery !== normalizedQuery &&
+      !isLoading &&
+      searchDebounceTimeoutRef.current === null
+    ) {
+      setSearchRefreshVersion(version => version + 1);
+    }
+  }, [isLoading, minQueryLength, normalizedQuery, resolvedOptionsQuery]);
+
   useEffect(() => {
     return () => {
       clearBlurTimeout();
+      clearSearchDebounceTimeout();
+      requestVersionRef.current += 1;
     };
-  }, [clearBlurTimeout]);
+  }, [clearBlurTimeout, clearSearchDebounceTimeout]);
 
   const handleShow = useCallback(
     (event?: Event) => {
@@ -652,10 +720,14 @@ function OmniBoxWidgetView({
 
   useEffect(() => {
     onQueryChange?.(query);
+  }, [onQueryChange, query]);
 
-    const normalizedQuery = query.trim();
+  useEffect(() => {
+    clearSearchDebounceTimeout();
     if (normalizedQuery.length < minQueryLength) {
+      requestVersionRef.current += 1;
       setOptions([]);
+      setResolvedOptionsQuery(normalizedQuery);
       setActiveOptionIndex(-1);
       setIsLoading(false);
       return;
@@ -663,34 +735,82 @@ function OmniBoxWidgetView({
 
     const requestVersion = requestVersionRef.current + 1;
     requestVersionRef.current = requestVersion;
+    setOptions([]);
+    setResolvedOptionsQuery(null);
+    setActiveOptionIndex(-1);
     setIsLoading(true);
 
-    const nextOptions =
+    const isCommandSearch = Boolean(
       commandManager && isCommandQuery(normalizedQuery, commandManager, commandSearchPrefix)
-        ? getCommandOptions(commandManager, normalizedQuery, commandSearchPrefix)
-        : getOptions(normalizedQuery);
-
-    Promise.resolve(nextOptions)
-      .then(nextOptions => {
-        if (requestVersionRef.current !== requestVersion) {
-          return;
-        }
-        setOptions(nextOptions);
-        setActiveOptionIndex(nextOptions.length > 0 ? 0 : -1);
-      })
-      .catch(() => {
-        if (requestVersionRef.current !== requestVersion) {
-          return;
-        }
-        setOptions([]);
-        setActiveOptionIndex(-1);
-      })
-      .finally(() => {
+    );
+    const loadOptions = () => {
+      let nextOptions: ReadonlyArray<OmniBoxOption> | Promise<ReadonlyArray<OmniBoxOption>>;
+      try {
+        nextOptions =
+          isCommandSearch && commandManager
+            ? getCommandOptions(commandManager, normalizedQuery, commandSearchPrefix)
+            : getOptions(normalizedQuery);
+      } catch {
         if (requestVersionRef.current === requestVersion) {
+          setOptions([]);
+          setResolvedOptionsQuery(normalizedQuery);
+          setActiveOptionIndex(-1);
           setIsLoading(false);
         }
-      });
-  }, [commandManager, commandSearchPrefix, getOptions, minQueryLength, onQueryChange, query]);
+        return;
+      }
+
+      Promise.resolve(nextOptions)
+        .then(nextOptions => {
+          if (requestVersionRef.current !== requestVersion) {
+            return;
+          }
+          const visibleOptions =
+            isCommandSearch || !sortOptions ? nextOptions : sortOptions(nextOptions);
+          setOptions(visibleOptions);
+          setResolvedOptionsQuery(normalizedQuery);
+          setActiveOptionIndex(visibleOptions.length > 0 ? 0 : -1);
+        })
+        .catch(() => {
+          if (requestVersionRef.current !== requestVersion) {
+            return;
+          }
+          setOptions([]);
+          setResolvedOptionsQuery(normalizedQuery);
+          setActiveOptionIndex(-1);
+        })
+        .finally(() => {
+          if (requestVersionRef.current === requestVersion) {
+            setIsLoading(false);
+          }
+        });
+    };
+
+    const normalizedSearchDebounceMs = normalizeSearchDebounceMs(searchDebounceMs);
+    if (isCommandSearch || normalizedSearchDebounceMs === 0) {
+      loadOptions();
+      return;
+    }
+
+    searchDebounceTimeoutRef.current = window.setTimeout(() => {
+      searchDebounceTimeoutRef.current = null;
+      loadOptions();
+    }, normalizedSearchDebounceMs);
+
+    return clearSearchDebounceTimeout;
+  }, [
+    clearSearchDebounceTimeout,
+    commandManager,
+    commandSearchPrefix,
+    getOptions,
+    minQueryLength,
+    normalizedQuery,
+    query,
+    searchDebounceMs,
+    searchRefreshKey,
+    searchRefreshVersion,
+    sortOptions
+  ]);
 
   useEffect(() => {
     if (isQueryHistoryOpen) {
@@ -839,16 +959,18 @@ function OmniBoxWidgetView({
 
       clearBlurTimeout();
       rememberQuery(query);
+      clearSearchDebounceTimeout();
       requestVersionRef.current += 1;
       setQuery('');
       setOptions([]);
+      setResolvedOptionsQuery('');
       setActiveOptionIndex(-1);
       setIsLoading(false);
       setIsFocused(false);
       setIsQueryHistoryOpen(false);
       setIsHidden(true);
     },
-    [clearBlurTimeout, query, rememberQuery]
+    [clearBlurTimeout, clearSearchDebounceTimeout, query, rememberQuery]
   );
 
   const handleInput: JSX.GenericEventHandler<HTMLInputElement> = useCallback(event => {
@@ -861,7 +983,8 @@ function OmniBoxWidgetView({
   const handleFocus: JSX.FocusEventHandler<HTMLInputElement> = useCallback(() => {
     clearBlurTimeout();
     setIsFocused(true);
-  }, [clearBlurTimeout]);
+    refreshCurrentQuery();
+  }, [clearBlurTimeout, refreshCurrentQuery]);
 
   const handleBlur: JSX.FocusEventHandler<HTMLInputElement> = useCallback(() => {
     clearBlurTimeout();
@@ -873,7 +996,6 @@ function OmniBoxWidgetView({
 
   const hasMatches = options.length > 0;
   const hasQueryHistory = queryHistoryOptions.length > 0;
-  const normalizedQuery = query.trim();
   const dropdownMode: OmniBoxResultsSummaryArgs['mode'] = isShowingQueryHistory
     ? 'history'
     : isCommandQuery(normalizedQuery, commandManager, commandSearchPrefix)
@@ -891,6 +1013,23 @@ function OmniBoxWidgetView({
     !isHidden &&
     (isShowingQueryHistory ||
       (isFocused && normalizedQuery.length >= minQueryLength && (isLoading || options.length > 0)));
+
+  useEffect(() => {
+    onResultsStateChange?.({
+      query: normalizedQuery,
+      options: visibleOptions,
+      mode: dropdownMode,
+      isLoading,
+      isOpen: shouldShowDropdown
+    });
+  }, [
+    dropdownMode,
+    isLoading,
+    normalizedQuery,
+    onResultsStateChange,
+    shouldShowDropdown,
+    visibleOptions
+  ]);
 
   const handleKeyDown: JSX.KeyboardEventHandler<HTMLInputElement> = useCallback(
     event => {
@@ -926,9 +1065,11 @@ function OmniBoxWidgetView({
       if (event.key === 'Escape') {
         event.preventDefault();
         if (isShowingQueryHistory || shouldShowDropdown) {
+          clearSearchDebounceTimeout();
           requestVersionRef.current += 1;
           setIsLoading(false);
           setIsFocused(false);
+          inputRef.current?.blur();
           setIsQueryHistoryOpen(false);
           setActiveOptionIndex(-1);
           return;
@@ -938,6 +1079,7 @@ function OmniBoxWidgetView({
     },
     [
       activeOptionIndex,
+      clearSearchDebounceTimeout,
       handleHide,
       isShowingQueryHistory,
       moveActiveOptionBy,
@@ -1252,6 +1394,8 @@ export class OmniBoxWidget extends Widget<OmniBoxWidgetProps> {
     placement: 'top-left',
     placeholder: 'Search…',
     minQueryLength: 1,
+    searchDebounceMs: 0,
+    searchRefreshKey: undefined,
     defaultOpen: true,
     closeOnSelect: true,
     rememberQueries: false,
@@ -1262,12 +1406,14 @@ export class OmniBoxWidget extends Widget<OmniBoxWidgetProps> {
     commandManager: undefined,
     commandSearchPrefix: DEFAULT_COMMAND_SEARCH_PREFIX,
     getOptions: (() => []) as OmniBoxOptionProvider,
+    sortOptions: undefined,
     renderOption: undefined,
     renderResultsSummary: undefined,
     onSelectOption: undefined,
     onActiveOptionChange: undefined,
     onNavigateOption: undefined,
-    onQueryChange: undefined
+    onQueryChange: undefined,
+    onResultsStateChange: undefined
   } satisfies Required<WidgetProps> &
     Required<Pick<OmniBoxWidgetProps, 'placeholder' | 'minQueryLength' | 'placement'>> &
     OmniBoxWidgetProps;
@@ -1311,6 +1457,10 @@ export class OmniBoxWidget extends Widget<OmniBoxWidgetProps> {
       <OmniBoxWidgetView
         placeholder={this.props.placeholder ?? OmniBoxWidget.defaultProps.placeholder}
         minQueryLength={this.props.minQueryLength ?? OmniBoxWidget.defaultProps.minQueryLength}
+        searchDebounceMs={
+          this.props.searchDebounceMs ?? OmniBoxWidget.defaultProps.searchDebounceMs
+        }
+        searchRefreshKey={this.props.searchRefreshKey}
         defaultOpen={this.props.defaultOpen ?? OmniBoxWidget.defaultProps.defaultOpen}
         closeOnSelect={this.props.closeOnSelect ?? OmniBoxWidget.defaultProps.closeOnSelect}
         rememberQueries={this.props.rememberQueries ?? OmniBoxWidget.defaultProps.rememberQueries}
@@ -1326,12 +1476,14 @@ export class OmniBoxWidget extends Widget<OmniBoxWidgetProps> {
           this.props.commandSearchPrefix ?? OmniBoxWidget.defaultProps.commandSearchPrefix
         }
         getOptions={this.props.getOptions ?? OmniBoxWidget.defaultProps.getOptions}
+        sortOptions={this.props.sortOptions}
         renderOption={this.props.renderOption}
         renderResultsSummary={this.props.renderResultsSummary}
         onSelectOption={this.props.onSelectOption}
         onActiveOptionChange={this.props.onActiveOptionChange}
         onNavigateOption={this.props.onNavigateOption}
         onQueryChange={this.props.onQueryChange}
+        onResultsStateChange={this.props.onResultsStateChange}
       />,
       rootElement
     );

--- a/modules/widgets/src/widgets/time-measure-widget.test.tsx
+++ b/modules/widgets/src/widgets/time-measure-widget.test.tsx
@@ -1,0 +1,277 @@
+import {describe, expect, it, vi} from 'vitest';
+
+import {TimeMeasureWidget} from './time-measure-widget';
+
+import type {PickingInfo, Viewport} from '@deck.gl/core';
+import type {EventManager} from 'mjolnir.js';
+
+type EventManagerHandler = (event: ReturnType<typeof createGestureEvent>) => void;
+type EventHandlerOptions = {priority?: number; srcElement?: 'root' | HTMLElement};
+
+/** Minimal event manager used to exercise widget-owned gesture listeners. */
+class TestEventManager {
+  handlers = new Map<string, EventManagerHandler>();
+  handlerOptions = new Map<string, EventHandlerOptions>();
+
+  /** Creates an event manager with the supplied root element. */
+  constructor(private readonly element: HTMLElement) {}
+
+  /** Returns the root element used by gesture registration. */
+  getElement(): HTMLElement {
+    return this.element;
+  }
+
+  /** Registers one event handler and its options. */
+  on(eventName: string, handler: EventManagerHandler, options: EventHandlerOptions = {}) {
+    this.handlers.set(eventName, handler);
+    this.handlerOptions.set(eventName, options);
+  }
+
+  /** Unregisters one event handler. */
+  off(eventName: string, handler: EventManagerHandler) {
+    if (this.handlers.get(eventName) === handler) {
+      this.handlers.delete(eventName);
+      this.handlerOptions.delete(eventName);
+    }
+  }
+}
+
+/** Returns a linear viewport whose x coordinate is the measured time. */
+function createViewport(): Viewport {
+  return {
+    id: 'main',
+    x: 0,
+    project: ([x]: number[]) => [x, 0],
+    unproject: ([x]: number[]) => [x, 0],
+    containsPixel: ({x, y}: {x: number; y: number}) => x >= 0 && x <= 1000 && y >= 0 && y <= 1000
+  } as unknown as Viewport;
+}
+
+/** Returns picking data at one time coordinate. */
+function createPickingInfo(timeMs: number): PickingInfo {
+  return {
+    coordinate: [timeMs, 0, 0],
+    viewport: createViewport()
+  } as PickingInfo;
+}
+
+/** Returns a minimal pointer gesture for widget interaction tests. */
+function createGestureEvent(
+  pointerState: Partial<
+    Pick<MouseEvent, 'altKey' | 'button' | 'buttons' | 'ctrlKey' | 'metaKey' | 'shiftKey'>
+  > = {},
+  position = {x: 0, y: 0}
+) {
+  return {
+    preventDefault: vi.fn(),
+    stopImmediatePropagation: vi.fn(),
+    stopPropagation: vi.fn(),
+    srcEvent: {
+      button: 0,
+      buttons: 0,
+      shiftKey: false,
+      ...pointerState
+    },
+    center: position,
+    offsetCenter: position
+  };
+}
+
+/** Creates a mounted widget with observable callbacks and a fake deck root. */
+function createWidget() {
+  const canvas = document.createElement('canvas');
+  const eventRoot = document.createElement('div');
+  eventRoot.appendChild(canvas);
+  const eventManager = new TestEventManager(eventRoot);
+  const viewport = createViewport();
+  const onActivate = vi.fn();
+  const onDeactivate = vi.fn();
+  const onRangeChange = vi.fn();
+  const onSelectionChange = vi.fn();
+  const widget = new TimeMeasureWidget({
+    eventViewId: 'main',
+    projectionViewId: 'main',
+    onActivate,
+    onDeactivate,
+    onRangeChange,
+    onSelectionChange
+  });
+  const deck = {
+    eventManager,
+    getCanvas: () => canvas,
+    getViewports: () => [viewport],
+    isInitialized: true
+  } as unknown as {eventManager: EventManager};
+  (widget as unknown as {deck: typeof deck}).deck = deck;
+  const root = widget.onAdd({deck: deck as never, viewId: null}) as HTMLDivElement;
+  document.body.appendChild(root);
+
+  return {
+    eventManager,
+    onActivate,
+    onDeactivate,
+    onRangeChange,
+    onSelectionChange,
+    widget,
+    cleanup() {
+      widget.onRemove();
+      root.remove();
+    }
+  };
+}
+
+/** Selects and commits one initial time range. */
+function selectRange(widget: TimeMeasureWidget, startTimeMs: number, endTimeMs: number) {
+  TimeMeasureWidget.performAction({widget});
+  widget.onClick(createPickingInfo(startTimeMs), createGestureEvent() as never);
+  widget.onClick(createPickingInfo(endTimeMs), createGestureEvent() as never);
+}
+
+describe('TimeMeasureWidget boundary editing', () => {
+  it('reports nearby completed boundaries without changing activation callbacks', () => {
+    const {onActivate, onDeactivate, onSelectionChange, widget, cleanup} = createWidget();
+    selectRange(widget, 100, 250);
+    onActivate.mockClear();
+    onDeactivate.mockClear();
+    onSelectionChange.mockClear();
+
+    widget.onHover(createPickingInfo(102), createGestureEvent() as never);
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({hoveredBoundary: 'start', adjustingBoundary: null})
+    );
+    expect(onActivate).not.toHaveBeenCalled();
+    expect(onDeactivate).not.toHaveBeenCalled();
+
+    widget.onHover(createPickingInfo(180), createGestureEvent() as never);
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({hoveredBoundary: null, adjustingBoundary: null})
+    );
+
+    cleanup();
+  });
+
+  it('remeasures either completed boundary and commits only after drag end', () => {
+    const {onRangeChange, widget, cleanup} = createWidget();
+    selectRange(widget, 100, 250);
+    onRangeChange.mockClear();
+
+    widget.onDragStart(createPickingInfo(100), createGestureEvent() as never);
+    widget.onDrag(createPickingInfo(125), createGestureEvent({}, {x: 125, y: 0}) as never);
+
+    expect(onRangeChange).not.toHaveBeenCalled();
+
+    widget.onDragEnd(createPickingInfo(125), createGestureEvent({}, {x: 125, y: 0}) as never);
+
+    expect(onRangeChange).toHaveBeenLastCalledWith({startTimeMs: 125, endTimeMs: 250});
+
+    widget.onDragStart(createPickingInfo(250), createGestureEvent() as never);
+    widget.onDragEnd(createPickingInfo(300), createGestureEvent({}, {x: 300, y: 0}) as never);
+
+    expect(onRangeChange).toHaveBeenLastCalledWith({startTimeMs: 125, endTimeMs: 300});
+
+    cleanup();
+  });
+
+  it('uses current gesture positions when picking data is stale', () => {
+    const {onRangeChange, onSelectionChange, widget, cleanup} = createWidget();
+    selectRange(widget, 100, 250);
+    const pointerDownPickingInfo = createPickingInfo(100);
+
+    widget.onDragStart(pointerDownPickingInfo, createGestureEvent() as never);
+    widget.onDrag(pointerDownPickingInfo, createGestureEvent({}, {x: 125, y: 0}) as never);
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({adjustingBoundary: 'start', cursorTimeMs: 125})
+    );
+
+    widget.onDragEnd(pointerDownPickingInfo, createGestureEvent({}, {x: 160, y: 0}) as never);
+
+    expect(onRangeChange).toHaveBeenLastCalledWith({startTimeMs: 160, endTimeMs: 250});
+
+    cleanup();
+  });
+
+  it('restores the completed range when boundary adjustment is cancelled', () => {
+    const {eventManager, onRangeChange, onSelectionChange, widget, cleanup} = createWidget();
+    selectRange(widget, 100, 250);
+    onRangeChange.mockClear();
+
+    widget.onDragStart(createPickingInfo(250), createGestureEvent() as never);
+    widget.onDrag(createPickingInfo(300), createGestureEvent({}, {x: 300, y: 0}) as never);
+    eventManager.handlers.get('keydown')?.({
+      ...createGestureEvent(),
+      srcEvent: {key: 'Escape'}
+    } as never);
+
+    expect(onRangeChange).not.toHaveBeenCalled();
+    expect(onSelectionChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        phase: 'selected',
+        range: {startTimeMs: 100, endTimeMs: 250},
+        adjustingBoundary: null
+      })
+    );
+
+    cleanup();
+  });
+
+  it('intercepts primary boundary pans and preserves modified or alternate-button pans', () => {
+    const {eventManager, onSelectionChange, widget, cleanup} = createWidget();
+    selectRange(widget, 100, 250);
+    onSelectionChange.mockClear();
+
+    const pointerMovePanStart = createGestureEvent({button: -1, buttons: 1}, {x: 100, y: 100});
+    eventManager.handlers.get('panstart')?.(pointerMovePanStart);
+
+    expect(eventManager.handlerOptions.get('panstart')?.priority).toBeGreaterThan(0);
+    expect(pointerMovePanStart.preventDefault).toHaveBeenCalledTimes(1);
+    expect(pointerMovePanStart.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    expect(pointerMovePanStart.stopPropagation).toHaveBeenCalledTimes(1);
+
+    widget.onDragEnd(createPickingInfo(100), createGestureEvent({}, {x: 100, y: 100}) as never);
+    onSelectionChange.mockClear();
+
+    const rightPanStart = {
+      ...createGestureEvent({button: 2}, {x: 100, y: 100}),
+      rightButton: true
+    };
+    eventManager.handlers.get('panstart')?.(rightPanStart);
+
+    expect(rightPanStart.preventDefault).not.toHaveBeenCalled();
+    expect(rightPanStart.stopImmediatePropagation).not.toHaveBeenCalled();
+    expect(onSelectionChange).not.toHaveBeenCalled();
+
+    for (const pointerState of [
+      {button: 1, buttons: 4},
+      {altKey: true},
+      {ctrlKey: true},
+      {metaKey: true}
+    ]) {
+      const panStart = createGestureEvent(pointerState, {x: 100, y: 100});
+      eventManager.handlers.get('panstart')?.(panStart);
+
+      expect(panStart.preventDefault).not.toHaveBeenCalled();
+      expect(panStart.stopImmediatePropagation).not.toHaveBeenCalled();
+
+      widget.onDragStart(createPickingInfo(100), panStart as never);
+
+      expect(onSelectionChange).not.toHaveBeenCalled();
+    }
+
+    const shiftPanStart = createGestureEvent({shiftKey: true}, {x: 100, y: 100});
+    eventManager.handlers.get('panstart')?.(shiftPanStart);
+
+    expect(shiftPanStart.preventDefault).not.toHaveBeenCalled();
+    expect(shiftPanStart.stopImmediatePropagation).not.toHaveBeenCalled();
+
+    widget.onDragStart(createPickingInfo(100), shiftPanStart as never);
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({phase: 'selecting-end', adjustingBoundary: null, range: null})
+    );
+
+    cleanup();
+  });
+});

--- a/modules/widgets/src/widgets/time-measure-widget.tsx
+++ b/modules/widgets/src/widgets/time-measure-widget.tsx
@@ -12,6 +12,9 @@ import type {
   MjolnirPointerEvent
 } from 'mjolnir.js';
 
+const RANGE_BOUNDARY_DRAG_RADIUS_PX = 8;
+const RANGE_BOUNDARY_PAN_INTERCEPT_PRIORITY = 100;
+
 /** Absolute time range selected by the time-measure widget. */
 export type TimeMeasureRange = {
   /** Start timestamp of the measured range in milliseconds. */
@@ -58,9 +61,13 @@ export type TimeMeasureSelectionState = {
   draftStartTimeMs: number | null;
   /** Completed selected time range, or null when none is selected. */
   range: TimeMeasureRange | null;
+  /** Completed range boundary currently under the pointer. */
+  hoveredBoundary?: 'start' | 'end' | null;
+  /** Completed range boundary currently being repositioned. */
+  adjustingBoundary?: 'start' | 'end' | null;
 };
 
-/** Deck widget that lets users measure a time range by interacting with a trace view. */
+/** Deck widget that lets users measure a time range by interacting with a time-oriented view. */
 export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
   static defaultProps: Required<TimeMeasureWidgetProps> = {
     ...Widget.defaultProps,
@@ -96,6 +103,12 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
   #projectionViewId: string | null = null;
   #eventManager?: EventManager | null;
   #dragSelecting = false;
+  /** Completed boundary currently under the pointer. */
+  #hoveredBoundary: 'start' | 'end' | null = null;
+  /** Completed boundary currently being repositioned. */
+  #adjustingBoundary: 'start' | 'end' | null = null;
+  /** Completed range to restore when adjusting one boundary is cancelled. */
+  #rangeBeforeAdjustment: TimeMeasureRange | null = null;
   /** Command id registered for toggling the measure-time interaction. */
   commandId = TimeMeasureWidget.defaultProps.commandId;
 
@@ -127,7 +140,7 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     // @ts-expect-error accessing protected member
     // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
     const eventManager = deck?.eventManager!;
-    this.#attachEventListeners(eventManager);
+    this.#attachEventListeners(eventManager, deck.getCanvas());
     return this.onCreateRootElement();
   }
 
@@ -153,7 +166,18 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
   }
 
   onHover(info: PickingInfo, event: MjolnirPointerEvent | MjolnirGestureEvent): void {
-    if (!this.#isSelecting() || !this.#shouldHandleEvent(info)) {
+    if (!this.#matchesEventView(info)) {
+      this.#setHoveredBoundary(null);
+      return;
+    }
+
+    if (this.#phase === 'selected') {
+      const timeMs = this.#eventToTimeMs(info, event);
+      this.#setHoveredBoundary(timeMs === null ? null : this.#getAdjustedBoundary(info, timeMs));
+      return;
+    }
+
+    if (!this.#isSelecting()) {
       return;
     }
     const timeMs = this.#eventToTimeMs(info, event);
@@ -208,27 +232,41 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
       return;
     }
     const srcEvent = event?.srcEvent as MouseEvent | PointerEvent | undefined;
-    if (!srcEvent?.shiftKey) {
-      return;
-    }
-    if (srcEvent.button === 2 || event.rightButton) {
+    if (this.#isRightButtonEvent(event)) {
       return;
     }
     const timeMs = this.#eventToTimeMs(info, event);
     if (timeMs === null) {
       return;
     }
-    srcEvent.preventDefault?.();
-    srcEvent.stopPropagation?.();
+
+    const adjustedBoundary = this.#isUnmodifiedPrimaryButtonEvent(event)
+      ? this.#getAdjustedBoundary(info, timeMs)
+      : null;
+    if (adjustedBoundary && this.#timeMeasureRange) {
+      this.#consumeDragEvent(event);
+      this.#dragSelecting = true;
+      this.#beginRangeAdjustment(adjustedBoundary, timeMs);
+      return;
+    }
+
+    if (!srcEvent?.shiftKey) {
+      return;
+    }
+    this.#consumeDragEvent(event);
     this.#dragSelecting = true;
     this.#beginDragSelection(timeMs);
   }
 
   onDrag(info: PickingInfo, event: MjolnirGestureEvent): void {
-    if (!this.#dragSelecting || !this.#matchesEventView(info)) {
+    if (!this.#dragSelecting) {
       return;
     }
-    const timeMs = this.#eventToTimeMs(info, event);
+    this.#consumeDragEvent(event);
+    if (!this.#matchesEventView(info)) {
+      return;
+    }
+    const timeMs = this.#eventToTimeMs(info, event, {preferEventPosition: true});
     if (timeMs === null) {
       return;
     }
@@ -240,12 +278,13 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     if (!this.#dragSelecting) {
       return;
     }
+    this.#consumeDragEvent(event);
     this.#dragSelecting = false;
     if (!this.#matchesEventView(info)) {
       this.#cancelSelection();
       return;
     }
-    const timeMs = this.#eventToTimeMs(info, event);
+    const timeMs = this.#eventToTimeMs(info, event, {preferEventPosition: true});
     if (timeMs === null || this.#draftStartTimeMs === null) {
       this.#cancelSelection();
       return;
@@ -280,7 +319,44 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     }
   };
 
-  #attachEventListeners(eventManager?: EventManager | null) {
+  /** Stops the view controller before async picking dispatches the matching boundary drag. */
+  #handlePanStart = (event: MjolnirGestureEvent) => {
+    if (
+      this.#phase !== 'selected' ||
+      !this.#timeMeasureRange ||
+      !this.#isUnmodifiedPrimaryButtonEvent(event)
+    ) {
+      return;
+    }
+    const center = event.offsetCenter ?? event.center;
+    if (!center || !this.#isEventPointInConfiguredView(center.x, center.y)) {
+      return;
+    }
+    const viewport = this.#getProjectionViewport({} as PickingInfo);
+    if (!viewport) {
+      return;
+    }
+    const cursorX = center.x - viewport.x;
+    const startX = viewport.project([this.#timeMeasureRange.startTimeMs, 0])[0];
+    const endX = viewport.project([this.#timeMeasureRange.endTimeMs, 0])[0];
+    const startDistance = Math.abs(cursorX - startX);
+    const endDistance = Math.abs(cursorX - endX);
+    if (Math.min(startDistance, endDistance) > RANGE_BOUNDARY_DRAG_RADIUS_PX) {
+      return;
+    }
+    const [cursorTimeMs] = viewport.unproject([cursorX, 0]);
+    if (!Number.isFinite(cursorTimeMs)) {
+      return;
+    }
+    this.#consumeDragEvent(event, {stopImmediatePropagation: true});
+    this.#dragSelecting = true;
+    this.#beginRangeAdjustment(startDistance <= endDistance ? 'start' : 'end', cursorTimeMs);
+  };
+
+  #attachEventListeners(
+    eventManager?: EventManager | null,
+    eventSourceElement?: HTMLElement | null
+  ) {
     if (!eventManager) {
       return;
     }
@@ -288,6 +364,13 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     this.#eventManager = eventManager;
     eventManager.on('keydown', this.#handleKeyDown);
     eventManager.on('keyup', this.#handleKeyUp);
+    eventManager.on('panstart', this.#handlePanStart, {
+      priority: RANGE_BOUNDARY_PAN_INTERCEPT_PRIORITY,
+      srcElement:
+        !eventSourceElement || eventManager.getElement() === eventSourceElement
+          ? 'root'
+          : eventSourceElement
+    });
   }
 
   #detachEventListeners() {
@@ -296,6 +379,7 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     }
     this.#eventManager.off('keydown', this.#handleKeyDown);
     this.#eventManager.off('keyup', this.#handleKeyUp);
+    this.#eventManager.off('panstart', this.#handlePanStart);
     this.#eventManager = null;
   }
 
@@ -321,19 +405,127 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     this.#draftStartTimeMs = null;
     this.#cursorTimeMs = null;
     this.#dragSelecting = false;
+    this.#hoveredBoundary = null;
+    this.#adjustingBoundary = null;
+    this.#rangeBeforeAdjustment = null;
     this.props.onActivate?.();
     this.#emitSelectionChange();
     this.updateHTML();
   }
 
   #beginDragSelection(startTimeMs: number) {
+    this.#rangeBeforeAdjustment = null;
     this.#updateRange(null, {suppressEmit: false});
     this.#phase = 'selecting-end';
     this.#draftStartTimeMs = startTimeMs;
     this.#cursorTimeMs = startTimeMs;
+    this.#hoveredBoundary = null;
+    this.#adjustingBoundary = null;
     this.props.onActivate?.();
     this.#emitSelectionChange();
     this.updateHTML();
+  }
+
+  /** Starts a live adjustment while preserving the completed range for cancellation. */
+  #beginRangeAdjustment(boundary: 'start' | 'end', cursorTimeMs: number) {
+    const range = this.#timeMeasureRange;
+    if (!range) {
+      return;
+    }
+    this.#rangeBeforeAdjustment = {...range};
+    this.#phase = 'selecting-end';
+    this.#draftStartTimeMs = boundary === 'start' ? range.endTimeMs : range.startTimeMs;
+    this.#cursorTimeMs = cursorTimeMs;
+    this.#hoveredBoundary = boundary;
+    this.#adjustingBoundary = boundary;
+    this.props.onActivate?.();
+    this.#emitSelectionChange();
+    this.updateHTML();
+  }
+
+  /** Returns the nearest completed range boundary within the fixed screen-space drag radius. */
+  #getAdjustedBoundary(info: PickingInfo, cursorTimeMs: number): 'start' | 'end' | null {
+    const range = this.#timeMeasureRange;
+    const viewport = this.#getProjectionViewport(info);
+    if (!range || !viewport) {
+      return null;
+    }
+    const cursorX = viewport.project([cursorTimeMs, 0])[0];
+    const startX = viewport.project([range.startTimeMs, 0])[0];
+    const endX = viewport.project([range.endTimeMs, 0])[0];
+    const startDistance = Math.abs(cursorX - startX);
+    const endDistance = Math.abs(cursorX - endX);
+    if (Math.min(startDistance, endDistance) > RANGE_BOUNDARY_DRAG_RADIUS_PX) {
+      return null;
+    }
+    return startDistance <= endDistance ? 'start' : 'end';
+  }
+
+  /** Returns whether a root-relative event point belongs to a configured interaction view. */
+  #isEventPointInConfiguredView(x: number, y: number): boolean {
+    const eventViewId = this.#eventViewId;
+    if (!eventViewId) {
+      return true;
+    }
+    const deck = this.deck;
+    if (!deck?.isInitialized) {
+      return false;
+    }
+    const allowedViewIds = Array.isArray(eventViewId) ? eventViewId : [eventViewId];
+    return deck
+      .getViewports()
+      .some(viewport => allowedViewIds.includes(viewport.id) && viewport.containsPixel({x, y}));
+  }
+
+  /** Emits completed-boundary hover changes without affecting ordinary selection callbacks. */
+  #setHoveredBoundary(boundary: 'start' | 'end' | null) {
+    if (boundary === this.#hoveredBoundary || this.#adjustingBoundary) {
+      return;
+    }
+    this.#hoveredBoundary = boundary;
+    this.#emitSelectionChange();
+  }
+
+  /** Consumes a measurement drag before deck.gl's pan controller handles the gesture. */
+  #consumeDragEvent(
+    event: MjolnirGestureEvent,
+    {stopImmediatePropagation = false}: {stopImmediatePropagation?: boolean} = {}
+  ) {
+    event.preventDefault();
+    if (stopImmediatePropagation) {
+      event.stopImmediatePropagation?.();
+    }
+    event.stopPropagation();
+  }
+
+  /** Returns whether a gesture is driven by the secondary pointer button. */
+  #isRightButtonEvent(event: MjolnirGestureEvent): boolean {
+    const srcEvent = event.srcEvent as MouseEvent | PointerEvent | undefined;
+    return Boolean(event.rightButton || srcEvent?.button === 2 || (srcEvent?.buttons ?? 0) & 2);
+  }
+
+  /** Returns whether a gesture is an unmodified primary-button or touch interaction. */
+  #isUnmodifiedPrimaryButtonEvent(event: MjolnirGestureEvent): boolean {
+    const srcEvent = event.srcEvent as MouseEvent | PointerEvent | TouchEvent | undefined;
+    if (
+      this.#isRightButtonEvent(event) ||
+      srcEvent?.altKey ||
+      srcEvent?.ctrlKey ||
+      srcEvent?.metaKey ||
+      srcEvent?.shiftKey
+    ) {
+      return false;
+    }
+    const buttons = srcEvent && 'buttons' in srcEvent ? srcEvent.buttons : null;
+    if (typeof buttons === 'number' && (buttons & ~1) !== 0) {
+      return false;
+    }
+    const button = srcEvent && 'button' in srcEvent ? srcEvent.button : null;
+    if (typeof button !== 'number' || button === 0) {
+      return true;
+    }
+    // PointerEvent panstart may originate from pointermove, where button is -1.
+    return button === -1 && buttons === 1;
   }
 
   #shouldHandleEvent(info: PickingInfo): boolean {
@@ -360,20 +552,25 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
 
   #eventToTimeMs(
     info: PickingInfo,
-    event: MjolnirGestureEvent | MjolnirPointerEvent
+    event: MjolnirGestureEvent | MjolnirPointerEvent,
+    {preferEventPosition = false}: {preferEventPosition?: boolean} = {}
   ): number | null {
     const projectionViewport = this.#getProjectionViewport(info);
     if (!projectionViewport) {
       return null;
     }
-    if (info.coordinate && Number.isFinite(info.coordinate[0])) {
-      if (!projectionViewport.id || info.viewport?.id === projectionViewport.id) {
-        return info.coordinate[0] as number;
-      }
+    const pickingCoordinate =
+      info.coordinate &&
+      Number.isFinite(info.coordinate[0]) &&
+      (!projectionViewport.id || info.viewport?.id === projectionViewport.id)
+        ? (info.coordinate[0] as number)
+        : null;
+    if (!preferEventPosition && pickingCoordinate !== null) {
+      return pickingCoordinate;
     }
     const center = (event as any).offsetCenter ?? (event as any).center;
     if (!center) {
-      return null;
+      return pickingCoordinate;
     }
     const x = 'x' in center ? center.x : Array.isArray(center) ? center[0] : null;
     if (typeof x !== 'number') {
@@ -381,7 +578,7 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     }
     const offsetX: number = x - projectionViewport.x;
     const [timeMs] = projectionViewport.unproject([offsetX, 0]);
-    return timeMs ?? null;
+    return Number.isFinite(timeMs) ? timeMs : null;
   }
 
   #getProjectionViewport(info: PickingInfo): Viewport | null {
@@ -407,6 +604,9 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
     this.#draftStartTimeMs = null;
     this.#cursorTimeMs = null;
     this.#dragSelecting = false;
+    this.#hoveredBoundary = null;
+    this.#adjustingBoundary = null;
+    this.#rangeBeforeAdjustment = null;
     this.props.onDeactivate?.();
     this.#emitSelectionChange();
     this.updateHTML();
@@ -423,11 +623,15 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
   }
 
   #cancelSelection() {
-    this.#updateRange(null);
-    this.#phase = 'idle';
+    const restoredRange = this.#rangeBeforeAdjustment;
+    this.#updateRange(restoredRange, {suppressEmit: restoredRange !== null});
+    this.#phase = restoredRange ? 'selected' : 'idle';
     this.#draftStartTimeMs = null;
     this.#cursorTimeMs = null;
     this.#dragSelecting = false;
+    this.#hoveredBoundary = null;
+    this.#adjustingBoundary = null;
+    this.#rangeBeforeAdjustment = null;
     this.props.onDeactivate?.();
     this.#emitSelectionChange();
     this.updateHTML();
@@ -450,7 +654,9 @@ export class TimeMeasureWidget extends Widget<TimeMeasureWidgetProps, null> {
       phase: this.#phase,
       cursorTimeMs: this.#cursorTimeMs,
       draftStartTimeMs: this.#draftStartTimeMs,
-      range: this.#timeMeasureRange
+      range: this.#timeMeasureRange,
+      hoveredBoundary: this.#hoveredBoundary,
+      adjustingBoundary: this.#adjustingBoundary
     });
   }
 


### PR DESCRIPTION
## Summary

Backports three already-reviewed widget improvements to the 9.3 line, preserving one commit per source PR:

- #724: edit either boundary of a completed TimeMeasure range.
- #722: add the JSON-safe ColorLegendWidget.
- #723: add debounced async search, refresh keys, caller ordering, and result-state callbacks to OmniBoxWidget.

## Why

Consumers pinned to deck.gl and luma.gl 9.3 need these widget APIs without moving to the 9.4 track.

## Validation

- `yarn vitest run modules/widgets/src/widgets/color-legend-widget.test.tsx modules/widgets/src/widgets/omni-box-widget.test.tsx modules/widgets/src/widgets/time-measure-widget.test.tsx --project headless`
- `yarn lint`
- `yarn build`
- `yarn --cwd website build`

## Backport notes

The API docs and sidebar entry are included. The v9.4 release-note hunks are intentionally omitted; the eventual 9.3.9 release-prep PR can add one consolidated release note.