### PR TITLE
Backport graph-layer website example fix to 9.3

### DIFF
--- a/examples/graph-layers/graph-viewer/app.ts
+++ b/examples/graph-layers/graph-viewer/app.ts
@@ -337,19 +337,14 @@ export function mountGraphViewerExample(
     },
     darkModeTheme: {
       ...DarkTheme
+    },
+    onThemeModeChange(themeMode) {
+      if (state.themeMode !== themeMode) {
+        state.themeMode = themeMode;
+        syncWidgets();
+      }
     }
-  }) as ThemeWidget & {
-    _applyTheme: (themeMode: 'light' | 'dark') => void;
-    themeMode: 'light' | 'dark';
-  };
-  const originalApplyTheme = themeWidget._applyTheme.bind(themeWidget);
-  themeWidget._applyTheme = (themeMode: 'light' | 'dark') => {
-    originalApplyTheme(themeMode);
-    if (state.themeMode !== themeMode) {
-      state.themeMode = themeMode;
-      syncWidgets();
-    }
-  };
+  });
   const sidebarWidget = new SidebarPanelWidget({
     id: 'graph-viewer-sidebar',
     placement: 'top-right',

--- a/examples/graph-layers/graph-viewer/examples.ts
+++ b/examples/graph-layers/graph-viewer/examples.ts
@@ -656,7 +656,7 @@ const KNOWLEDGE_GRAPH_STYLE: ExampleStyles = {
       fontSize: 12,
       textAnchor: 'start',
       offset: [10, 0],
-      alignmentBaseline: 'middle',
+      alignmentBaseline: 'center',
       scaleWithZoom: false
     }
   ],
@@ -697,7 +697,7 @@ const MULTI_GRAPH_STYLE: ExampleStyles = {
       color: [255, 255, 255],
       fontSize: 14,
       textAnchor: 'middle',
-      alignmentBaseline: 'middle',
+      alignmentBaseline: 'center',
       scaleWithZoom: false
     }
   ],


### PR DESCRIPTION
## Summary

Backports #719 to the 9.3 release line.

- use the supported ThemeWidget theme-change callback
- correct invalid TextLayer alignment values for hive and multi-graph examples
- restore all graph-layer website examples

## Testing

- `yarn lint`
- `yarn test-node modules/graph-layers/test`
- `yarn --cwd website build`
- browser-verified all five graph example routes against the 9.3 production build