### PR TITLE
chore: use npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,19 +34,24 @@ jobs:
     needs: check_branch
     permissions:
       contents: write
+      id-token: write
 
     if: ${{ github.repository_owner == 'visgl' && needs.check_branch.outputs.should_build }}
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      NPM_ACCESS_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - name: Update npm
+        run: npm install --global npm@^11.15.0
 
       - name: Enable Corepack
         run: corepack enable yarn
@@ -61,40 +66,6 @@ jobs:
         run: |
           yarn lint
           yarn test
-
-      - name: Login to NPM
-        run: npm config set "//registry.npmjs.org/:_authToken=${NPM_ACCESS_TOKEN}"
-
-      - name: Verify NPM token
-        run: |
-          npm ping
-          npm whoami
-          node - <<'NODE'
-          const fs = require('fs');
-          const path = require('path');
-
-          const packageDirs = ['modules', 'dev'].flatMap((root) =>
-            fs.existsSync(root)
-              ? fs
-                  .readdirSync(root, {withFileTypes: true})
-                  .filter((entry) => entry.isDirectory())
-                  .map((entry) => path.join(root, entry.name))
-              : []
-          );
-
-          const packages = packageDirs
-            .map((directory) => path.join(directory, 'package.json'))
-            .filter((filename) => fs.existsSync(filename))
-            .map((filename) => JSON.parse(fs.readFileSync(filename, 'utf8')))
-            .filter((pkg) => pkg.name?.startsWith('@deck.gl-community/') && !pkg.private)
-            .map((pkg) => pkg.name)
-            .sort();
-
-          console.log(`NPM token is valid. Publishing ${packages.length} public packages:`);
-          for (const name of packages) {
-            console.log(`- ${name}`);
-          }
-          NODE
 
       - name: Publish to NPM
         run: npx ocular-publish from-git

--- a/modules/bing-maps/package.json
+++ b/modules/bing-maps/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/visgl/deck.gl-community.gl.git"
+    "url": "https://github.com/visgl/deck.gl-community.git"
   },
   "type": "module",
   "sideEffects": false,

--- a/modules/experimental/package.json
+++ b/modules/experimental/package.json
@@ -3,6 +3,10 @@
   "version": "9.4.0-alpha.2",
   "description": "Experimental layers for deck.gl",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/deck.gl-community.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -3,6 +3,10 @@
   "version": "9.4.0-alpha.2",
   "description": "Add-0n geospatial layers for deck.gl",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/deck.gl-community.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/modules/graph-layers/package.json
+++ b/modules/graph-layers/package.json
@@ -3,6 +3,10 @@
   "version": "9.4.0-alpha.2",
   "description": "WebGL2-Powered library for Graph Visualization",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/deck.gl-community.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/modules/infovis-layers/package.json
+++ b/modules/infovis-layers/package.json
@@ -3,6 +3,10 @@
   "version": "9.4.0-alpha.2",
   "description": "Infovis layers (non-geospatial) for deck.gl",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/deck.gl-community.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -3,6 +3,10 @@
   "version": "9.4.0-alpha.2",
   "description": "Add-on layers for deck.gl",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/deck.gl-community.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/modules/panels/package.json
+++ b/modules/panels/package.json
@@ -3,6 +3,10 @@
   "version": "9.4.0-alpha.2",
   "description": "Deck-independent panel composition and standalone UI",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/deck.gl-community.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/modules/three/package.json
+++ b/modules/three/package.json
@@ -3,6 +3,10 @@
   "version": "9.4.0-alpha.2",
   "description": "Three.js-powered layers for deck.gl",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/deck.gl-community.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/modules/timeline-layers/package.json
+++ b/modules/timeline-layers/package.json
@@ -3,6 +3,10 @@
   "version": "9.4.0-alpha.2",
   "description": "Layers for compact timeline visualizations in deck.gl",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/deck.gl-community.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/modules/widgets/package.json
+++ b/modules/widgets/package.json
@@ -3,6 +3,10 @@
   "version": "9.4.0-alpha.2",
   "description": "UI widgets for deck.gl",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/deck.gl-community.git"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
- Use trusted publishing and drop npm token
- Add missing required package metadata