### PR TITLE
fix(editable-layers): remove layers peerDependency

### DIFF
--- a/modules/editable-layers/package.json
+++ b/modules/editable-layers/package.json
@@ -77,7 +77,6 @@
     "preact": "^10.17.0"
   },
   "peerDependencies": {
-    "@deck.gl-community/layers": "~9.4.0-alpha.0",
     "@deck.gl/core": "~9.4.0-alpha.2",
     "@deck.gl/extensions": "~9.4.0-alpha.2",
     "@deck.gl/geo-layers": "~9.4.0-alpha.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -513,7 +513,6 @@ __metadata:
     lodash.throttle: "npm:^4.1.1"
     preact: "npm:^10.17.0"
   peerDependencies:
-    "@deck.gl-community/layers": ~9.4.0-alpha.0
     "@deck.gl/core": ~9.4.0-alpha.2
     "@deck.gl/extensions": ~9.4.0-alpha.2
     "@deck.gl/geo-layers": ~9.4.0-alpha.2


### PR DESCRIPTION
Nothing in `@deck.gl-community/editable-layers` references `@deck.gl-community/layers` (since the deletions in https://github.com/visgl/deck.gl-community/pull/447). By listing as a peer, consumers of `@deck.gl-community/editable-layers` are incorrectly prompted to include  `@deck.gl-community/layers` which they do not need

### Changes

- Remove `@deck.gl-community/layers` peerDependency