### PR TITLE
Complete deck.gl 9.4 WebGPU follow-ups

### DIFF
--- a/docs/modules/arrow-layers/README.md
+++ b/docs/modules/arrow-layers/README.md
@@ -1,7 +1,7 @@
 # Overview
 
 ![deck.gl v9](https://img.shields.io/badge/deck.gl-v9-green.svg?style=flat-square")
-![WebGPU partially supported](https://img.shields.io/badge/webgpu-partial-yellow.svg?style=flat-square")
+![WebGPU supported](https://img.shields.io/badge/webgpu-yes-green.svg?style=flat-square")
 
 This module provides deck.gl layers that accept Apache Arrow and [GeoArrow](https://geoarrow.org) tables. 
 These layers take advantage of the deck.gl [low-level binary interface](https://deck.gl/docs/developer-guide/performance#supply-attributes-directly) to provide binary arrow data from Apache Arrow tables directly to the GPU.

--- a/docs/modules/geo-layers/README.md
+++ b/docs/modules/geo-layers/README.md
@@ -25,8 +25,7 @@ This module exports geospatial deck.gl layers developed by the community.
 
 :::caution Work in progress
 The wind-layer API and historical showcase are experimental. `ParticleLayer`, filled arrows, and
-station-triangulated terrain are verified on WebGL2 and WebGPU. The original image-derived mountain
-terrain remains WebGL2-only because upstream `TerrainLayer` does not yet support WebGPU.
+both station-triangulated and image-derived terrain are verified on WebGL2 and WebGPU.
 :::
 
 The [wind showcase guide](./developer-guide/wind-showcase.md) recreates Nicolas Belmonte's

--- a/docs/modules/geo-layers/api-reference/delaunay-cover-layer.md
+++ b/docs/modules/geo-layers/api-reference/delaunay-cover-layer.md
@@ -4,7 +4,7 @@ import LayerLiveExample from '@site/src/components/docs/layer-live-example';
 
 :::caution Work in progress
 The station-surface appearance and API may change. Its native triangle primitive works on WebGL2
-and WebGPU; image-derived mountain terrain remains dependent on upstream `TerrainLayer` support.
+and WebGPU; deck.gl 9.4 also supports the separate image-derived terrain path.
 :::
 
 `DelaunayCoverLayer` renders one elevation-colored polygon for each triangle in a shared

--- a/docs/modules/geo-layers/api-reference/elevation-layer.md
+++ b/docs/modules/geo-layers/api-reference/elevation-layer.md
@@ -3,8 +3,7 @@ import LayerLiveExample from '@site/src/components/docs/layer-live-example';
 # ElevationLayer
 
 :::caution Work in progress
-The terrain API, height-map smoothing, material, and exaggeration are experimental. WebGPU
-compatibility depends on upstream `TerrainLayer` and loaders.gl support.
+The terrain API, height-map smoothing, material, and exaggeration are experimental.
 :::
 
 `ElevationLayer` decodes a grayscale height map into illuminated, extruded mountain geometry.
@@ -37,11 +36,10 @@ const terrain = new ElevationLayer({
 For smoother relief, filter the grayscale image once before passing it as `elevationData`. Do not
 recreate or decode the terrain mesh during particle animation.
 
-Height-map rendering currently requires WebGL2 because upstream `TerrainLayer` uses a WebGL-only
-mesh renderer. On WebGPU, `ElevationLayer` safely omits its terrain sub-layer; use
-[`DelaunayCoverLayer`](/docs/modules/geo-layers/api-reference/delaunay-cover-layer) for a
-WebGPU-compatible station-triangulated terrain surface. See the
-[WebGPU support matrix](/docs/webgpu) for the current status.
+Height-map rendering is browser-verified on WebGL2 and WebGPU through deck.gl 9.4's upstream
+`TerrainLayer` and `SimpleMeshLayer`. [`DelaunayCoverLayer`](./delaunay-cover-layer.md) remains a
+separate station-triangulated debugging surface. See the [WebGPU support matrix](/docs/webgpu) for
+the current status.
 
 ## Properties
 

--- a/docs/modules/geo-layers/api-reference/particle-layer.md
+++ b/docs/modules/geo-layers/api-reference/particle-layer.md
@@ -5,7 +5,7 @@ import LayerLiveExample from '@site/src/components/docs/layer-live-example';
 :::caution Work in progress
 The wind-layer API, GPU simulation, particle appearance, and tuning controls are experimental and
 may change. WebGL2 and WebGPU particle simulation, wind arrows, and station surfaces are
-browser-tested independently; image-derived mountain terrain still depends on upstream support.
+browser-tested independently, together with the image-derived mountain terrain.
 :::
 
 `ParticleLayer` animates GPU-resident particles through a station-interpolated geographic wind
@@ -123,8 +123,8 @@ Radius of moving particle heads in screen pixels.
 - Coverage: invalid samples are respawned within the wind field; overlong segments are clipped.
 - Cleanup: deck.gl finalization releases the weather textures, simulation buffers, and pipeline
   after submitted GPU work has completed.
-- Scope: native wind arrows and station-triangulated surfaces support WebGPU, but image-derived
-  mountain terrain still depends on upstream `TerrainLayer` compatibility.
+- Scope: native wind arrows, station-triangulated surfaces, and image-derived terrain support
+  WebGPU with stable deck.gl 9.4.
 
 See the [wind showcase guide](../developer-guide/wind-showcase.md), the
 [Wind Map example](/examples/geo-layers/wind), and the

--- a/docs/modules/geo-layers/api-reference/wind-layer.md
+++ b/docs/modules/geo-layers/api-reference/wind-layer.md
@@ -4,7 +4,7 @@ import LayerLiveExample from '@site/src/components/docs/layer-live-example';
 
 :::caution Work in progress
 The wind arrow API and styling are experimental. Native triangle glyphs and portable line
-segments render on WebGL2 and WebGPU; image-based mountain terrain remains in progress.
+segments render on WebGL2 and WebGPU, as does the showcase's image-based mountain terrain.
 :::
 
 `WindLayer` renders a Delaunay-interpolated station forecast as directional, speed-colored arrow

--- a/docs/modules/geo-layers/developer-guide/wind-showcase.md
+++ b/docs/modules/geo-layers/developer-guide/wind-showcase.md
@@ -5,8 +5,7 @@ import LayerLiveExample from '@site/src/components/docs/layer-live-example';
 :::caution Work in progress
 The reusable wind layers and the historical showcase are experimental. GPU particle advection has
 been independently verified on WebGL2 and WebGPU, along with filled wind arrows and station
-surfaces. Image-derived mountain terrain still depends on upstream `TerrainLayer` support, so the
-WebGPU showcase substitutes the station-triangulated surface.
+surfaces. Stable deck.gl 9.4 also renders the image-derived mountain terrain on both backends.
 :::
 
 The Wind Map restores
@@ -194,9 +193,9 @@ buffers on every slider event.
 | `ParticleLayer` | Supported | Supported | Independently browser-tested GPU advection and rendering. |
 | Wind data and `DelaunayInterpolation` | Supported | Supported | Backend-independent indexing and explicit sampling. |
 | `WindLayer` | Supported | Supported | Native GLSL/WGSL filled arrows and portable line shafts. |
-| `ElevationLayer` | Supported | Blocked | Image-derived mountain terrain depends on upstream `TerrainLayer`. |
+| `ElevationLayer` | Supported | Supported | Browser-tested upstream `TerrainLayer` and `SimpleMeshLayer`. |
 | `DelaunayCoverLayer` | Supported | Supported | Native GLSL/WGSL station-triangulated surface. |
-| Complete original showcase | Supported | In progress | WebGPU renders state boundaries and uses station terrain while image-derived mountains remain blocked. |
+| Complete original showcase | Supported | Supported | Browser-tested image terrain, particles, arrows, labels, boundaries, and station terrain. |
 
 See the full [WebGPU compatibility matrix](/docs/webgpu).
 

--- a/docs/modules/three/README.md
+++ b/docs/modules/three/README.md
@@ -1,5 +1,7 @@
 # Overview
 
+![WebGPU supported](https://img.shields.io/badge/webgpu-yes-green.svg?style=flat-square)
+
 A collection of deck.gl layers powered by [Three.js](https://threejs.org/), giving access to Three.js geometry primitives and scene graph tooling directly inside deck.gl visualisations.
 
 ```bash

--- a/docs/modules/timeline-layers/README.md
+++ b/docs/modules/timeline-layers/README.md
@@ -1,5 +1,7 @@
 # @deck.gl-community/timeline-layers
 
+![WebGPU supported](https://img.shields.io/badge/webgpu-yes-green.svg?style=flat-square)
+
 Layers for compact timeline visualizations in deck.gl.
 
 ```bash

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -23,9 +23,8 @@ Please refer the documentation of each module for detailed upgrade guides.
   WebGL `Transform` and `Texture2D` dependencies.
 - `trailLength` controls the device-free CPU fallback; GPU rendering uses ping-pong buffers,
   lifetime fading, and high-density point rendering.
-- WebGPU supports GPU-resident particles, filled wind arrows, and station-triangulated surfaces
-  through native shaders. Image-derived mountain terrain remains dependent on upstream
-  `TerrainLayer` compatibility. See the
+- WebGPU supports GPU-resident particles, filled wind arrows, station-triangulated surfaces, and
+  image-derived mountain terrain through stable deck.gl 9.4. See the
   [WebGPU support matrix](./webgpu.md).
 
 ### `@deck.gl-community/panels`

--- a/docs/webgpu.md
+++ b/docs/webgpu.md
@@ -20,10 +20,11 @@ deck.gl-community is adding WebGPU support incrementally while continuing to sup
 | `@deck.gl-community/infovis-layers` | `FastTextLayer` | ✅ | ✅ | Native WGSL adapted from luma.gl's text-renderer patterns; existing packed glyphs, bitmap/SDF atlases, clipping, alignment, and mipmaps work on both backends. |
 | `@deck.gl-community/timeline-layers` | `HorizonGraphLayer` | ✅ | ✅ | Native WGSL; WebGPU preserves float bits in baseline-compatible `r32uint` textures. |
 | `@deck.gl-community/timeline-layers` | `MultiHorizonGraphLayer` | ✅ | ✅ | Portable horizon shaders and dual-backend line dividers. |
-| `@deck.gl-community/timeline-layers` | `TimeAxisLayer` | ✅ | 🚧 | Grid lines are portable; upstream `TextLayer` labels still require stable WebGPU validation. |
+| `@deck.gl-community/timeline-layers` | `TimeAxisLayer` | ✅ | ✅ | Browser-verified grid lines and upstream `TextLayer` tick labels. |
 | `@deck.gl-community/timeline-layers` | `VerticalGridLayer` | ✅ | ✅ | Browser-verified portable `LineLayer` grid marks and viewport-driven ticks. |
 | `@deck.gl-community/timeline-layers` | `TimelineLayer` geometry | ✅ | ✅ | Browser-verified tracks, clips, scrubber polygons, and lines using upstream dual-backend layers. |
-| `@deck.gl-community/timeline-layers` | `TimelineLayer` labels and interactions | ✅ | 🚧 | Text labels and pointer/drag behavior still require stable WebGPU browser coverage. |
+| `@deck.gl-community/timeline-layers` | `TimelineLayer` labels | ✅ | ✅ | Browser-verified upstream `TextLayer` track, clip, axis, and scrubber labels. |
+| `@deck.gl-community/timeline-layers` | `TimelineLayer` interactions | ✅ | 🚧 | Pointer, drag, and selection behavior is backend-neutral but still needs browser interaction coverage. |
 | `@deck.gl-community/graph-layers` | `GraphLayer`, `EdgeLayer`, and node layers | ✅ | 🚧 | Static path edges, arrow decorators, and rounded nodes are portable; complete graph styling, images, labels, layouts, and picking still require end-to-end validation. |
 | `@deck.gl-community/graph-layers` | `RoundedRectangleLayer` | ✅ | ✅ | Rounded corners are CPU-tessellated and rendered with upstream dual-backend `PolygonLayer`. |
 | `@deck.gl-community/graph-layers` | `PathEdgeLayer` and `EdgeArrowLayer` | ✅ | ✅ | Browser-verified upstream path rendering and polygon arrowheads. |
@@ -31,17 +32,16 @@ deck.gl-community is adding WebGPU support incrementally while continuing to sup
 | `@deck.gl-community/geo-layers` | `ParticleLayer` | ✅ | ✅ | Browser-verified WebGL2 transform-feedback and WebGPU compute advection; production rendering uses GPU particle buffers without readbacks. |
 | `@deck.gl-community/geo-layers` | Wind-field utilities and `DelaunayInterpolation` | ✅ | ✅ | Backend-independent station indexing, explicit sampling, and optional CPU rasterization. |
 | `@deck.gl-community/geo-layers` | `WindLayer` | ✅ | ✅ | Native WGSL/GLSL filled-arrow triangles and portable line shafts and arrowheads. |
-| `@deck.gl-community/geo-layers` | `ElevationLayer` | ✅ | ❌ | Image-derived mountain terrain depends on upstream `TerrainLayer`; skipped safely on WebGPU. |
+| `@deck.gl-community/geo-layers` | `ElevationLayer` | ✅ | ✅ | Browser-verified image-derived mountain terrain through upstream `TerrainLayer` and `SimpleMeshLayer`. |
 | `@deck.gl-community/geo-layers` | `DelaunayCoverLayer` | ✅ | ✅ | Native WGSL/GLSL station triangles, elevation scaling, and height-based coloring. |
-| `@deck.gl-community/geo-layers` | Complete Wind Map showcase | ✅ | 🚧 | GPU particles, arrows, labels, state boundaries, and station terrain are portable; image terrain remains upstream-dependent. |
-| `@deck.gl-community/geo-layers` | `GlobalGridLayer` and `TileGridLayer` borders | ✅ | ✅ | Browser-verified upstream polygon and path renderers using local grid and tile data. |
+| `@deck.gl-community/geo-layers` | Complete Wind Map showcase | ✅ | ✅ | Browser-verified image terrain, GPU particles, arrows, labels, state boundaries, and station terrain. |
+| `@deck.gl-community/geo-layers` | `GlobalGridLayer` and `TileGridLayer` | ✅ | ✅ | Browser-verified upstream polygon, path, and text renderers using local grid and tile data. |
 | `@deck.gl-community/geo-layers` | `SharedTile2DLayer` and `TileSourceLayer` | ✅ | 🚧 | Validate tile formats, texture upload, labels, and picking. |
-| `@deck.gl-community/arrow-layers` | Column, heatmap, path, point-cloud, polygon, scatterplot, and solid-polygon layers | ✅ | ✅ | Browser-verified Arrow binary attributes through the corresponding upstream renderers. |
-| `@deck.gl-community/arrow-layers` | Arc, H3, text, and trips layers | ✅ | 🚧 | Arc binary attributes exceed the baseline eight-vertex-buffer limit; the others require upstream renderer validation or remaining custom shader work. |
+| `@deck.gl-community/arrow-layers` | Arc, column, H3, heatmap, path, point-cloud, polygon, scatterplot, solid-polygon, text, and trips layers | ✅ | ✅ | Browser-verified Arrow binary data through the corresponding upstream renderers; H3 indexes and text glyph positions are adapted for their composite sublayers. |
 | `@deck.gl-community/editable-layers` | GeoJSON paths, polygons, and edit handles | ✅ | ✅ | Browser-verified `EditableGeoJsonLayer` rendering in `ModifyMode`, including the WebGPU picking-width shader path. |
 | `@deck.gl-community/editable-layers` | Editing and selection interactions | ✅ | 🚧 | Pointer, drag, snapping, and selection behavior still require browser interaction coverage on WebGPU. |
 | `@deck.gl-community/basemap-layers` | `BasemapLayer` | ✅ | 🚧 | Support depends on the selected style's polygon, path, and label sublayers. |
-| `@deck.gl-community/three` | `TreeLayer` | ✅ | 🚧 | Three.js builds the geometry, but deck.gl renders it through upstream `SimpleMeshLayer`, whose WebGPU port is still pending. |
+| `@deck.gl-community/three` | `TreeLayer` | ✅ | ✅ | Browser-verified procedural Three.js geometry rendered through upstream `SimpleMeshLayer`. |
 | `@deck.gl-community/leaflet` | Leaflet map overlay | ✅ | ❌ | A host-owned WebGL context cannot be switched to WebGPU. |
 | `@deck.gl-community/bing-maps` | Bing Maps overlay | ✅ | ❌ | A host-owned WebGL context cannot be switched to WebGPU. |
 | `@deck.gl-community/widgets` | `DeviceManagerController` and `DeviceTabsWidget` | ✅ | ✅ | Selects and attaches an independently managed real rendering device. |
@@ -119,13 +119,13 @@ routes now render through the selected backend.
 | --- | --- | --- |
 | Existing reference | `SkyboxLayer` | Provides native WGSL and GLSL sources, portable cubemap bindings, and a switchable skybox example. |
 | First wave | `BlockLayer`, `DependencyArrowLayer` marker geometry, `HorizonGraphLayer`, and `MultiHorizonGraphLayer` | Native WGSL and existing GLSL are maintained together. Stacked horizon dividers use the upstream dual-backend `LineLayer`; the website injects real WebGPU/WebGL2 device selection into the skybox, path, block, and horizon examples. |
-| Wind showcase | `ParticleLayer`, wind-field utilities, `WindLayer`, and `DelaunayCoverLayer` | WebGL2 transform-feedback, WebGPU compute, native arrow triangles, and station-surface rendering are browser-verified. Image-based mountain terrain still depends on upstream `TerrainLayer`. |
-| Path and polygon unblock | `PathOutlineLayer`, `PathMarkerLayer`, `DependencyArrowLayer`, `TimelineLayer` geometry, GeoArrow renderers, editable GeoJSON, global-grid and tile-border layers, and static graph geometry | deck.gl 9.4 alpha.2 supplies dual-backend path and polygon shaders. Community layers use them directly, with a local WGSL dash plugin until `PathStyleExtension` gains native WGSL. |
-| Fast text | `FastTextLayer` | The existing bitmap/SDF glyph layer now has native WGSL and remains available while upstream `TextLayer` WebGPU support stabilizes. |
-| Upstream follow-ups | `TextLayer`, `TripsLayer`, `SimpleMeshLayer`, and specialized geo-cell layers | Adopt and validate upstream WebGPU implementations as they become available; keep local fallbacks narrowly scoped. |
+| Wind showcase | `ParticleLayer`, wind-field utilities, `WindLayer`, `ElevationLayer`, and `DelaunayCoverLayer` | WebGL2 transform-feedback, WebGPU compute, native arrow triangles, station surfaces, and upstream image terrain are browser-verified. |
+| Path and polygon unblock | `PathOutlineLayer`, `PathMarkerLayer`, `DependencyArrowLayer`, `TimelineLayer` geometry, GeoArrow renderers, editable GeoJSON, global-grid and tile-border layers, and static graph geometry | deck.gl 9.4 supplies dual-backend path and polygon shaders. Community layers use them directly, with a local WGSL dash plugin until `PathStyleExtension` gains native WGSL. |
+| Fast text | `FastTextLayer` | The existing bitmap/SDF glyph layer has native WGSL and remains available as a packed, Arrow-aware alternative to upstream `TextLayer`. |
+| Stable 9.4 upstream follow-ups | `TextLayer`, `TripsLayer`, `SimpleMeshLayer`, `TerrainLayer`, and H3 layers | Community timeline labels, GeoArrow wrappers, trees, tile labels, and image terrain are browser-verified against the stable upstream implementations. |
 | Graph geometry | `RoundedRectangleLayer`, `PathEdgeLayer`, and `EdgeArrowLayer` | Replace the fragment-only rounded rectangle and mesh arrowhead with CPU-tessellated polygons, then validate static path and polygon geometry on both backends. Full `GraphLayer` integration remains in progress. |
 | Dedicated redesign | `FlowPathLayer` and animated graph flows | The current transform-feedback implementation is incomplete and WebGL-specific. Replace it with a backend-neutral animation or compute design; do not treat shader translation alone as a port. |
-| Subsequent validation | Arrow arc/H3/text/trips, editable interactions, geospatial tile sources, and basemap layers | Reduce Arrow arc vertex-buffer usage; validate remaining upstream sublayers, picking interactions, tile and texture formats, and each demonstrated example independently. |
+| Subsequent validation | Editable interactions, geospatial tile sources, graph composition, and basemap layers | Validate picking and drag interactions, tile and texture formats, complete graph styling/layout, and each basemap style independently. |
 | Host-dependent integrations | Leaflet, Bing Maps, and external map renderers | Support depends on the host renderer and canvas ownership. A host-owned WebGL context cannot be switched to WebGPU by adding device tabs. |
 
 The skybox map example also composes a basemap. `SkyboxLayer` itself has native WebGPU shaders, while complete basemap compatibility remains subject to the downstream GeoJSON, polygon, path, and label sublayers used by the selected style.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -12,7 +12,9 @@ Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community
 
 - Added the [WebGPU support matrix and migration roadmap](./webgpu.md), covering WebGL2 and WebGPU support by module and layer, upstream dependencies, and host integration limitations.
 - `SkyboxLayer`: validated the existing native WGSL and GLSL implementation with real WebGPU/WebGL2 device selection in the skybox example.
-- `BlockLayer`: added native WGSL for instanced block fills, outlines, projection, opacity, and picking while preserving the existing WebGL2 shaders.
+- `BlockLayer`: added native WGSL for instanced block fills, outlines, projection, opacity, and
+  picking while preserving the existing WebGL2 shaders; stable deck.gl 9.4 packs the per-instance
+  data into a baseline-compatible vertex buffer and uses an aligned float color-override selector.
 - `FastTextLayer`: added an upstream-informed WGSL compatibility shader for existing packed bitmap and signed-distance-field glyphs, font-atlas bindings, clipping, alignment, and WebGPU mipmaps.
 - `TimeDeltaLayer`: uses portable line guides and native-WGSL fast-text labels on WebGPU while preserving WebGL2 label backgrounds.
 - `DependencyArrowLayer`: added native WGSL for directional arrow-marker geometry and picking; line, arc, and path routing are browser-verified on both backends with deck.gl 9.4.
@@ -20,7 +22,7 @@ Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community
 - `HorizonGraphLayer`: added native WGSL and baseline-compatible WebGPU integer data textures that preserve the original float bits.
 - `MultiHorizonGraphLayer`: made stacked horizon graphs portable by using dual-backend `LineLayer` dividers alongside the new horizon shaders.
 - `VerticalGridLayer`: validated viewport-driven timeline ticks and grid lines on both graphics backends.
-- `TimelineLayer`: validated track, clip, scrubber, and line geometry with the upstream WebGPU polygon and line layers; text labels and interactions remain in progress.
+- `TimeAxisLayer` and `TimelineLayer`: validated tick, track, clip, axis, and scrubber labels with the stable upstream WebGPU `TextLayer`; pointer and drag interaction coverage remains in progress.
 - `WindLayer` and `DelaunayCoverLayer`: render filled directional arrows and station-triangulated surfaces using native WebGL2/WebGPU triangle shaders.
 - `ParticleLayer`: restored the historical wind showcase's GPU-resident particle advection using
   WebGL2 transform feedback and native WebGPU compute, with no production particle readbacks and
@@ -30,13 +32,17 @@ Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community
   `float32-filterable`.
 - `RoundedRectangleLayer`, `PathEdgeLayer`, and `EdgeArrowLayer`: replaced WebGL-only graph
   primitives with CPU-tessellated polygons and browser-verified upstream path rendering.
-- GeoArrow column, heatmap, path, point-cloud, polygon, scatterplot, and solid-polygon layers now
-  have browser coverage for Arrow binary attributes on WebGL2 and WebGPU. The compatibility matrix
-  records the remaining baseline vertex-buffer limit in `GeoArrowArcLayer`.
+- All GeoArrow renderers now have browser coverage on WebGL2 and WebGPU, including Arc, H3, Text,
+  and Trips. H3 string indexes stay available to its CPU composite stage, while text glyph
+  positions use deck.gl 9.4-compatible child-layer packing.
 - `EditableGeoJsonLayer`: browser-verified polygon, path, and edit-handle rendering on WebGPU,
   including its picking-width shader customization.
 - `GlobalGridLayer`, `TileGridLayer` borders, and the wind showcase's state boundaries now have
   local-data browser coverage on WebGL2 and WebGPU.
+- `ElevationLayer` and the complete Wind Map now render image-derived terrain through stable
+  upstream `TerrainLayer` on WebGPU; the example no longer substitutes station triangles.
+- `TreeLayer` now has WebGL2/WebGPU browser coverage for its procedural geometry through stable
+  upstream `SimpleMeshLayer`.
 - Every website gallery example and live layer-reference example now receives a standalone
   `DeviceTabsWidget` from the shared imperative host, with an independent device manager, WebGPU
   preference, WebGL2 fallback, renderer remounting, and preserved view state.
@@ -55,8 +61,8 @@ Scope tracked in the [v9.4 milestone](https://github.com/visgl/deck.gl-community
   vertically exaggerated image-based mountain terrain.
 - `DelaunayCoverLayer` exposes the weather-station mesh, while `DelaunayInterpolation` provides
   backend-independent explicit weather sampling and rasterization.
-- `WindLayer` arrows and `DelaunayCoverLayer` station terrain now use native GLSL/WGSL triangle
-  geometry; image-based mountain terrain remains dependent on upstream WebGPU support.
+- `WindLayer` arrows and `DelaunayCoverLayer` station terrain use native GLSL/WGSL triangle
+  geometry, and `ElevationLayer` uses the upstream dual-backend terrain renderer.
 - Added public weather data, field, measurement, bounds, sample, triangle, and field-options types,
   including robust Delaunay station triangulation for skinny station hulls.
 - Added a complete wind showcase guide, six reference pages with inline live examples, documented

--- a/examples/geo-layers/wind/app.ts
+++ b/examples/geo-layers/wind/app.ts
@@ -13,7 +13,6 @@ import {
   type Widget
 } from '@deck.gl/core';
 import {GeoJsonLayer, ScatterplotLayer, TextLayer} from '@deck.gl/layers';
-import {FastTextLayer} from '@deck.gl-community/infovis-layers';
 import {
   createWindField,
   DelaunayCoverLayer,
@@ -133,7 +132,7 @@ type WindExampleLayerStack = {
   boundaries: GeoJsonLayer | false;
   wind: WindLayer | false;
   particles: ParticleLayer | false;
-  labels: TextLayer<WindCity> | FastTextLayer<WindCity>;
+  labels: TextLayer<WindCity>;
   stations: ScatterplotLayer<WindStation> | false;
 };
 
@@ -427,12 +426,9 @@ export function mountWindExample(
       return;
     }
 
-    const isWebgpu = options.device?.type === 'webgpu';
-
     layerStack = {
       terrain:
         settings.showTerrain &&
-        !isWebgpu &&
         new ElevationLayer({
           id: 'wind-height-map',
           elevationData: terrainData.elevationData,
@@ -444,7 +440,7 @@ export function mountWindExample(
           texture: terrainData.texture
         }),
       stationMesh:
-        (settings.showStationMesh || (settings.showTerrain && isWebgpu)) &&
+        settings.showStationMesh &&
         new DelaunayCoverLayer({
           id: 'wind-station-terrain',
           windField: field,
@@ -465,47 +461,26 @@ export function mountWindExample(
       }),
       wind: createWindLayer(field),
       particles: createParticleLayer(field),
-      labels: isWebgpu
-        ? new FastTextLayer<WindCity>({
-            id: 'wind-city-labels',
-            data: WIND_CITIES,
-            getPosition: city => {
-              const sample = sampleWindField(field, city.position, 0);
-              return [
-                city.position[0],
-                city.position[1],
-                (sample?.elevation ?? 0) * ELEVATION_SCALE + 2_200
-              ];
-            },
-            getText: city => city.name,
-            getColor: [231, 232, 238, 215],
-            size: 12,
-            sizeUnits: 'pixels',
-            textAnchor: 'middle',
-            alignmentBaseline: 'center',
-            parameters: {depthWriteEnabled: false},
-            pickable: false
-          })
-        : new TextLayer<WindCity>({
-            id: 'wind-city-labels',
-            data: WIND_CITIES,
-            getPosition: city => {
-              const sample = sampleWindField(field, city.position, 0);
-              return [
-                city.position[0],
-                city.position[1],
-                (sample?.elevation ?? 0) * ELEVATION_SCALE + 2_200
-              ];
-            },
-            getText: city => city.name,
-            getColor: [231, 232, 238, 215],
-            getSize: 12,
-            sizeUnits: 'pixels',
-            getTextAnchor: 'middle',
-            getAlignmentBaseline: 'center',
-            parameters: {depthWriteEnabled: false},
-            pickable: false
-          }),
+      labels: new TextLayer<WindCity>({
+        id: 'wind-city-labels',
+        data: WIND_CITIES,
+        getPosition: city => {
+          const sample = sampleWindField(field, city.position, 0);
+          return [
+            city.position[0],
+            city.position[1],
+            (sample?.elevation ?? 0) * ELEVATION_SCALE + 2_200
+          ];
+        },
+        getText: city => city.name,
+        getColor: [231, 232, 238, 215],
+        getSize: 12,
+        sizeUnits: 'pixels',
+        getTextAnchor: 'middle',
+        getAlignmentBaseline: 'center',
+        parameters: {depthWriteEnabled: false},
+        pickable: false
+      }),
       stations:
         settings.showStations &&
         new ScatterplotLayer<WindStation>({

--- a/examples/geo-layers/wind/package.json
+++ b/examples/geo-layers/wind/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@deck.gl-community/geo-layers": "workspace:*",
-    "@deck.gl-community/infovis-layers": "workspace:*",
     "@deck.gl/core": "~9.4.0",
     "@deck.gl/extensions": "~9.4.0",
     "@deck.gl/geo-layers": "~9.4.0",

--- a/modules/arrow-layers/README.md
+++ b/modules/arrow-layers/README.md
@@ -2,5 +2,6 @@
 
 [![NPM Version](https://img.shields.io/npm/v/@deck.gl-community/arrow-layers.svg)](https://www.npmjs.com/package/@deck.gl-community/arrow-layers)
 [![NPM Downloads](https://img.shields.io/npm/dw/@deck.gl-community/arrow-layers.svg)](https://www.npmjs.com/package/@deck.gl-community/arrow-layers)
+![WebGPU supported](https://img.shields.io/badge/webgpu-yes-green.svg?style=flat-square)
 
 This module contains community maintained Apache Arrow layers pack for deck.gl.

--- a/modules/arrow-layers/src/layers/geo-arrow-h3-hexagon-layer.ts
+++ b/modules/arrow-layers/src/layers/geo-arrow-h3-hexagon-layer.ts
@@ -85,7 +85,6 @@ export class GeoArrowH3HexagonLayer<ExtraProps extends {} = {}> extends Composit
     const layers: H3HexagonLayer[] = [];
     for (let recordBatchIdx = 0; recordBatchIdx < table.batches.length; recordBatchIdx++) {
       const hexData = hexagonColumn.data[recordBatchIdx];
-      const hexValues = hexData.values;
 
       const props: H3HexagonLayerProps = {
         // Note: because this is a composite layer and not doing the rendering
@@ -97,19 +96,18 @@ export class GeoArrowH3HexagonLayer<ExtraProps extends {} = {}> extends Composit
         recordBatchIdx,
         tableOffsets,
 
-        id: `${this.props.id}-geoarrow-arc-${recordBatchIdx}`,
+        id: `${this.props.id}-geoarrow-h3-${recordBatchIdx}`,
+
+        // H3HexagonLayer converts indexes to polygons/centroids on the CPU before forwarding
+        // data to its renderable sublayers. Unlike shader attributes, the string index therefore
+        // needs to remain available as an accessor while iterating binary data.
+        getHexagon: (_object, objectInfo) =>
+          hexagonColumn.get(tableOffsets[recordBatchIdx] + objectInfo.index)!,
 
         data: {
           // @ts-expect-error passed through to enable use by function accessors
           data: table.batches[recordBatchIdx],
-          length: hexData.length,
-          attributes: {
-            getHexagon: {
-              value: hexValues,
-              // h3 cells should always be 15 characters...?
-              size: 15
-            }
-          }
+          length: hexData.length
         }
       };
 

--- a/modules/arrow-layers/src/layers/geo-arrow-text-layer.ts
+++ b/modules/arrow-layers/src/layers/geo-arrow-text-layer.ts
@@ -17,7 +17,6 @@ import * as arrow from 'apache-arrow';
 import * as ga from '@geoarrow/geoarrow-js';
 import {
   assignAccessor,
-  expandArrayToCoords,
   extractAccessorsFromProps,
   getGeometryVector
 } from '../utils/utils';
@@ -208,22 +207,30 @@ export class GeoArrowTextLayer<ExtraProps extends {} = {}> extends CompositeLaye
         recordBatchIdx,
         tableOffsets,
 
-        id: `${this.props.id}-geoarrow-heatmap-${recordBatchIdx}`,
+        id: `${this.props.id}-geoarrow-text-${recordBatchIdx}`,
+        // TextLayer forwards positions through an intermediate MultiIconLayer. Supplying a CPU
+        // accessor lets deck.gl generate the interleaved high/low position buffer required by
+        // WebGPU instead of forwarding a single unsplit binary buffer to the child layer.
+        getPosition: (_object, objectInfo) => {
+          const offset = objectInfo.index * geometryData.type.listSize;
+          objectInfo.target[0] = flatCoordinateArray[offset];
+          objectInfo.target[1] = flatCoordinateArray[offset + 1];
+          objectInfo.target[2] = flatCoordinateArray[offset + 2] ?? 0;
+          return objectInfo.target as [number, number, number];
+        },
         data: {
           // @ts-expect-error passed through to enable use by function accessors
           data: table.batches[recordBatchIdx],
           length: geometryData.length,
           startIndices: characterOffsets,
+          // TextLayer expands one logical row into one instance per glyph. Exposing the logical
+          // rows to the attribute manager lets deck.gl 9.4 build and pack its child attributes.
+          *[Symbol.iterator]() {
+            for (let index = 0; index < geometryData.length; index++) {
+              yield table.batches[recordBatchIdx];
+            }
+          },
           attributes: {
-            // Positions need to be expanded to be one per character!
-            getPosition: {
-              value: expandArrayToCoords(
-                flatCoordinateArray,
-                geometryData.type.listSize,
-                characterOffsets
-              ),
-              size: geometryData.type.listSize
-            },
             // TODO: support non-ascii characters
             getText: {
               value: textValues

--- a/modules/arrow-layers/test/webgpu-layers.browser.spec.ts
+++ b/modules/arrow-layers/test/webgpu-layers.browser.spec.ts
@@ -11,6 +11,7 @@ import {
   FixedSizeList,
   Float32,
   List,
+  Utf8,
   tableFromArrays,
   vectorFromArray
 } from 'apache-arrow';
@@ -18,12 +19,16 @@ import {describe, expect, it} from 'vitest';
 
 import {
   GeoArrowColumnLayer,
+  GeoArrowArcLayer,
+  _GeoArrowH3HexagonLayer as GeoArrowH3HexagonLayer,
   GeoArrowHeatmapLayer,
   GeoArrowPathLayer,
   GeoArrowPointCloudLayer,
   GeoArrowPolygonLayer,
   GeoArrowScatterplotLayer,
-  GeoArrowSolidPolygonLayer
+  GeoArrowSolidPolygonLayer,
+  _GeoArrowTextLayer as GeoArrowTextLayer,
+  GeoArrowTripsLayer
 } from '../src';
 
 type BrowserGpu = {requestAdapter: () => Promise<unknown>};
@@ -38,9 +43,15 @@ const pointType = new FixedSizeList(2, new Field('xy', new Float32()));
 const point3DType = new FixedSizeList(3, new Field('xyz', new Float32()));
 const lineStringType = new List(new Field('vertices', pointType));
 const polygonType = new List(new Field('rings', lineStringType));
+const timestampsType = new List(new Field('timestamps', new Float32()));
 const table = tableFromArrays({id: [0]});
 const points = vectorFromArray([[0, 0]], pointType);
+const sourcePoints = vectorFromArray([[-24, 8]], pointType);
+const targetPoints = vectorFromArray([[24, 8]], pointType);
 const pointCloudPoints = vectorFromArray([[0, 0, 8]], point3DType);
+const h3Indexes = vectorFromArray(['8928308280fffff'], new Utf8());
+const text = vectorFromArray(['GPU'], new Utf8());
+const timestamps = vectorFromArray([[0, 50, 100]], timestampsType);
 const lineStrings = vectorFromArray(
   [
     [
@@ -94,6 +105,18 @@ async function renderGeoArrowLayers(type: 'webgl' | 'webgpu'): Promise<void> {
     pickable: true
   });
   const layers = [
+    new GeoArrowArcLayer({
+      id: `geoarrow-arc-${type}`,
+      coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+      data: table,
+      getSourcePosition: sourcePoints,
+      getTargetPosition: targetPoints,
+      getSourceColor: [14, 165, 233, 255],
+      getTargetColor: [168, 85, 247, 255],
+      getWidth: 3,
+      widthUnits: 'pixels',
+      pickable: true
+    }),
     new GeoArrowColumnLayer({
       id: `geoarrow-column-${type}`,
       coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
@@ -114,6 +137,15 @@ async function renderGeoArrowLayers(type: 'webgl' | 'webgpu'): Promise<void> {
       getWeight: 1,
       radiusPixels: 24,
       pickable: false
+    }),
+    new GeoArrowH3HexagonLayer({
+      id: `geoarrow-h3-${type}`,
+      data: table,
+      getHexagon: h3Indexes,
+      highPrecision: true,
+      getFillColor: [245, 158, 11, 180],
+      material: false,
+      pickable: true
     }),
     new GeoArrowPointCloudLayer({
       id: `geoarrow-point-cloud-${type}`,
@@ -151,7 +183,31 @@ async function renderGeoArrowLayers(type: 'webgl' | 'webgpu'): Promise<void> {
       pickable: true
     }),
     polygonLayer,
-    pathLayer
+    pathLayer,
+    new GeoArrowTextLayer({
+      id: `geoarrow-text-${type}`,
+      coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+      data: table,
+      getPosition: points,
+      getText: text,
+      getColor: [15, 23, 42, 255],
+      getSize: 14,
+      sizeUnits: 'pixels',
+      pickable: true
+    }),
+    new GeoArrowTripsLayer({
+      id: `geoarrow-trips-${type}`,
+      coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+      data: table,
+      getPath: lineStrings,
+      getTimestamps: timestamps,
+      currentTime: 75,
+      trailLength: 100,
+      getColor: [244, 63, 94, 255],
+      getWidth: 4,
+      widthUnits: 'pixels',
+      pickable: true
+    })
   ];
 
   let device: Device | undefined;
@@ -215,7 +271,7 @@ async function renderGeoArrowLayers(type: 'webgl' | 'webgpu'): Promise<void> {
 describe('GeoArrow graphics backend compatibility', () => {
   it('renders binary attributes through portable upstream renderers on WebGL2', async () => {
     await renderGeoArrowLayers('webgl');
-  }, 20_000);
+  }, 60_000);
 
   it('renders binary attributes through portable upstream renderers on WebGPU', async ({skip}) => {
     const gpu = (navigator as Navigator & {gpu?: BrowserGpu}).gpu;
@@ -224,5 +280,5 @@ describe('GeoArrow graphics backend compatibility', () => {
     }
 
     await renderGeoArrowLayers('webgpu');
-  }, 20_000);
+  }, 60_000);
 });

--- a/modules/geo-layers/README.md
+++ b/modules/geo-layers/README.md
@@ -38,8 +38,8 @@ const layers = [
 ```
 
 WebGL2 and WebGPU particle simulation are independently browser-tested. Wind arrows, state
-boundaries, and station-triangulated terrain are portable; complete rendering of the original
-mountain scene remains in progress because upstream `TerrainLayer` does not yet support WebGPU.
+boundaries, station-triangulated terrain, and the original image-derived mountain terrain are
+portable with stable deck.gl 9.4.
 
 See the [wind showcase guide](https://deck.gl-community.github.io/docs/modules/geo-layers/developer-guide/wind-showcase)
 and [standalone example](https://github.com/visgl/deck.gl-community/tree/master/examples/geo-layers/wind).

--- a/modules/geo-layers/src/wind-layer/elevation-layer.ts
+++ b/modules/geo-layers/src/wind-layer/elevation-layer.ts
@@ -42,8 +42,7 @@ const defaultProps: DefaultProps<ElevationLayerProps> = {
  *
  * @remarks
  * This API is a work in progress. Smooth the source height map before applying strong
- * exaggeration; use a smaller `meshMaxError` to preserve mountain detail. WebGPU support
- * depends on the upstream `TerrainLayer` and active loaders.gl rendering path.
+ * exaggeration; use a smaller `meshMaxError` to preserve mountain detail.
  *
  * @example
  * ```ts
@@ -65,7 +64,7 @@ export class ElevationLayer extends CompositeLayer<ElevationLayerProps> {
   renderLayers(): TerrainLayer | null {
     const {elevationData, bounds, elevationRange, elevationScale, meshMaxError, color, texture} =
       this.props;
-    if (!elevationData || this.context?.device?.type === 'webgpu') {
+    if (!elevationData) {
       return null;
     }
 

--- a/modules/geo-layers/test/wind-layer/wind-layers.browser.spec.ts
+++ b/modules/geo-layers/test/wind-layer/wind-layers.browser.spec.ts
@@ -67,12 +67,7 @@ function createElevationData(): string {
   return canvas.toDataURL('image/png');
 }
 
-function createLayers(
-  field: WindField,
-  time: number,
-  elevationData: string,
-  deviceType: 'webgl' | 'webgpu'
-) {
+function createLayers(field: WindField, time: number, elevationData: string) {
   const particles = new ParticleLayer({
     id: 'test-wind-particles',
     windField: field,
@@ -83,18 +78,14 @@ function createLayers(
   });
 
   return [
-    ...(deviceType === 'webgpu'
-      ? []
-      : [
-          new ElevationLayer({
-            id: 'test-wind-height-map',
-            elevationData,
-            bounds: [-100, 35, -96, 39],
-            elevationRange: [0, 255],
-            elevationScale: 2,
-            meshMaxError: 4
-          })
-        ]),
+    new ElevationLayer({
+      id: 'test-wind-height-map',
+      elevationData,
+      bounds: [-100, 35, -96, 39],
+      elevationRange: [0, 255],
+      elevationScale: 2,
+      meshMaxError: 4
+    }),
     new DelaunayCoverLayer({id: 'test-wind-terrain', windField: field, elevationScale: 2}),
     new WindLayer({
       id: 'test-wind-arrows',
@@ -186,11 +177,11 @@ async function renderWindLayers(type: 'webgl' | 'webgpu'): Promise<void> {
         height: 120,
         views: new MapView({id: 'wind-test'}),
         initialViewState: {longitude: -98, latitude: 37, zoom: 4},
-        layers: createLayers(field, 0, elevationData, type),
+        layers: createLayers(field, 0, elevationData),
         onAfterRender: () => {
           if (!renderedAnimation) {
             renderedAnimation = true;
-            const layers = createLayers(field, 0.5, elevationData, type);
+            const layers = createLayers(field, 0.5, elevationData);
             particleLayer = layers.find(layer => layer instanceof ParticleLayer) as ParticleLayer;
             deck?.setProps({layers});
             return;
@@ -245,9 +236,9 @@ async function renderWindLayers(type: 'webgl' | 'webgpu'): Promise<void> {
 describe('wind showcase rendering', () => {
   it('renders and animates terrain, arrows, and particles on WebGL2', async () => {
     await renderWindLayers('webgl');
-  }, 20_000);
+  }, 60_000);
 
-  it('renders portable boundaries, arrows, station terrain, and particles on WebGPU', async ({
+  it('renders height-map terrain, boundaries, arrows, station terrain, and particles on WebGPU', async ({
     skip
   }) => {
     const gpu = (navigator as Navigator & {gpu?: BrowserGpu}).gpu;
@@ -256,5 +247,5 @@ describe('wind showcase rendering', () => {
     }
 
     await renderWindLayers('webgpu');
-  }, 20_000);
+  }, 60_000);
 });

--- a/modules/geo-layers/test/wind-layer/wind-layers.spec.ts
+++ b/modules/geo-layers/test/wind-layer/wind-layers.spec.ts
@@ -107,7 +107,7 @@ describe('reusable wind showcase layers', () => {
     expect((terrain.props.data as {polygon: number[][]}[])[0].polygon[0][2]).toBeGreaterThan(0);
   });
 
-  it('does not instantiate upstream WebGL-only height-map terrain on WebGPU', () => {
+  it('instantiates height-map terrain on WebGPU', () => {
     const layer = new ElevationLayer({
       id: 'webgpu-elevation-test',
       elevationData: 'https://example.com/elevation.png',
@@ -115,7 +115,7 @@ describe('reusable wind showcase layers', () => {
     });
     Object.defineProperty(layer, 'context', {value: {device: {type: 'webgpu'}}});
 
-    expect(layer.renderLayers()).toBeNull();
+    expect(layer.renderLayers()).toBeInstanceOf(TerrainLayer);
   });
 
   it('advects particles a visible, elapsed-time-scaled distance through the wind field', () => {

--- a/modules/infovis-layers/src/layers/block-layer/block-layer.ts
+++ b/modules/infovis-layers/src/layers/block-layer/block-layer.ts
@@ -180,17 +180,20 @@ export class BlockLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
       instanceSizes: {
         size: 2,
         transition: true,
+        bufferGroup: 'block-instance-data',
         accessor: 'getSize'
       },
       instanceLineWidths: {
         size: 1,
         transition: true,
+        bufferGroup: 'block-instance-data',
         accessor: 'getLineWidth'
       },
       instanceLineColors: {
         size: this.props.colorFormat.length,
         type: 'unorm8',
         transition: true,
+        bufferGroup: 'block-instance-data',
         accessor: 'getLineColor',
         defaultValue: DEFAULT_COLOR
       },
@@ -198,18 +201,20 @@ export class BlockLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
         size: this.props.colorFormat.length,
         type: 'unorm8',
         transition: true,
+        bufferGroup: 'block-instance-data',
         accessor: 'getFillColor',
         defaultValue: DEFAULT_COLOR
       },
       instanceOpacities: {
         size: 1,
         transition: true,
+        bufferGroup: 'block-instance-data',
         accessor: 'getOpacity',
         defaultValue: 1
       },
       instanceColorOverrides: {
         size: 1,
-        type: 'uint8',
+        bufferGroup: 'block-instance-data',
         accessor: 'getColorOverride',
         defaultValue: 0
       }

--- a/modules/layers/test/webgpu-layers.browser.spec.ts
+++ b/modules/layers/test/webgpu-layers.browser.spec.ts
@@ -425,7 +425,7 @@ async function renderPortableLayers(type: 'webgl' | 'webgpu'): Promise<void> {
 describe('community graphics backend compatibility', () => {
   it('renders custom shaders, paths, polygons, graph, timeline, and editing on WebGL2', async () => {
     await renderPortableLayers('webgl');
-  }, 20_000);
+  }, 60_000);
 
   it('renders custom shaders, paths, polygons, graph, timeline, and editing on WebGPU', async ({
     skip
@@ -436,5 +436,5 @@ describe('community graphics backend compatibility', () => {
     }
 
     await renderPortableLayers('webgpu');
-  }, 20_000);
+  }, 60_000);
 });

--- a/modules/three/README.md
+++ b/modules/three/README.md
@@ -2,6 +2,7 @@
 
 [![NPM Version](https://img.shields.io/npm/v/@deck.gl-community/three.svg)](https://www.npmjs.com/package/@deck.gl-community/three)
 [![NPM Downloads](https://img.shields.io/npm/dw/@deck.gl-community/three.svg)](https://www.npmjs.com/package/@deck.gl-community/three)
+![WebGPU supported](https://img.shields.io/badge/webgpu-yes-green.svg?style=flat-square)
 
 A collection of deck.gl layers powered by [Three.js](https://threejs.org/), giving access to Three.js geometry primitives and scene graph tooling directly inside deck.gl visualisations.
 

--- a/modules/three/test/webgpu-layers.browser.spec.ts
+++ b/modules/three/test/webgpu-layers.browser.spec.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {COORDINATE_SYSTEM, Deck, OrthographicView} from '@deck.gl/core';
+import {Deck, MapView} from '@deck.gl/core';
 import {luma, type Device} from '@luma.gl/core';
 import {webgl2Adapter} from '@luma.gl/webgl';
 import {webgpuAdapter} from '@luma.gl/webgpu';
 import {describe, expect, it} from 'vitest';
 
-import {GlobalGridLayer, SharedTile2DHeader, TileGridLayer, type GlobalGrid} from '../src';
+import {TreeLayer} from '../src';
 
 type BrowserGpu = {requestAdapter: () => Promise<unknown>};
 type NativeGpuError = {error?: {message?: string}};
@@ -18,55 +18,14 @@ type NativeGpuDevice = {
   queue: {onSubmittedWorkDone: () => Promise<void>};
 };
 
-const TEST_GRID: GlobalGrid = {
-  name: 'browser-test-grid',
-  hasNumericRepresentation: false,
-  cellToLngLat: () => [0, 0],
-  cellToBoundary: () => [
-    [-28, -20],
-    [-4, -20],
-    [-4, 4],
-    [-28, 4]
-  ]
-};
-
-function createPortableGeoLayers() {
-  const tile = new SharedTile2DHeader({x: 0, y: 0, z: 0});
-  tile.bbox = {left: 4, top: -20, right: 28, bottom: 4};
-
-  return [
-    new GlobalGridLayer({
-      id: 'webgpu-global-grid',
-      coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
-      data: [{cellId: 'test-cell'}],
-      globalGrid: TEST_GRID,
-      filled: true,
-      stroked: true,
-      getFillColor: [14, 165, 233, 160],
-      getLineColor: [3, 105, 161, 255],
-      getLineWidth: 2,
-      lineWidthUnits: 'pixels',
-      pickable: true
-    }),
-    new TileGridLayer({
-      id: 'webgpu-tile-grid',
-      coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
-      tile,
-      showLabel: true,
-      borderColor: [245, 158, 11, 255],
-      borderWidthMinPixels: 2
-    })
-  ];
-}
-
-async function renderPortableGeoLayers(type: 'webgl' | 'webgpu'): Promise<void> {
+async function renderTreeLayer(type: 'webgl' | 'webgpu'): Promise<void> {
   const parent = document.createElement('div');
   parent.style.width = '128px';
   parent.style.height = '128px';
   document.body.append(parent);
 
   let device: Device | undefined;
-  let deck: Deck<OrthographicView> | undefined;
+  let deck: Deck | undefined;
   let nativeDevice: NativeGpuDevice | undefined;
   const validationErrors: string[] = [];
   const captureValidationError = (event: NativeGpuError): void => {
@@ -86,7 +45,7 @@ async function renderPortableGeoLayers(type: 'webgl' | 'webgpu'): Promise<void> 
 
     await new Promise<void>((resolve, reject) => {
       const timeout = window.setTimeout(() => {
-        reject(new Error(`Timed out while rendering portable geospatial layers with ${type}.`));
+        reject(new Error(`Timed out while rendering TreeLayer with ${type}.`));
       }, 10_000);
 
       deck = new Deck({
@@ -94,9 +53,18 @@ async function renderPortableGeoLayers(type: 'webgl' | 'webgpu'): Promise<void> 
         parent,
         width: 128,
         height: 128,
-        views: new OrthographicView({id: 'geo-layers-webgpu-test', flipY: false}),
-        initialViewState: {target: [0, 0, 0], zoom: 0},
-        layers: createPortableGeoLayers(),
+        views: new MapView({id: 'tree-webgpu-test'}),
+        initialViewState: {longitude: 0, latitude: 0, zoom: 18, pitch: 45},
+        layers: [
+          new TreeLayer({
+            id: `tree-${type}`,
+            data: [{position: [0, 0] as [number, number]}],
+            getPosition: datum => datum.position,
+            getTreeType: () => 'oak',
+            getHeight: () => 12,
+            pickable: true
+          })
+        ],
         onAfterRender: () => {
           window.clearTimeout(timeout);
           resolve();
@@ -114,26 +82,22 @@ async function renderPortableGeoLayers(type: 'webgl' | 'webgpu'): Promise<void> 
   } finally {
     nativeDevice?.removeEventListener('uncapturederror', captureValidationError);
     deck?.finalize();
-    // Deck finalization releases WebGPU resources; leave final WebGPU teardown to the browser so
-    // this test remains compatible with shared software adapters when CI enables them separately.
-    if (device?.type !== 'webgpu') {
-      device?.destroy();
-    }
+    device?.destroy();
     parent.remove();
   }
 }
 
-describe('geospatial graphics backend compatibility', () => {
-  it('renders global-grid polygons plus tile outlines and labels on WebGL2', async () => {
-    await renderPortableGeoLayers('webgl');
-  }, 60_000);
+describe('TreeLayer graphics backend compatibility', () => {
+  it('renders procedural SimpleMeshLayer geometry on WebGL2', async () => {
+    await renderTreeLayer('webgl');
+  }, 20_000);
 
-  it('renders global-grid polygons plus tile outlines and labels on WebGPU', async ({skip}) => {
+  it('renders procedural SimpleMeshLayer geometry on WebGPU', async ({skip}) => {
     const gpu = (navigator as Navigator & {gpu?: BrowserGpu}).gpu;
     if (!gpu || !(await gpu.requestAdapter())) {
       skip('This browser does not expose an available WebGPU adapter.');
     }
 
-    await renderPortableGeoLayers('webgpu');
-  }, 60_000);
+    await renderTreeLayer('webgpu');
+  }, 20_000);
 });

--- a/modules/timeline-layers/README.md
+++ b/modules/timeline-layers/README.md
@@ -3,7 +3,7 @@
 [![NPM Version](https://img.shields.io/npm/v/@deck.gl-community/timeline-layers.svg)](https://www.npmjs.com/package/@deck.gl-community/timeline-layers)
 [![NPM Downloads](https://img.shields.io/npm/dw/@deck.gl-community/timeline-layers.svg)](https://www.npmjs.com/package/@deck.gl-community/timeline-layers)
 ![deck.gl v9](https://img.shields.io/badge/deck.gl-v9-green.svg?style=flat-square")
-![WebGPU partially supported](https://img.shields.io/badge/webgpu-partial-yellow.svg?style=flat-square")
+![WebGPU supported](https://img.shields.io/badge/webgpu-yes-green.svg?style=flat-square")
 
 Experimental timeline visualization layers for [deck.gl](https://deck.gl), including HorizonGraph primitives and timeline axes/grid utilities for compact time series displays.
 

--- a/modules/timeline-layers/test/webgpu-layers.browser.spec.ts
+++ b/modules/timeline-layers/test/webgpu-layers.browser.spec.ts
@@ -8,7 +8,7 @@ import {webgl2Adapter} from '@luma.gl/webgl';
 import {webgpuAdapter} from '@luma.gl/webgpu';
 import {describe, expect, it} from 'vitest';
 
-import {GlobalGridLayer, SharedTile2DHeader, TileGridLayer, type GlobalGrid} from '../src';
+import {TimeAxisLayer, TimelineLayer} from '../src';
 
 type BrowserGpu = {requestAdapter: () => Promise<unknown>};
 type NativeGpuError = {error?: {message?: string}};
@@ -18,48 +18,47 @@ type NativeGpuDevice = {
   queue: {onSubmittedWorkDone: () => Promise<void>};
 };
 
-const TEST_GRID: GlobalGrid = {
-  name: 'browser-test-grid',
-  hasNumericRepresentation: false,
-  cellToLngLat: () => [0, 0],
-  cellToBoundary: () => [
-    [-28, -20],
-    [-4, -20],
-    [-4, 4],
-    [-28, 4]
-  ]
-};
-
-function createPortableGeoLayers() {
-  const tile = new SharedTile2DHeader({x: 0, y: 0, z: 0});
-  tile.bbox = {left: 4, top: -20, right: 28, bottom: 4};
-
+function createTimelineLayers() {
   return [
-    new GlobalGridLayer({
-      id: 'webgpu-global-grid',
+    new TimeAxisLayer({
+      id: 'time-axis',
       coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
-      data: [{cellId: 'test-cell'}],
-      globalGrid: TEST_GRID,
-      filled: true,
-      stroked: true,
-      getFillColor: [14, 165, 233, 160],
-      getLineColor: [3, 105, 161, 255],
-      getLineWidth: 2,
-      lineWidthUnits: 'pixels',
-      pickable: true
+      startTimeMs: -30,
+      endTimeMs: 30,
+      tickCount: 4,
+      y: 32,
+      color: [15, 23, 42, 255]
     }),
-    new TileGridLayer({
-      id: 'webgpu-tile-grid',
+    new TimelineLayer({
+      id: 'timeline',
       coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
-      tile,
-      showLabel: true,
-      borderColor: [245, 158, 11, 255],
-      borderWidthMinPixels: 2
+      data: [
+        {
+          id: 'track',
+          name: 'WebGPU',
+          clips: [
+            {id: 'clip', label: 'portable', startMs: 0, endMs: 700, color: [14, 165, 233, 255]}
+          ]
+        }
+      ],
+      timelineStart: 0,
+      timelineEnd: 1000,
+      currentTimeMs: 500,
+      x: -25,
+      y: -5,
+      width: 50,
+      trackHeight: 10,
+      trackSpacing: 2,
+      showAxis: true,
+      showClipLabels: true,
+      showTrackLabels: true,
+      showScrubber: true,
+      pickable: true
     })
   ];
 }
 
-async function renderPortableGeoLayers(type: 'webgl' | 'webgpu'): Promise<void> {
+async function renderTimelineLayers(type: 'webgl' | 'webgpu'): Promise<void> {
   const parent = document.createElement('div');
   parent.style.width = '128px';
   parent.style.height = '128px';
@@ -86,7 +85,7 @@ async function renderPortableGeoLayers(type: 'webgl' | 'webgpu'): Promise<void> 
 
     await new Promise<void>((resolve, reject) => {
       const timeout = window.setTimeout(() => {
-        reject(new Error(`Timed out while rendering portable geospatial layers with ${type}.`));
+        reject(new Error(`Timed out while rendering timeline labels with ${type}.`));
       }, 10_000);
 
       deck = new Deck({
@@ -94,9 +93,9 @@ async function renderPortableGeoLayers(type: 'webgl' | 'webgpu'): Promise<void> 
         parent,
         width: 128,
         height: 128,
-        views: new OrthographicView({id: 'geo-layers-webgpu-test', flipY: false}),
+        views: new OrthographicView({id: 'timeline-webgpu-test', flipY: false}),
         initialViewState: {target: [0, 0, 0], zoom: 0},
-        layers: createPortableGeoLayers(),
+        layers: createTimelineLayers(),
         onAfterRender: () => {
           window.clearTimeout(timeout);
           resolve();
@@ -114,26 +113,22 @@ async function renderPortableGeoLayers(type: 'webgl' | 'webgpu'): Promise<void> 
   } finally {
     nativeDevice?.removeEventListener('uncapturederror', captureValidationError);
     deck?.finalize();
-    // Deck finalization releases WebGPU resources; leave final WebGPU teardown to the browser so
-    // this test remains compatible with shared software adapters when CI enables them separately.
-    if (device?.type !== 'webgpu') {
-      device?.destroy();
-    }
+    device?.destroy();
     parent.remove();
   }
 }
 
-describe('geospatial graphics backend compatibility', () => {
-  it('renders global-grid polygons plus tile outlines and labels on WebGL2', async () => {
-    await renderPortableGeoLayers('webgl');
-  }, 60_000);
+describe('timeline text graphics backend compatibility', () => {
+  it('renders axis, track, clip, and scrubber labels on WebGL2', async () => {
+    await renderTimelineLayers('webgl');
+  }, 20_000);
 
-  it('renders global-grid polygons plus tile outlines and labels on WebGPU', async ({skip}) => {
+  it('renders axis, track, clip, and scrubber labels on WebGPU', async ({skip}) => {
     const gpu = (navigator as Navigator & {gpu?: BrowserGpu}).gpu;
     if (!gpu || !(await gpu.requestAdapter())) {
       skip('This browser does not expose an available WebGPU adapter.');
     }
 
-    await renderPortableGeoLayers('webgpu');
-  }, 60_000);
+    await renderTimelineLayers('webgpu');
+  }, 20_000);
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -69,7 +69,7 @@ const BROWSER_RESOLVE_CONFIG = {
 };
 
 const BROWSER_OPTIMIZE_DEPS_CONFIG = {
-  include: ['apache-arrow', 'zod']
+  include: ['@deck.gl/mesh-layers', 'apache-arrow', 'three', 'zod']
 };
 
 const BROWSER_TEST_EXCLUDE = ['modules/**/dist/**', 'dev/**/dist/**'];

--- a/website/src/components/docs/webgpu-support.js
+++ b/website/src/components/docs/webgpu-support.js
@@ -1,5 +1,6 @@
 const SUPPORTED_DOC_IDS = new Set([
   'modules/geo-layers/api-reference/delaunay-cover-layer',
+  'modules/geo-layers/api-reference/elevation-layer',
   'modules/geo-layers/api-reference/global-grid-layer',
   'modules/geo-layers/api-reference/particle-layer',
   'modules/geo-layers/api-reference/tile-grid-layer',
@@ -12,11 +13,12 @@ const SUPPORTED_DOC_IDS = new Set([
   'modules/infovis-layers/api-reference/time-delta-layer',
   'modules/timeline-layers/api-reference/horizon-graph-layer',
   'modules/timeline-layers/api-reference/multi-horizon-graph-layer',
+  'modules/timeline-layers/api-reference/time-axis-layer',
   'modules/timeline-layers/api-reference/vertical-grid-layer',
+  'modules/three/api-reference/tree-layer',
 ]);
 
 const UNSUPPORTED_DOC_IDS = new Set([
-  'modules/geo-layers/api-reference/elevation-layer',
   'modules/graph-layers/api-reference/layers/flow-layer',
   'modules/graph-layers/api-reference/layers/flow-path-layer'
 ]);
@@ -42,7 +44,7 @@ const NOT_APPLICABLE_DOC_ID_PATTERNS = [
 ];
 
 const MODULE_STATUS = {
-  'arrow-layers': 'partial',
+  'arrow-layers': 'supported',
   'basemap-layers': 'partial',
   'bing-maps': 'unsupported',
   'editable-layers': 'partial',
@@ -54,8 +56,8 @@ const MODULE_STATUS = {
   leaflet: 'unsupported',
   panels: 'not-applicable',
   react: 'not-applicable',
-  three: 'partial',
-  'timeline-layers': 'partial',
+  three: 'supported',
+  'timeline-layers': 'supported',
   widgets: 'supported'
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12622,7 +12622,6 @@ __metadata:
   resolution: "wind-layer-example@workspace:examples/geo-layers/wind"
   dependencies:
     "@deck.gl-community/geo-layers": "workspace:*"
-    "@deck.gl-community/infovis-layers": "workspace:*"
     "@deck.gl/core": "npm:~9.4.0"
     "@deck.gl/extensions": "npm:~9.4.0"
     "@deck.gl/geo-layers": "npm:~9.4.0"


### PR DESCRIPTION
## Summary

- adopt the stable deck.gl 9.4 WebGPU implementations for `TerrainLayer`, `TextLayer`, `TripsLayer`, `SimpleMeshLayer`, and H3 sublayers
- fix GeoArrow H3 and text data forwarding through deck.gl's composite layers
- keep `BlockLayer` within baseline WebGPU vertex-buffer and write-alignment limits
- add dual-backend browser coverage for all GeoArrow wrappers, `ElevationLayer`, wind terrain, `TreeLayer`, timeline labels, and tile labels
- update the WebGPU matrix, module badges, upgrade notes, example documentation, and `whats-new.md`

This PR is based directly on `master`. It does **not** enable WebGPU in CI and is not stacked on the separate CI-enablement work.

## WebGPU porting status

| Area | Status after this PR | Fixed / validated here |
| --- | --- | :---: |
| `ElevationLayer` and complete Wind Map terrain | Supported | ✅ |
| `TimeAxisLayer` and `TimelineLayer` labels | Supported | ✅ |
| `TreeLayer` / upstream `SimpleMeshLayer` | Supported | ✅ |
| All GeoArrow wrappers, including Arc, H3, Text, and Trips | Supported | ✅ |
| `GlobalGridLayer` / `TileGridLayer` labels | Supported | ✅ |
| `BlockLayer` on baseline WebGPU limits | Supported | ✅ |
| Local path dash/marker fallback | Supported; upstream `PathStyleExtension` remains GLSL-only | ✅ existing fallback |
| `FlowPathLayer` | Unsupported on both backends; implementation currently throws and needs a redesign | ⬜ |
| `SharedTile2DLayer` / `TileSourceLayer` | Partial; tile formats, texture upload, labels, and picking need end-to-end validation | ⬜ |
| `GraphLayer` composition | Partial; full styling, images, labels, layouts, and picking need end-to-end validation | ⬜ |
| Editable and timeline interactions | Partial; pointer, drag, snapping, and selection need browser interaction coverage | ⬜ |
| Basemap integrations | Partial; each style/tile/label combination needs validation | ⬜ |
| Leaflet and Bing overlays | Host-owned WebGL contexts cannot be ported by deck.gl-community | N/A |
| WebGPU CI enablement | Separate PR by design | ⬜ |

## Validation

- `yarn`
- `yarn lint`
- `yarn test` — 89 files, 616 passed, 9 skipped
- full software-WebGPU browser run — 38 files, 239 passed
- focused WebGL2/WebGPU browser tests for wind, GeoArrow, Tree, Timeline, tile labels, and the combined community layer suite
- `yarn build`
- `cd website && yarn && yarn build`
- `yarn vitest run --project examples examples/geo-layers/wind`
- `yarn workspace wind-layer-example build`
