### PR TITLE
chore: finalize the 9.4 release

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,6 +1,8 @@
 # What's New
 
-## v9.4 - In Development
+## v9.4
+
+Release Date: Sep 7, 2026
 
 Highlights:
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -126,14 +126,18 @@ const config = {
             '@loaders.gl/obj': resolve('node_modules/@loaders.gl/obj'),
             '@loaders.gl/ply': resolve('node_modules/@loaders.gl/ply'),
             '@loaders.gl': resolve('../node_modules/@loaders.gl'),
-            preact: resolve('node_modules/preact'),
-            'preact/hooks': resolve('node_modules/preact/hooks'),
-            'preact/jsx-runtime': resolve('node_modules/preact/jsx-runtime'),
-            'preact/jsx-dev-runtime': resolve('node_modules/preact/jsx-dev-runtime'),
+            'preact$': resolve('node_modules/preact/dist/preact.module.js'),
+            'preact/hooks': resolve('node_modules/preact/hooks/dist/hooks.module.js'),
+            'preact/jsx-runtime': resolve(
+              'node_modules/preact/jsx-runtime/dist/jsxRuntime.module.js'
+            ),
+            'preact/jsx-dev-runtime': resolve(
+              'node_modules/preact/jsx-runtime/dist/jsxRuntime.module.js'
+            ),
             'react/jsx-dev-runtime': resolve('node_modules/react/jsx-dev-runtime'),
             'react/jsx-runtime': resolve('node_modules/react/jsx-runtime'),
             'react-dom/client': resolve('node_modules/react-dom/client'),
-            react: websiteReact,
+            'react$': websiteReact,
             'react-dom': websiteReactDom
           }
         },

--- a/website/src/components/docs/webgpu-badge.module.css
+++ b/website/src/components/docs/webgpu-badge.module.css
@@ -29,6 +29,7 @@
 
 .badge span {
   padding: 0 7px;
+  color: #fff;
 }
 
 .name {
@@ -40,7 +41,7 @@
 }
 
 .partial {
-  background: #b7791f;
+  background: #8a5a10;
 }
 
 .unsupported {
@@ -48,7 +49,7 @@
 }
 
 .not-applicable {
-  background: #607d8b;
+  background: #455a64;
 }
 
 .mixed {


### PR DESCRIPTION
## Summary

- finalize the v9.4 release notes with the September 7, 2026 release date
- improve WebGPU badge contrast across every support status and both site themes
- resolve React and Preact JSX runtimes to explicit ESM files for the Rspack-powered website

## Verification

- `yarn lint`
- `yarn test` (616 passed, 9 skipped)
- verified all five WebGPU badge variants on the running website in light and dark modes
