### PR TITLE
fix: declare widgets peer and export ToastManager

### DIFF
--- a/docs/modules/panels/README.md
+++ b/docs/modules/panels/README.md
@@ -62,8 +62,8 @@ and URL docs stay synchronized with the app.
   deep links documented by `URLParametersPanel`
 - [CommandManager](./api-reference/managers/command-manager.md) registers
   executable app commands
-- [Toast Manager](./api-reference/managers/toast-manager.md) owns toast state
-  rendered by `ToastComponent`
+- [ToastManager](./api-reference/managers/toast-manager.md) owns toast state
+  rendered by `ToastComponent`; `toastManager` is the shared instance
 
 Start with [Using Panels](./developer-guide/using-panels.md) for panel
 composition, [Using Components](./developer-guide/using-components.md) for

--- a/docs/modules/panels/api-reference/managers/toast-manager.md
+++ b/docs/modules/panels/api-reference/managers/toast-manager.md
@@ -8,7 +8,9 @@ import PanelLiveExample from '@site/src/components/docs/panel-live-example';
 
 <PanelLiveExample highlight="panels" />
 
-`toastManager` manages toast state independently of any specific rendering host.
+`ToastManager` manages toast state independently of any specific rendering host.
+The package also exports `toastManager`, a shared instance for applications that
+do not need an isolated toast queue.
 
 Use it when application code needs to enqueue, dismiss, or observe toast
 messages without coupling that logic to a React component or a deck.gl widget.
@@ -16,10 +18,19 @@ messages without coupling that logic to a React component or a deck.gl widget.
 ## Usage
 
 ```ts
-import {toastManager, type ToastKind, type ToastRequest} from '@deck.gl-community/panels';
+import {ToastManager, toastManager, type ToastKind, type ToastRequest} from '@deck.gl-community/panels';
 ```
 
 ## API
+
+### `new ToastManager(maxVisibleToasts?)`
+
+Creates an isolated toast manager. The optional argument controls the maximum
+number of visible toasts; it defaults to three.
+
+```ts
+const isolatedToastManager = new ToastManager(5);
+```
 
 ### `toastManager.toast(request)`
 

--- a/modules/panels/README.md
+++ b/modules/panels/README.md
@@ -13,7 +13,8 @@ visualization applications.
 
 It exports `PanelComponent`, panel/container types, reusable panel content
 classes, `ToolbarComponent`, `ToastComponent`, `PanelManager`, panel theme
-primitives, and application-managed helpers such as `toastManager`.
+primitives, and application-managed helpers such as `ToastManager` and the
+shared `toastManager` instance.
 
 ## Panels
 
@@ -30,6 +31,7 @@ application-specific panel-managed controls extend it.
 ## Managers
 
 `PanelManager` mounts `PanelComponent[]` without deck.gl. `SettingsManager`,
-keyboard shortcut managers, `URLManager`, `CommandManager`, and `toastManager`
+keyboard shortcut managers, `URLManager`, `CommandManager`, and `ToastManager`
 keep app behavior and state outside rendering so panels and components can
-reuse the same descriptors or state.
+reuse the same descriptors or state. The package also exports a shared
+`toastManager` instance for applications that do not need an isolated toast queue.

--- a/modules/panels/src/index.ts
+++ b/modules/panels/src/index.ts
@@ -151,6 +151,7 @@ export {
 } from './components/toolbar-component';
 export {ToastComponent, type ToastComponentProps} from './components/toast-component';
 export {
+  ToastManager,
   toastManager,
   type ToastEntry,
   type ToastKind,

--- a/modules/panels/test/imports.spec.ts
+++ b/modules/panels/test/imports.spec.ts
@@ -14,8 +14,14 @@ beforeAll(async () => {
   Panels = await import('../src/index');
 });
 
-it('exports PanelManager', () => {
+it('exports all manager classes', () => {
   expect(Panels.PanelManager).toBeDefined();
+  expect(Panels.SettingsManager).toBeDefined();
+  expect(Panels.CommandManager).toBeDefined();
+  expect(Panels.ToastManager).toBeDefined();
+  expect(Panels.URLManager).toBeDefined();
+  expect(Panels.KeyboardShortcutsManager).toBeDefined();
+  expect(Panels.KeyboardShortcutsManagerDocument).toBeDefined();
 });
 
 it('exports panel component primitives', () => {

--- a/modules/widgets/package.json
+++ b/modules/widgets/package.json
@@ -44,6 +44,7 @@
   "peerDependencies": {
     "@deck.gl-community/panels": "~9.4.0-alpha.0",
     "@deck.gl/core": "~9.4.0",
+    "@deck.gl/widgets": "~9.4.0",
     "@luma.gl/core": "~9.4.0",
     "@luma.gl/webgl": "~9.4.0",
     "@luma.gl/webgpu": "~9.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -750,6 +750,7 @@ __metadata:
   peerDependencies:
     "@deck.gl-community/panels": ~9.4.0-alpha.0
     "@deck.gl/core": ~9.4.0
+    "@deck.gl/widgets": ~9.4.0
     "@luma.gl/core": ~9.4.0
     "@luma.gl/webgl": ~9.4.0
     "@luma.gl/webgpu": ~9.4.0


### PR DESCRIPTION
## Summary

- declare @deck.gl/widgets as a required peer of @deck.gl-community/widgets
- export ToastManager alongside the shared toastManager instance
- verify every panels manager class through the public entry point
- document isolated and shared toast manager usage

## Testing

- yarn lint
- targeted panels import suite: 14 passed
- targeted peer-dependency suite: 39 passed
- pre-commit Node suite: 89 files passed, 617 tests passed, 9 skipped