### PR TITLE
feat(three): add Seasonal Farm demo

### DIFF
--- a/docs/modules/three/api-reference/tree-layer.md
+++ b/docs/modules/three/api-reference/tree-layer.md
@@ -21,20 +21,9 @@ new TreeLayer({
 });
 ```
 
-Explore the [full Wild Forest demo](/examples/three/wild-forest), which opens directly
-in Siwa's date-palm grove. Seven regional groves cover all five TreeLayer forms, with
-400 varied trees in each. Choose a region to fly to its centered grove. One local-season
-selector updates foliage, fruit, flowers, and bare branches together. Planted rows and
-irregular woodland clusters contain saplings through veterans, with independently varied
-crown and trunk proportions, bark and foliage tones, branch tiers, vigor, seasonal timing,
-fruit size, and crop load. Hover a tree to inspect its simulated attributes.
-
-Trees retain metre-scale dimensions at every zoom level. Region changes use smooth
-fly-to interpolation, while wheel input and zoom buttons respond immediately and can
-interrupt a flight. Camera motion reuses the tree geometry.
-Positions are representative regional examples, not surveyed tree inventories. Seasons illustrate
-local conditions rather than a simultaneous global date; fruit and flowers are enlarged for visibility.
-Each selected sample links to a source for its regional context.
+Try the [Wild Forest demo](/examples/three/wild-forest) to explore seven regional groves
+with 400 varied trees each. Choose a region and season, then hover a tree to inspect its
+attributes. Tree locations and seasonal traits are illustrative, not surveyed data.
 
 ## Features
 

--- a/docs/modules/three/api-reference/tree-layer.md
+++ b/docs/modules/three/api-reference/tree-layer.md
@@ -21,6 +21,21 @@ new TreeLayer({
 });
 ```
 
+Explore the [full Wild Forest demo](/examples/three/wild-forest), which opens directly
+in Siwa's date-palm grove. Seven regional groves cover all five TreeLayer forms, with
+400 varied trees in each. Choose a region to fly to its centered grove. One local-season
+selector updates foliage, fruit, flowers, and bare branches together. Planted rows and
+irregular woodland clusters contain saplings through veterans, with independently varied
+crown and trunk proportions, bark and foliage tones, branch tiers, vigor, seasonal timing,
+fruit size, and crop load. Hover a tree to inspect its simulated attributes.
+
+Trees retain metre-scale dimensions at every zoom level. Region changes use smooth
+fly-to interpolation, while wheel input and zoom buttons respond immediately and can
+interrupt a flight. Camera motion reuses the tree geometry.
+Positions are representative regional examples, not surveyed tree inventories. Seasons illustrate
+local conditions rather than a simultaneous global date; fruit and flowers are enlarged for visibility.
+Each selected sample links to a source for its regional context.
+
 ## Features
 
 - **5 tree species / silhouettes**: pine (tiered cones), oak (sphere), date palm (ring-scarred trunk and pinnate fronds), birch (narrow oval), cherry (round sphere)

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,5 +1,18 @@
 # What's New
 
+## Unreleased
+
+- [Wild Forest](/examples/three/wild-forest) opens directly in a date-palm grove, with
+  seven regional settings and 400 varied trees per region. All trees retain metre-scale dimensions.
+  Region changes reuse resident tree/crop attributes and cached camera fits during one-second
+  fly-to interpolation; wheel and button zoom remain immediate. Centered
+  3D framing and a compact region/season/zoom bar are shared by the standalone demo and website.
+  Independent maturity, crown and trunk proportions, bark tones, vigor, seasonal timing, and crop
+  load vary across orchard rows and woodland clusters. Seasonal foliage, fruit, flowers, and winter
+  branches update together on a light vector basemap; hover reveals each tree's simulated traits.
+- TreeLayer reuses pine geometry during color, crop, and size changes to avoid rebuilding GPU models.
+  Corrected its Y-up to Z-up conversion so pine tiers point upward and trunks taper toward the canopy.
+
 ## v9.4
 
 Release Date: Sep 7, 2026

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,16 +2,10 @@
 
 ## Unreleased
 
-- [Wild Forest](/examples/three/wild-forest) opens directly in a date-palm grove, with
-  seven regional settings and 400 varied trees per region. All trees retain metre-scale dimensions.
-  Region changes reuse resident tree/crop attributes and cached camera fits during one-second
-  fly-to interpolation; wheel and button zoom remain immediate. Centered
-  3D framing and a compact region/season/zoom bar are shared by the standalone demo and website.
-  Independent maturity, crown and trunk proportions, bark tones, vigor, seasonal timing, and crop
-  load vary across orchard rows and woodland clusters. Seasonal foliage, fruit, flowers, and winter
-  branches update together on a light vector basemap; hover reveals each tree's simulated traits.
-- TreeLayer reuses pine geometry during color, crop, and size changes to avoid rebuilding GPU models.
-  Corrected its Y-up to Z-up conversion so pine tiers point upward and trunks taper toward the canopy.
+- [Wild Forest](/examples/three/wild-forest) adds seven regional groves with seasonal trees,
+  smoother navigation, and simpler controls.
+- [`TreeLayer`](/docs/modules/three/api-reference/tree-layer) fixes tree orientation and
+  reuses pine geometry when attributes change.
 
 ## v9.4
 

--- a/examples/three/wild-forest/README.md
+++ b/examples/three/wild-forest/README.md
@@ -1,20 +1,11 @@
 # Wild Forest
 
-A minimal TreeLayer explorer that opens in Siwa's date-palm grove. Seven regional
-settings contain 400 varied trees each, covering all five procedural forms (palm, oak,
-pine, birch, and cherry): 2,800 trees in total. Orchards use planted rows and working
-lanes; woodland groves have irregular clusters and openings. Trees and grove spacing always use metre-scale dimensions.
+A TreeLayer explorer with seven regional groves of 400 trees each, starting in Siwa's
+date-palm grove. Trees vary in age, size, shape, foliage, and crop load.
 
-Choose a region in the compact selector to fly to its centered grove. Region changes
-use `FlyToInterpolator` with a 1-second animation; reduced-motion preferences apply
-the destination immediately. The flight remains continuous through the globe/map
-projection change. Drag, scroll, pinch, or press +/− to take control immediately.
-The only appearance control is **Local season**; foliage, fruit, flowers, and bare
-branches update together. Each tree has independent maturity, height, crown width,
-trunk thickness and proportion, bark and foliage tones, branch tiers, vigor, seasonal
-timing, crop load, and fruit size. Saplings do not carry crops; blossom, foliage fullness,
-ripening, and fruit drop vary across mature trees. Hover a crown to inspect its simulated
-attributes. Resizing the demo refits the selected grove.
+Choose a region to fly to its grove and a local season to update foliage, fruit, and
+flowers. Drag, scroll, pinch, or use +/− to explore and interrupt flights. With reduced
+motion enabled, region changes are immediate. Hover a tree to inspect its attributes.
 
 ## Run
 
@@ -25,29 +16,20 @@ yarn
 yarn --cwd examples/three/wild-forest start
 ```
 
-The Vite configuration resolves TreeLayer from source without a package build. The same
-mount function powers the documentation and gallery; their graphics backend switcher
-preserves the camera and both selections. The demo explicitly pairs GlobeController with
-a globe viewport and MapController with a local map viewport at the projection handoff.
+TreeLayer loads from source without a package build. The same mount function powers the
+standalone demo, documentation, and gallery. Switching graphics backends preserves the
+camera, region, and season.
 
 ## Data and display scale
 
-The source-linked regional examples in `forest-data.ts` include Siwa date palms,
-São Paulo oranges, Kyoto ornamental cherries, Finnish birch, Alentejo cork oak,
-Riverland almonds, and Yosemite pine. These are representative locations and procedural
-models, not surveyed individual trees, terrain data, or a complete species distribution.
+Regional examples in `forest-data.ts` include Siwa date palms, São Paulo oranges, Kyoto
+ornamental cherries, Finnish birch, Alentejo cork oak, Riverland almonds, and Yosemite
+pine. Each region links to a source. Tree locations and traits are procedural examples,
+not surveyed inventories or a complete species distribution.
 
-Models retain their metre-scale dimensions even while flying between regions or
-zooming out to the globe. Camera motion reuses resident tree and crop geometry, including across projection changes.
-Distant groves are culled from drawing; fitted cameras and crown hit areas are cached.
-Map tile requests wait for 200 ms of settled movement instead of fetching every intermediate
-flight view. Each selected season
-represents the local season of every sample; it is
-not a single date occurring simultaneously in both hemispheres. Phenology is illustrative,
-and fruit and flower markers are enlarged for visibility. Ornamental cherry shows blossom,
-not an edible-cherry harvest.
+Trees retain metre-scale dimensions at every zoom. Seasons illustrate local conditions
+rather than a single date across both hemispheres. Fruit and flowers are enlarged for
+visibility; ornamental cherry shows blossom, not an edible-cherry harvest.
 
-The vector basemap uses CARTO / OpenStreetMap MVT tiles with muted land, water, roads,
-and buildings. Source zoom 14 tiles are overzoomed for close inspection. Network access
-is required; attribution and a map retry action remain available. No API key or location
-permission is needed.
+The CARTO / OpenStreetMap vector basemap requires network access. No API key or location
+permission is needed. A retry action appears if map tiles fail to load.

--- a/examples/three/wild-forest/README.md
+++ b/examples/three/wild-forest/README.md
@@ -1,0 +1,53 @@
+# Wild Forest
+
+A minimal TreeLayer explorer that opens in Siwa's date-palm grove. Seven regional
+settings contain 400 varied trees each, covering all five procedural forms (palm, oak,
+pine, birch, and cherry): 2,800 trees in total. Orchards use planted rows and working
+lanes; woodland groves have irregular clusters and openings. Trees and grove spacing always use metre-scale dimensions.
+
+Choose a region in the compact selector to fly to its centered grove. Region changes
+use `FlyToInterpolator` with a 1-second animation; reduced-motion preferences apply
+the destination immediately. The flight remains continuous through the globe/map
+projection change. Drag, scroll, pinch, or press +/− to take control immediately.
+The only appearance control is **Local season**; foliage, fruit, flowers, and bare
+branches update together. Each tree has independent maturity, height, crown width,
+trunk thickness and proportion, bark and foliage tones, branch tiers, vigor, seasonal
+timing, crop load, and fruit size. Saplings do not carry crops; blossom, foliage fullness,
+ripening, and fruit drop vary across mature trees. Hover a crown to inspect its simulated
+attributes. Resizing the demo refits the selected grove.
+
+## Run
+
+From the repository root:
+
+```sh
+yarn
+yarn --cwd examples/three/wild-forest start
+```
+
+The Vite configuration resolves TreeLayer from source without a package build. The same
+mount function powers the documentation and gallery; their graphics backend switcher
+preserves the camera and both selections. The demo explicitly pairs GlobeController with
+a globe viewport and MapController with a local map viewport at the projection handoff.
+
+## Data and display scale
+
+The source-linked regional examples in `forest-data.ts` include Siwa date palms,
+São Paulo oranges, Kyoto ornamental cherries, Finnish birch, Alentejo cork oak,
+Riverland almonds, and Yosemite pine. These are representative locations and procedural
+models, not surveyed individual trees, terrain data, or a complete species distribution.
+
+Models retain their metre-scale dimensions even while flying between regions or
+zooming out to the globe. Camera motion reuses resident tree and crop geometry, including across projection changes.
+Distant groves are culled from drawing; fitted cameras and crown hit areas are cached.
+Map tile requests wait for 200 ms of settled movement instead of fetching every intermediate
+flight view. Each selected season
+represents the local season of every sample; it is
+not a single date occurring simultaneously in both hemispheres. Phenology is illustrative,
+and fruit and flower markers are enlarged for visibility. Ornamental cherry shows blossom,
+not an edible-cherry harvest.
+
+The vector basemap uses CARTO / OpenStreetMap MVT tiles with muted land, water, roads,
+and buildings. Source zoom 14 tiles are overzoomed for close inspection. Network access
+is required; attribution and a map retry action remain available. No API key or location
+permission is needed.

--- a/examples/three/wild-forest/app.browser.spec.ts
+++ b/examples/three/wild-forest/app.browser.spec.ts
@@ -11,6 +11,8 @@ import {mountWildForestExample} from './app';
 import {getGroveBoundsPoints} from './forest-camera';
 import {createTreeSamples} from './forest-data';
 
+type BrowserGpu = {requestAdapter: () => Promise<unknown>};
+
 // Exercise real vector rendering without depending on the tile provider.
 vi.mock('@deck.gl/geo-layers', async importOriginal => {
   const original = await importOriginal<typeof import('@deck.gl/geo-layers')>();
@@ -43,190 +45,202 @@ vi.mock('@deck.gl/geo-layers', async importOriginal => {
 });
 
 describe('Wild Forest integration', () => {
-  it.each([
+  it.for([
     {type: 'webgl', reducedMotion: false},
     {type: 'webgpu', reducedMotion: false},
     {type: 'webgl', reducedMotion: true}
-  ] as const)('supports grove defaults, interpolated flights, immediate zoom, and remounts on $type (reduced motion: $reducedMotion)', async ({
-    type,
-    reducedMotion
-  }) => {
-    const originalMatchMedia = window.matchMedia.bind(window);
-    const motionPreference = vi.spyOn(window, 'matchMedia').mockImplementation(query => {
-      const result = originalMatchMedia(query);
-      if (query === '(prefers-reduced-motion: reduce)') {
-        Object.defineProperty(result, 'matches', {value: reducedMotion});
-      }
-      return result;
-    });
-    const parent = document.createElement('div');
-    Object.assign(parent.style, {width: '900px', height: '600px'});
-    document.body.append(parent);
-    let device: Device | undefined;
-    let deck: Deck<_GlobeView | MapView>;
-    let view: MapViewState;
-    let cleanup: (() => void) | undefined;
-    const errors: Error[] = [];
-    const frames = vi.fn();
-    const cameraFrames: MapViewState[] = [];
-    const mount = (initialViewState?: MapViewState) =>
-      mountWildForestExample(parent, {
-        device,
-        initialViewState,
-        onViewStateChange(params) {
-          view = params.viewState;
-          cameraFrames.push({...view});
-          return params.viewState;
-        },
-        onDeckInitialized(instance) {
-          deck = instance;
-          deck.setProps({onError: error => errors.push(error), onAfterRender: frames});
+  ] as const)(
+    'supports grove defaults, interpolated flights, immediate zoom, and remounts on $type (reduced motion: $reducedMotion)',
+    {timeout: 60_000},
+    async ({type, reducedMotion}, {skip}) => {
+      if (type === 'webgpu') {
+        const gpu = (navigator as Navigator & {gpu?: BrowserGpu}).gpu;
+        if (!gpu || !(await gpu.requestAdapter())) {
+          skip('This browser does not expose an available WebGPU adapter.');
         }
-      });
-    const click = (selector: string) => parent.querySelector<HTMLButtonElement>(selector)!.click();
-    const root = () => parent.querySelector<HTMLElement>('.forest-explorer')!;
-    try {
-      device = await luma.createDevice({
-        type,
-        adapters: [webgl2Adapter, webgpuAdapter],
-        createCanvasContext: {container: parent}
-      });
-      cleanup = mount();
-      await expect.poll(() => frames.mock.calls.length).toBeGreaterThan(0);
-      expect(deck!.props.device).toBe(device);
-      expect(root().dataset.view).toBe('grove');
-      expect(root().dataset.site).toBe('siwa');
-      expect(root().dataset.flying).toBe('false');
-      expect(parent.querySelectorAll('select')).toHaveLength(2);
-      expect(parent.querySelectorAll('input')).toHaveLength(0);
-      const regions = parent.querySelector<HTMLSelectElement>('[aria-label="Explore a tree"]')!;
-      expect(regions.value).toBe('siwa');
-      expect([...regions.options].every(option => Boolean(option.value))).toBe(true);
-      expect(regions.options).toHaveLength(7);
-      const select = (label: string, value: string) => {
-        const control = parent.querySelector<HTMLSelectElement>(`[aria-label="${label}"]`)!;
-        control.value = value;
-        control.dispatchEvent(new Event('change'));
-      };
-      const treeLayers = () =>
-        (deck!.props.layers as any[]).filter(layer => layer.id.startsWith('forest-trees-'));
-      expect(treeLayers().reduce((count, layer) => count + layer.props.data.length, 0)).toBe(2800);
-      expect(treeLayers().every(layer => layer.props.sizeScale === 1)).toBe(true);
-      expect(treeLayers().every(layer => layer.props.data.length === 400)).toBe(true);
-      const palms = treeLayers().find(layer => layer.id.endsWith('siwa'));
-      const palm = palms.props.data[0];
-      const autumnColor = palms.props.getCanopyColor(palm);
-      const autumnCrop = palms.props.getCrop(palm);
-      expect(autumnCrop.count).toBeGreaterThan(0);
-      const distant = treeLayers().find(layer => layer.id.endsWith('saopaulo'));
-      expect(distant.props.getCrop(distant.props.data[0])?.count).toBeGreaterThan(0);
-      const fittedZoom = deck!.getViewports()[0].zoom;
-      expect(fittedZoom).toBeGreaterThan(15);
-      const localLayers = treeLayers();
-      click('[data-action="zoom-out"]');
-      click('[data-action="zoom-out"]');
-      expect(view!.zoom).toBeCloseTo(fittedZoom - 2);
-      expect(treeLayers()[0]).toBe(localLayers[0]);
-      await expect.poll(() => deck!.getViewports()[0].zoom).toBeCloseTo(view!.zoom);
-      const canvas = parent.querySelector('canvas')!;
-      const wheel = (deltaY: number) => {
-        const rect = canvas.getBoundingClientRect();
-        canvas.dispatchEvent(
-          new WheelEvent('wheel', {
-            bubbles: true,
-            deltaY,
-            clientX: rect.left + rect.width / 2,
-            clientY: rect.top + rect.height / 2
-          })
-        );
-      };
-      const wheelStart = view!.zoom;
-      wheel(-240);
-      await expect.poll(() => view!.zoom, {timeout: 1000}).toBeGreaterThan(wheelStart + 0.8);
-      expect(treeLayers()[0]).toBe(localLayers[0]);
-      select('Local season', 'winter');
-      expect(root().dataset.season).toBe('winter');
-      expect(
-        treeLayers()
-          .find(layer => layer.id.endsWith('siwa'))
-          .props.getCrop(palm)
-      ).toBeNull();
-      expect(autumnColor).toHaveLength(4);
-      expect(
-        treeLayers().find(layer => layer.id.endsWith('kyoto')).props._subLayerProps['canopy-cherry']
-          .visible
-      ).toBe(false);
-      // Citrus uses the cherry-shaped mesh, but keeps its evergreen crown in winter.
-      expect(
-        treeLayers().find(layer => layer.id.endsWith('saopaulo')).props._subLayerProps
-      ).toEqual({});
-      const winterLayers = treeLayers();
-      cameraFrames.length = 0;
-      select('Explore a tree', 'kyoto');
-      expect(root().dataset.site).toBe('kyoto');
-      if (!reducedMotion) {
-        expect(root().dataset.flying).toBe('true');
-        expect(view!.longitude).toBeCloseTo(25.53, 2);
       }
-      await expect.poll(() => root().dataset.flying, {timeout: 6000}).toBe('false');
-      expect(view!.longitude).toBeCloseTo(135.7847, 2);
-      expect(view!.zoom).toBeGreaterThan(15);
-      expect(view!.position![2]).toBeGreaterThan(0);
-      // Crossing globe/map projections must not recreate any grove or its crop attributes.
-      expect(treeLayers().every((layer, index) => layer === winterLayers[index])).toBe(true);
-      expect(treeLayers().every(layer => layer.props.sizeScale === 1)).toBe(true);
-      if (!reducedMotion) {
-        expect(cameraFrames.length).toBeGreaterThan(1);
-        // Native input interrupts a region flight immediately.
-        select('Explore a tree', 'yosemite');
-        wheel(-120);
-        await expect.poll(() => root().dataset.flying).toBe('false');
+
+      const originalMatchMedia = window.matchMedia.bind(window);
+      const motionPreference = vi.spyOn(window, 'matchMedia').mockImplementation(query => {
+        const result = originalMatchMedia(query);
+        if (query === '(prefers-reduced-motion: reduce)') {
+          Object.defineProperty(result, 'matches', {value: reducedMotion});
+        }
+        return result;
+      });
+      const parent = document.createElement('div');
+      Object.assign(parent.style, {width: '900px', height: '600px'});
+      document.body.append(parent);
+      let device: Device | undefined;
+      let deck: Deck<_GlobeView | MapView>;
+      let view: MapViewState;
+      let cleanup: (() => void) | undefined;
+      const errors: Error[] = [];
+      const frames = vi.fn();
+      const cameraFrames: MapViewState[] = [];
+      const mount = (initialViewState?: MapViewState) =>
+        mountWildForestExample(parent, {
+          device,
+          initialViewState,
+          onViewStateChange(params) {
+            view = params.viewState;
+            cameraFrames.push({...view});
+            return params.viewState;
+          },
+          onDeckInitialized(instance) {
+            deck = instance;
+            deck.setProps({onError: error => errors.push(error), onAfterRender: frames});
+          }
+        });
+      const click = (selector: string) =>
+        parent.querySelector<HTMLButtonElement>(selector)!.click();
+      const root = () => parent.querySelector<HTMLElement>('.forest-explorer')!;
+      try {
+        device = await luma.createDevice({
+          type,
+          adapters: [webgl2Adapter, webgpuAdapter],
+          createCanvasContext: {container: parent}
+        });
+        cleanup = mount();
+        await expect.poll(() => frames.mock.calls.length).toBeGreaterThan(0);
+        expect(deck!.props.device).toBe(device);
+        expect(root().dataset.view).toBe('grove');
+        expect(root().dataset.site).toBe('siwa');
+        expect(root().dataset.flying).toBe('false');
+        expect(parent.querySelectorAll('select')).toHaveLength(2);
+        expect(parent.querySelectorAll('input')).toHaveLength(0);
+        const regions = parent.querySelector<HTMLSelectElement>('[aria-label="Explore a tree"]')!;
+        expect(regions.value).toBe('siwa');
+        expect([...regions.options].every(option => Boolean(option.value))).toBe(true);
+        expect(regions.options).toHaveLength(7);
+        const select = (label: string, value: string) => {
+          const control = parent.querySelector<HTMLSelectElement>(`[aria-label="${label}"]`)!;
+          control.value = value;
+          control.dispatchEvent(new Event('change'));
+        };
+        const treeLayers = () =>
+          (deck!.props.layers as any[]).filter(layer => layer.id.startsWith('forest-trees-'));
+        expect(treeLayers().reduce((count, layer) => count + layer.props.data.length, 0)).toBe(
+          2800
+        );
+        expect(treeLayers().every(layer => layer.props.sizeScale === 1)).toBe(true);
+        expect(treeLayers().every(layer => layer.props.data.length === 400)).toBe(true);
+        const palms = treeLayers().find(layer => layer.id.endsWith('siwa'));
+        const palm = palms.props.data[0];
+        const autumnColor = palms.props.getCanopyColor(palm);
+        const autumnCrop = palms.props.getCrop(palm);
+        expect(autumnCrop.count).toBeGreaterThan(0);
+        const distant = treeLayers().find(layer => layer.id.endsWith('saopaulo'));
+        expect(distant.props.getCrop(distant.props.data[0])?.count).toBeGreaterThan(0);
+        const fittedZoom = deck!.getViewports()[0].zoom;
+        expect(fittedZoom).toBeGreaterThan(15);
+        const localLayers = treeLayers();
+        click('[data-action="zoom-out"]');
+        click('[data-action="zoom-out"]');
+        expect(view!.zoom).toBeCloseTo(fittedZoom - 2);
+        expect(treeLayers()[0]).toBe(localLayers[0]);
+        await expect.poll(() => deck!.getViewports()[0].zoom).toBeCloseTo(view!.zoom);
+        const canvas = parent.querySelector('canvas')!;
+        const wheel = (deltaY: number) => {
+          const rect = canvas.getBoundingClientRect();
+          canvas.dispatchEvent(
+            new WheelEvent('wheel', {
+              bubbles: true,
+              deltaY,
+              clientX: rect.left + rect.width / 2,
+              clientY: rect.top + rect.height / 2
+            })
+          );
+        };
+        const wheelStart = view!.zoom;
+        wheel(-240);
+        await expect.poll(() => view!.zoom, {timeout: 1000}).toBeGreaterThan(wheelStart + 0.8);
+        expect(treeLayers()[0]).toBe(localLayers[0]);
+        select('Local season', 'winter');
+        expect(root().dataset.season).toBe('winter');
+        expect(
+          treeLayers()
+            .find(layer => layer.id.endsWith('siwa'))
+            .props.getCrop(palm)
+        ).toBeNull();
+        expect(autumnColor).toHaveLength(4);
+        expect(
+          treeLayers().find(layer => layer.id.endsWith('kyoto')).props._subLayerProps[
+            'canopy-cherry'
+          ].visible
+        ).toBe(false);
+        // Citrus uses the cherry-shaped mesh, but keeps its evergreen crown in winter.
+        expect(
+          treeLayers().find(layer => layer.id.endsWith('saopaulo')).props._subLayerProps
+        ).toEqual({});
+        const winterLayers = treeLayers();
+        cameraFrames.length = 0;
+        select('Explore a tree', 'kyoto');
+        expect(root().dataset.site).toBe('kyoto');
+        if (!reducedMotion) {
+          expect(root().dataset.flying).toBe('true');
+          expect(view!.longitude).toBeCloseTo(25.53, 2);
+        }
+        await expect.poll(() => root().dataset.flying, {timeout: 6000}).toBe('false');
+        expect(view!.longitude).toBeCloseTo(135.7847, 2);
+        expect(view!.zoom).toBeGreaterThan(15);
+        expect(view!.position![2]).toBeGreaterThan(0);
+        // Crossing globe/map projections must not recreate any grove or its crop attributes.
+        expect(treeLayers().every((layer, index) => layer === winterLayers[index])).toBe(true);
+        expect(treeLayers().every(layer => layer.props.sizeScale === 1)).toBe(true);
+        if (!reducedMotion) {
+          expect(cameraFrames.length).toBeGreaterThan(1);
+          // Native input interrupts a region flight immediately.
+          select('Explore a tree', 'yosemite');
+          wheel(-120);
+          await expect.poll(() => root().dataset.flying).toBe('false');
+          select('Explore a tree', 'kyoto');
+          await expect.poll(() => root().dataset.flying, {timeout: 6000}).toBe('false');
+          expect(view!.longitude).toBeCloseTo(135.7847, 2);
+        }
+        // A newer selection replaces a pending destination without rebuilding any grove.
+        select('Explore a tree', 'riverland');
+        select('Explore a tree', 'alentejo');
         select('Explore a tree', 'kyoto');
         await expect.poll(() => root().dataset.flying, {timeout: 6000}).toBe('false');
         expect(view!.longitude).toBeCloseTo(135.7847, 2);
+        expect(treeLayers().every((layer, index) => layer === winterLayers[index])).toBe(true);
+        const savedView = {...view!};
+        cleanup();
+        cleanup = mount(savedView);
+        await expect.poll(() => deck!.isInitialized).toBe(true);
+        expect(root().dataset.site).toBe('kyoto');
+        expect(root().dataset.season).toBe('winter');
+        expect(parent.querySelector<HTMLSelectElement>('[aria-label="Local season"]')!.value).toBe(
+          'winter'
+        );
+        Object.assign(parent.style, {width: '390px', height: '740px'});
+        await expect.poll(() => deck!.getViewports()[0].width, {timeout: 5000}).toBe(390);
+        const points = getGroveBoundsPoints(
+          createTreeSamples().filter(tree => tree.siteId === 'kyoto')
+        );
+        await expect
+          .poll(() => {
+            const viewport = deck!.getViewports()[0];
+            return points.every(point => {
+              const [x, y] = viewport.project(point);
+              return x >= 23 && x <= 367 && y >= 119 && y <= 651;
+            });
+          })
+          .toBe(true);
+        expect(errors).toEqual([]);
+        select('Explore a tree', 'yosemite');
+        cleanup();
+        cleanup = undefined;
+        const callbacksAtCleanup = cameraFrames.length;
+        await new Promise(resolve => setTimeout(resolve, 100));
+        expect(cameraFrames).toHaveLength(callbacksAtCleanup);
+      } finally {
+        cleanup?.();
+        device?.destroy();
+        parent.remove();
+        motionPreference.mockRestore();
       }
-      // A newer selection replaces a pending destination without rebuilding any grove.
-      select('Explore a tree', 'riverland');
-      select('Explore a tree', 'alentejo');
-      select('Explore a tree', 'kyoto');
-      await expect.poll(() => root().dataset.flying, {timeout: 6000}).toBe('false');
-      expect(view!.longitude).toBeCloseTo(135.7847, 2);
-      expect(treeLayers().every((layer, index) => layer === winterLayers[index])).toBe(true);
-      const savedView = {...view!};
-      cleanup();
-      cleanup = mount(savedView);
-      await expect.poll(() => deck!.isInitialized).toBe(true);
-      expect(root().dataset.site).toBe('kyoto');
-      expect(root().dataset.season).toBe('winter');
-      expect(parent.querySelector<HTMLSelectElement>('[aria-label="Local season"]')!.value).toBe(
-        'winter'
-      );
-      Object.assign(parent.style, {width: '390px', height: '740px'});
-      await expect.poll(() => deck!.getViewports()[0].width, {timeout: 5000}).toBe(390);
-      const points = getGroveBoundsPoints(
-        createTreeSamples().filter(tree => tree.siteId === 'kyoto')
-      );
-      await expect
-        .poll(() => {
-          const viewport = deck!.getViewports()[0];
-          return points.every(point => {
-            const [x, y] = viewport.project(point);
-            return x >= 23 && x <= 367 && y >= 119 && y <= 651;
-          });
-        })
-        .toBe(true);
-      expect(errors).toEqual([]);
-      select('Explore a tree', 'yosemite');
-      cleanup();
-      cleanup = undefined;
-      const callbacksAtCleanup = cameraFrames.length;
-      await new Promise(resolve => setTimeout(resolve, 100));
-      expect(cameraFrames).toHaveLength(callbacksAtCleanup);
-    } finally {
-      cleanup?.();
-      device?.destroy();
-      parent.remove();
-      motionPreference.mockRestore();
     }
-  }, 60_000);
+  );
 });

--- a/examples/three/wild-forest/app.browser.spec.ts
+++ b/examples/three/wild-forest/app.browser.spec.ts
@@ -1,0 +1,232 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Deck, type _GlobeView, type MapView, type MapViewState} from '@deck.gl/core';
+import {luma, type Device} from '@luma.gl/core';
+import {webgl2Adapter} from '@luma.gl/webgl';
+import {webgpuAdapter} from '@luma.gl/webgpu';
+import {describe, expect, it, vi} from 'vitest';
+import {mountWildForestExample} from './app';
+import {getGroveBoundsPoints} from './forest-camera';
+import {createTreeSamples} from './forest-data';
+
+// Exercise real vector rendering without depending on the tile provider.
+vi.mock('@deck.gl/geo-layers', async importOriginal => {
+  const original = await importOriginal<typeof import('@deck.gl/geo-layers')>();
+  return {
+    ...original,
+    TileLayer: class extends original.TileLayer {
+      getTileData() {
+        // Geographic coordinates remain valid through the globe/map handoff.
+        return Promise.resolve([
+          {
+            type: 'Feature' as const,
+            properties: {layerName: 'landcover'},
+            geometry: {
+              type: 'Polygon' as const,
+              coordinates: [
+                [
+                  [-1, 38],
+                  [0, 38],
+                  [0, 39],
+                  [-1, 39],
+                  [-1, 38]
+                ]
+              ]
+            }
+          }
+        ]);
+      }
+    }
+  };
+});
+
+describe('Wild Forest integration', () => {
+  it.each([
+    {type: 'webgl', reducedMotion: false},
+    {type: 'webgpu', reducedMotion: false},
+    {type: 'webgl', reducedMotion: true}
+  ] as const)('supports grove defaults, interpolated flights, immediate zoom, and remounts on $type (reduced motion: $reducedMotion)', async ({
+    type,
+    reducedMotion
+  }) => {
+    const originalMatchMedia = window.matchMedia.bind(window);
+    const motionPreference = vi.spyOn(window, 'matchMedia').mockImplementation(query => {
+      const result = originalMatchMedia(query);
+      if (query === '(prefers-reduced-motion: reduce)') {
+        Object.defineProperty(result, 'matches', {value: reducedMotion});
+      }
+      return result;
+    });
+    const parent = document.createElement('div');
+    Object.assign(parent.style, {width: '900px', height: '600px'});
+    document.body.append(parent);
+    let device: Device | undefined;
+    let deck: Deck<_GlobeView | MapView>;
+    let view: MapViewState;
+    let cleanup: (() => void) | undefined;
+    const errors: Error[] = [];
+    const frames = vi.fn();
+    const cameraFrames: MapViewState[] = [];
+    const mount = (initialViewState?: MapViewState) =>
+      mountWildForestExample(parent, {
+        device,
+        initialViewState,
+        onViewStateChange(params) {
+          view = params.viewState;
+          cameraFrames.push({...view});
+          return params.viewState;
+        },
+        onDeckInitialized(instance) {
+          deck = instance;
+          deck.setProps({onError: error => errors.push(error), onAfterRender: frames});
+        }
+      });
+    const click = (selector: string) => parent.querySelector<HTMLButtonElement>(selector)!.click();
+    const root = () => parent.querySelector<HTMLElement>('.forest-explorer')!;
+    try {
+      device = await luma.createDevice({
+        type,
+        adapters: [webgl2Adapter, webgpuAdapter],
+        createCanvasContext: {container: parent}
+      });
+      cleanup = mount();
+      await expect.poll(() => frames.mock.calls.length).toBeGreaterThan(0);
+      expect(deck!.props.device).toBe(device);
+      expect(root().dataset.view).toBe('grove');
+      expect(root().dataset.site).toBe('siwa');
+      expect(root().dataset.flying).toBe('false');
+      expect(parent.querySelectorAll('select')).toHaveLength(2);
+      expect(parent.querySelectorAll('input')).toHaveLength(0);
+      const regions = parent.querySelector<HTMLSelectElement>('[aria-label="Explore a tree"]')!;
+      expect(regions.value).toBe('siwa');
+      expect([...regions.options].every(option => Boolean(option.value))).toBe(true);
+      expect(regions.options).toHaveLength(7);
+      const select = (label: string, value: string) => {
+        const control = parent.querySelector<HTMLSelectElement>(`[aria-label="${label}"]`)!;
+        control.value = value;
+        control.dispatchEvent(new Event('change'));
+      };
+      const treeLayers = () =>
+        (deck!.props.layers as any[]).filter(layer => layer.id.startsWith('forest-trees-'));
+      expect(treeLayers().reduce((count, layer) => count + layer.props.data.length, 0)).toBe(2800);
+      expect(treeLayers().every(layer => layer.props.sizeScale === 1)).toBe(true);
+      expect(treeLayers().every(layer => layer.props.data.length === 400)).toBe(true);
+      const palms = treeLayers().find(layer => layer.id.endsWith('siwa'));
+      const palm = palms.props.data[0];
+      const autumnColor = palms.props.getCanopyColor(palm);
+      const autumnCrop = palms.props.getCrop(palm);
+      expect(autumnCrop.count).toBeGreaterThan(0);
+      const distant = treeLayers().find(layer => layer.id.endsWith('saopaulo'));
+      expect(distant.props.getCrop(distant.props.data[0])?.count).toBeGreaterThan(0);
+      const fittedZoom = deck!.getViewports()[0].zoom;
+      expect(fittedZoom).toBeGreaterThan(15);
+      const localLayers = treeLayers();
+      click('[data-action="zoom-out"]');
+      click('[data-action="zoom-out"]');
+      expect(view!.zoom).toBeCloseTo(fittedZoom - 2);
+      expect(treeLayers()[0]).toBe(localLayers[0]);
+      await expect.poll(() => deck!.getViewports()[0].zoom).toBeCloseTo(view!.zoom);
+      const canvas = parent.querySelector('canvas')!;
+      const wheel = (deltaY: number) => {
+        const rect = canvas.getBoundingClientRect();
+        canvas.dispatchEvent(
+          new WheelEvent('wheel', {
+            bubbles: true,
+            deltaY,
+            clientX: rect.left + rect.width / 2,
+            clientY: rect.top + rect.height / 2
+          })
+        );
+      };
+      const wheelStart = view!.zoom;
+      wheel(-240);
+      await expect.poll(() => view!.zoom, {timeout: 1000}).toBeGreaterThan(wheelStart + 0.8);
+      expect(treeLayers()[0]).toBe(localLayers[0]);
+      select('Local season', 'winter');
+      expect(root().dataset.season).toBe('winter');
+      expect(
+        treeLayers()
+          .find(layer => layer.id.endsWith('siwa'))
+          .props.getCrop(palm)
+      ).toBeNull();
+      expect(autumnColor).toHaveLength(4);
+      expect(
+        treeLayers().find(layer => layer.id.endsWith('kyoto')).props._subLayerProps['canopy-cherry']
+          .visible
+      ).toBe(false);
+      // Citrus uses the cherry-shaped mesh, but keeps its evergreen crown in winter.
+      expect(
+        treeLayers().find(layer => layer.id.endsWith('saopaulo')).props._subLayerProps
+      ).toEqual({});
+      const winterLayers = treeLayers();
+      cameraFrames.length = 0;
+      select('Explore a tree', 'kyoto');
+      expect(root().dataset.site).toBe('kyoto');
+      if (!reducedMotion) {
+        expect(root().dataset.flying).toBe('true');
+        expect(view!.longitude).toBeCloseTo(25.53, 2);
+      }
+      await expect.poll(() => root().dataset.flying, {timeout: 6000}).toBe('false');
+      expect(view!.longitude).toBeCloseTo(135.7847, 2);
+      expect(view!.zoom).toBeGreaterThan(15);
+      expect(view!.position![2]).toBeGreaterThan(0);
+      // Crossing globe/map projections must not recreate any grove or its crop attributes.
+      expect(treeLayers().every((layer, index) => layer === winterLayers[index])).toBe(true);
+      expect(treeLayers().every(layer => layer.props.sizeScale === 1)).toBe(true);
+      if (!reducedMotion) {
+        expect(cameraFrames.length).toBeGreaterThan(1);
+        // Native input interrupts a region flight immediately.
+        select('Explore a tree', 'yosemite');
+        wheel(-120);
+        await expect.poll(() => root().dataset.flying).toBe('false');
+        select('Explore a tree', 'kyoto');
+        await expect.poll(() => root().dataset.flying, {timeout: 6000}).toBe('false');
+        expect(view!.longitude).toBeCloseTo(135.7847, 2);
+      }
+      // A newer selection replaces a pending destination without rebuilding any grove.
+      select('Explore a tree', 'riverland');
+      select('Explore a tree', 'alentejo');
+      select('Explore a tree', 'kyoto');
+      await expect.poll(() => root().dataset.flying, {timeout: 6000}).toBe('false');
+      expect(view!.longitude).toBeCloseTo(135.7847, 2);
+      expect(treeLayers().every((layer, index) => layer === winterLayers[index])).toBe(true);
+      const savedView = {...view!};
+      cleanup();
+      cleanup = mount(savedView);
+      await expect.poll(() => deck!.isInitialized).toBe(true);
+      expect(root().dataset.site).toBe('kyoto');
+      expect(root().dataset.season).toBe('winter');
+      expect(parent.querySelector<HTMLSelectElement>('[aria-label="Local season"]')!.value).toBe(
+        'winter'
+      );
+      Object.assign(parent.style, {width: '390px', height: '740px'});
+      await expect.poll(() => deck!.getViewports()[0].width, {timeout: 5000}).toBe(390);
+      const points = getGroveBoundsPoints(
+        createTreeSamples().filter(tree => tree.siteId === 'kyoto')
+      );
+      await expect
+        .poll(() => {
+          const viewport = deck!.getViewports()[0];
+          return points.every(point => {
+            const [x, y] = viewport.project(point);
+            return x >= 23 && x <= 367 && y >= 119 && y <= 651;
+          });
+        })
+        .toBe(true);
+      expect(errors).toEqual([]);
+      select('Explore a tree', 'yosemite');
+      cleanup();
+      cleanup = undefined;
+      const callbacksAtCleanup = cameraFrames.length;
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(cameraFrames).toHaveLength(callbacksAtCleanup);
+    } finally {
+      cleanup?.();
+      device?.destroy();
+      parent.remove();
+      motionPreference.mockRestore();
+    }
+  }, 60_000);
+});

--- a/examples/three/wild-forest/app.tsx
+++ b/examples/three/wild-forest/app.tsx
@@ -2,469 +2,427 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Deck, type MapViewState} from '@deck.gl/core';
-import {TreeLayer} from '@deck.gl-community/three';
-import type {CropConfig, Season, TreeType} from '@deck.gl-community/three';
 import {
-  ColumnPanel,
-  CustomPanel,
-  MarkdownPanel,
-  SettingsPanel,
-  type SettingsSchema,
-  type SettingsState
-} from '@deck.gl-community/panels';
-import {BoxPanelWidget} from '@deck.gl-community/widgets';
+  Deck,
+  _GlobeView,
+  _GlobeViewport,
+  MapView,
+  type MapViewState,
+  type PickingInfo,
+  type ViewStateChangeParameters,
+  type Widget
+} from '@deck.gl/core';
+import {LineLayer, SolidPolygonLayer} from '@deck.gl/layers';
+import type {Device} from '@luma.gl/core';
+import {TreeLayer, type Season} from '@deck.gl-community/three';
+import {
+  FOREST_SITES,
+  SEASONS,
+  TREES_PER_SITE,
+  createTreeSamples,
+  getFoliageColor,
+  getBarkColor,
+  getSeasonalCanopyRadius,
+  getSeasonalCrop,
+  getSeasonDescription,
+  createWinterBranches,
+  type ForestTree
+} from './forest-data';
+import {createForestBasemap} from './forest-basemap';
+import {getGroveView, pickTreeAtPixel, createGroveFlight} from './forest-camera';
+import './style.css';
 
-import '@deck.gl/widgets/stylesheet.css';
-
-type TreeDatum = {
-  position: [number, number];
-  type: TreeType;
-  height: number;
-  trunkRadius: number;
-  canopyRadius: number;
-  trunkHeightFraction: number;
-  season: Season;
-  branchLevels: number;
-  label: string;
-  crop: CropConfig | null;
-};
-
-type WildForestSettings = {
-  render: {
-    sizeScale: number;
-    showCrops: boolean;
-  };
-};
-
-type WildForestState = {
-  settings: WildForestSettings;
-};
-
-type WildForestExampleOptions = {
+export type WildForestExampleOptions = {
   showControlsWidget?: boolean;
+  /** Reuse the website's selected graphics device. */
+  device?: Device;
+  widgets?: Widget[];
+  /** Restore the camera after a graphics backend switch. */
+  initialViewState?: MapViewState;
+  onViewStateChange?: <ViewStateT extends MapViewState>(
+    params: ViewStateChangeParameters<ViewStateT>
+  ) => ViewStateT;
+  onDeckInitialized?: (deck: Deck<_GlobeView | MapView>) => void;
 };
 
-type ZoneInfo = {
-  label: string;
-  color: string;
-};
-
-const INITIAL_VIEW_STATE: MapViewState = {
-  longitude: -0.022,
-  latitude: 51.503,
-  zoom: 13,
-  pitch: 62,
-  bearing: 20
-};
-
-const ROOT_STYLE = {
-  position: 'relative',
-  width: '100%',
-  height: '100%',
-  minHeight: '100%'
-} as const;
-
-const INITIAL_SETTINGS: WildForestSettings = {
-  render: {
-    sizeScale: 30,
-    showCrops: true
+// Keep projection and controller paired through the handoff. GlobeView's implicit
+// Mercator switch otherwise leaves GlobeController handling a flat viewport.
+class ForestGlobeView extends _GlobeView {
+  getViewportType() {
+    return _GlobeViewport;
   }
-};
+}
 
-const SETTINGS_SCHEMA: SettingsSchema = {
-  title: 'Wild Forest Controls',
-  sections: [
-    {
-      id: 'render',
-      name: 'Render',
-      initiallyCollapsed: false,
-      settings: [
-        {
-          name: 'render.sizeScale',
-          label: 'Size Scale',
-          type: 'number',
-          min: 5,
-          max: 80,
-          step: 1,
-          description: 'Scales tree geometry uniformly.'
-        },
-        {
-          name: 'render.showCrops',
-          label: 'Show Crops',
-          type: 'boolean',
-          description: 'Toggle blossoms, oranges, and almonds.'
-        }
-      ]
-    }
+type ExplorerState = {siteId: string; season: Season};
+const SAMPLES = createTreeSamples();
+const GROVES = FOREST_SITES.map(site => ({
+  site,
+  trees: SAMPLES.filter(tree => tree.siteId === site.id)
+}));
+const DEFAULT_SITE_ID = 'siwa';
+const FLIGHT_DURATION = 1000;
+// Preserve the two selectors when the website remounts for a graphics backend switch.
+const HOST_STATE = new WeakMap<HTMLElement, ExplorerState>();
+const VIEW_LIMITS: Partial<MapViewState> = {minZoom: -1, maxZoom: 21, maxPitch: 75};
+const WORLD_POLYGON = [
+  [
+    [-180, 90],
+    [0, 90],
+    [180, 90],
+    [180, -90],
+    [0, -90],
+    [-180, -90]
   ]
-};
-
-const ZONES: ZoneInfo[] = [
-  {label: 'Pine Forest (Summer)', color: '#006400'},
-  {label: 'Oak Grove (Autumn)', color: '#b45314'},
-  {label: 'Cherry Blossom (Spring)', color: '#ffb4c8'},
-  {label: 'Palm Grove (Summer)', color: '#14911e'},
-  {label: 'Birch Glade (Autumn)', color: '#e6b928'},
-  {label: 'Oak Silhouettes (Winter)', color: 'rgba(100,80,80,0.4)'},
-  {label: 'Birch Grove (Spring)', color: '#96d26e'},
-  {label: 'Citrus Orchard (Fruiting)', color: '#ff8c00'},
-  {label: 'Almond Grove (Harvest)', color: '#c39b5a'}
 ];
 
-const FOREST_DATA = generateForest();
+// Keep the depth-occluding globe just below tile geometry. Coincident tessellations
+// otherwise produce white seams over the open ocean near the antimeridian.
+const GLOBE_BACKGROUND = WORLD_POLYGON.map(polygon =>
+  polygon.map(([lng, lat]) => [lng, lat, -20000])
+);
 
+/** Mount a grove explorer that starts in Siwa with metre-scale trees. */
 export function mountWildForestExample(
   container: HTMLElement,
   options: WildForestExampleOptions = {}
 ): () => void {
-  const rootElement = container.ownerDocument.createElement('div');
-  applyElementStyle(rootElement, ROOT_STYLE);
-  container.replaceChildren(rootElement);
-
-  const state: WildForestState = {
-    settings: cloneSettings(INITIAL_SETTINGS)
-  };
-
-  const controlsWidget =
-    options.showControlsWidget === false
-      ? null
-      : new BoxPanelWidget({
-          id: 'wild-forest-controls',
-          placement: 'top-right',
-          widthPx: 320,
-          title: 'Wild Forest + Orchards',
-          panel: buildControlPanel(state, handleSettingsChange)
-        });
-
+  const doc = container.ownerDocument;
+  const root = doc.createElement('div');
+  root.className = 'forest-explorer';
+  root.dataset.flying = 'false';
+  root.dataset.managedDevice = String(Boolean(options.device));
+  const canvasHost = doc.createElement('div');
+  canvasHost.className = 'forest-canvas';
+  root.append(canvasHost);
+  container.replaceChildren(root);
+  const savedState = HOST_STATE.get(container);
+  const state: ExplorerState = {...(savedState ?? {siteId: DEFAULT_SITE_ID, season: 'autumn'})};
+  if (!FOREST_SITES.some(site => site.id === state.siteId)) state.siteId = DEFAULT_SITE_ID;
+  let currentView =
+    savedState && options.initialViewState ? options.initialViewState : getSelectedView();
+  let flightFrame: number | null = null;
+  const reducedMotion = doc.defaultView?.matchMedia?.('(prefers-reduced-motion: reduce)');
+  let disposed = false;
+  let mapRevision = 0;
+  let mapFailed = false;
+  let mapLoaded = false;
+  const ui = createControls(root, options.showControlsWidget !== false);
+  let basemap = createBasemap();
+  let globeProjection = currentView.zoom <= 12;
+  // Keep every grove's GPU attributes resident across region and projection changes.
+  // Only a season change needs to regenerate foliage, fruit, or winter branches.
+  let groveLayers = createGroveLayers();
   const deck = new Deck({
-    parent: rootElement,
-    initialViewState: INITIAL_VIEW_STATE,
-    controller: {
-      maxPitch: 80
+    parent: canvasHost,
+    device: options.device,
+    views: createView(),
+    initialViewState: {...currentView, ...VIEW_LIMITS},
+    controller: {touchRotate: true, inertia: 100, scrollZoom: {smooth: false, speed: 0.025}},
+    useDevicePixels: Math.min(2, doc.defaultView?.devicePixelRatio || 1),
+    widgets: options.widgets ?? [],
+    pickingRadius: 8,
+    layers: buildLayers(),
+    layerFilter({layer, viewport}) {
+      const grove = GROVES.find(
+        ({site}) =>
+          layer.id.startsWith(`forest-trees-${site.id}`) || layer.id === `forest-winter-${site.id}`
+      );
+      if (!grove) return true;
+      if (viewport.zoom < 13) return false;
+      const lngDelta = ((grove.site.position[0] - currentView.longitude + 540) % 360) - 180;
+      return Math.abs(lngDelta) < 1 && Math.abs(grove.site.position[1] - currentView.latitude) < 1;
     },
-    layers: buildLayers(state),
-    parameters: {clearColor: [0.06, 0.1, 0.06, 1]},
-    getTooltip: getTooltip,
-    widgets: controlsWidget ? [controlsWidget] : []
+    onViewStateChange(params) {
+      // Ignore trailing controller callbacks while the flight owns the camera.
+      // New native input cancels the flight in the capture listeners below.
+      if (flightFrame !== null) return currentView as typeof params.viewState;
+      const viewState = options.onViewStateChange?.(params) ?? params.viewState;
+      currentView = viewState as MapViewState;
+      // Camera motion only changes the viewport, not tree data or mesh attributes.
+      if (globeProjection !== currentView.zoom <= 12) {
+        globeProjection = currentView.zoom <= 12;
+        deck.setProps({
+          views: createView(),
+          initialViewState: {...currentView, ...VIEW_LIMITS, transitionDuration: 0},
+          layers: buildLayers()
+        });
+      }
+      updateControls();
+      return viewState;
+    },
+    getTooltip(info: PickingInfo<ForestTree>) {
+      const tree = getTreeAtPointer(info);
+      if (!tree) return null;
+      const site = FOREST_SITES.find(item => item.id === tree.siteId)!;
+      const crop = getSeasonalCrop(tree, state.season);
+      const stage = tree.maturity[0].toUpperCase() + tree.maturity.slice(1);
+      const structure =
+        tree.species === 'pine'
+          ? `${tree.branchLevels} branch tiers`
+          : `${Math.round((getSeasonalCanopyRadius(tree, state.season) / tree.canopyRadius) * 100)}% crown fullness`;
+      const yieldText = crop
+        ? `${crop.count} fruit / flower markers · ${crop.droppedCount} fallen`
+        : 'Resting crop';
+      return {
+        text: `${tree.label} · ${stage}\n${tree.height.toFixed(1)} m high · ${(tree.trunkRadius * 2).toFixed(2)} m trunk\n${Math.round(tree.vigor * 100)}% vigour · ${structure}\n${yieldText}\nSimulated tree · ${site.name}`
+      };
+    },
+    onClick(info: PickingInfo<ForestTree>) {
+      const tree = getTreeAtPointer(info);
+      if (tree) focusTree(tree.siteId);
+    }
   });
-
+  options.onDeckInitialized?.(deck);
+  const interactionEvents = ['pointerdown', 'wheel', 'keydown'] as const;
+  const onUserInput = (event: Event) => {
+    const target = event.target as Node | null;
+    // A website-owned device may keep its canvas outside the mounting container.
+    if (target && (container.contains(target) || target === deck.getCanvas())) stopFlight();
+  };
+  for (const event of interactionEvents) {
+    doc.addEventListener(event, onUserInput, {capture: true, passive: true});
+  }
+  updateControls();
+  ui.treeSelect.onchange = () => focusTree(ui.treeSelect.value);
+  ui.seasonSelect.onchange = () => {
+    state.season = ui.seasonSelect.value as Season;
+    groveLayers = createGroveLayers();
+    updateScene();
+  };
+  ui.zoomIn.onclick = () => zoomBy(1);
+  ui.zoomOut.onclick = () => zoomBy(-1);
+  ui.retry.onclick = () => {
+    mapFailed = false;
+    mapLoaded = false;
+    mapRevision++;
+    basemap = createBasemap();
+    updateScene();
+  };
+  let previousSize = [container.clientWidth, container.clientHeight];
+  const resizeObserver = new ResizeObserver(() => {
+    const size = [container.clientWidth, container.clientHeight];
+    if (size[0] && size[1] && size.some((value, index) => value !== previousSize[index])) {
+      previousSize = size;
+      focusTree(state.siteId, false);
+    }
+  });
+  resizeObserver.observe(container);
   return () => {
+    disposed = true;
+    stopFlight();
+    for (const event of interactionEvents) doc.removeEventListener(event, onUserInput, true);
+    resizeObserver.disconnect();
+    HOST_STATE.set(container, {...state});
     deck.finalize();
-    rootElement.remove();
-    container.replaceChildren();
+    root.remove();
   };
 
-  function handleSettingsChange(nextSettings: SettingsState) {
-    state.settings = cloneSettings(nextSettings as WildForestSettings);
-    deck.setProps({layers: buildLayers(state)});
-    controlsWidget?.setProps({
-      panel: buildControlPanel(state, handleSettingsChange)
+  function createView() {
+    // Distinct IDs also dispose the outgoing controller and its event listeners.
+    return globeProjection
+      ? new ForestGlobeView({id: 'forest-globe', resolution: 5})
+      : new MapView({id: 'forest-map'});
+  }
+  function getSelectedView(): MapViewState {
+    return getGroveView(
+      GROVES.find(grove => grove.site.id === state.siteId)!.trees,
+      container.clientWidth || 900,
+      container.clientHeight || 600
+    );
+  }
+  function zoomBy(delta: number) {
+    stopFlight();
+    const zoom = Math.max(-1, Math.min(21, currentView.zoom + delta));
+    setView({...currentView, zoom});
+  }
+  function stopFlight() {
+    if (flightFrame !== null) doc.defaultView!.cancelAnimationFrame(flightFrame);
+    flightFrame = null;
+    root.dataset.flying = 'false';
+  }
+  function flyTo(view: MapViewState) {
+    stopFlight();
+    if (reducedMotion?.matches) {
+      setView(view);
+      return;
+    }
+    const interpolate = createGroveFlight(
+      currentView,
+      view,
+      container.clientWidth || 900,
+      container.clientHeight || 600
+    );
+    let startedAt: number | null = null;
+    root.dataset.flying = 'true';
+    // Own the flight clock so crossing the globe/map boundary cannot cancel the flight
+    // when the matching viewport and controller are replaced.
+    const frame = (now: number) => {
+      // Start on the first available frame rather than consuming the flight during setup.
+      startedAt ??= now;
+      const progress = Math.min(1, (now - startedAt) / FLIGHT_DURATION);
+      const eased = progress * progress * (3 - 2 * progress);
+      setView(interpolate(eased));
+      if (progress < 1) {
+        flightFrame = doc.defaultView!.requestAnimationFrame(frame);
+      } else {
+        flightFrame = null;
+        root.dataset.flying = 'false';
+      }
+    };
+    flightFrame = doc.defaultView!.requestAnimationFrame(frame);
+  }
+  function setView(view: MapViewState) {
+    // Apply each camera frame directly; wheel input never waits behind a transition.
+    currentView =
+      options.onViewStateChange?.({
+        viewId: view.zoom <= 12 ? 'forest-globe' : 'forest-map',
+        viewState: view,
+        oldViewState: currentView,
+        interactionState: {}
+      }) ?? view;
+    const projectionChanged = globeProjection !== currentView.zoom <= 12;
+    globeProjection = currentView.zoom <= 12;
+    deck.setProps({
+      initialViewState: {...currentView, ...VIEW_LIMITS, transitionDuration: 0},
+      ...(projectionChanged ? {views: createView(), layers: buildLayers()} : {})
+    });
+    updateControls();
+  }
+  function focusTree(siteId: string, animate = true) {
+    if (!FOREST_SITES.some(site => site.id === siteId)) return;
+    state.siteId = siteId;
+    HOST_STATE.set(container, {...state});
+    if (animate) {
+      flyTo(getSelectedView());
+    } else {
+      stopFlight();
+      setView(getSelectedView());
+    }
+    updateControls();
+  }
+  function updateScene() {
+    HOST_STATE.set(container, {...state});
+    deck.setProps({layers: buildLayers()});
+    updateControls();
+  }
+  function updateControls() {
+    if (disposed) return;
+    const site = FOREST_SITES.find(item => item.id === state.siteId)!;
+    root.dataset.site = state.siteId;
+    root.dataset.season = state.season;
+    root.dataset.view = currentView.zoom <= 12 ? 'globe' : 'grove';
+    ui.treeSelect.value = state.siteId;
+    ui.seasonSelect.value = state.season;
+    ui.heading.textContent = `${site.name}, ${site.country}`;
+    ui.caption.textContent = `${TREES_PER_SITE} trees · ${getSeasonDescription(site, state.season)}`;
+    ui.source.hidden = false;
+    ui.source.href = site.source;
+    ui.scaleNote.textContent = 'Illustrative tree locations';
+    ui.zoomIn.disabled = currentView.zoom >= 21;
+    ui.zoomOut.disabled = currentView.zoom <= -1;
+    ui.status.textContent = mapFailed ? 'Map unavailable' : mapLoaded ? '' : 'Loading map…';
+    ui.retry.hidden = !mapFailed;
+  }
+  function createBasemap() {
+    return createForestBasemap({
+      id: `forest-vector-${mapRevision}`,
+      onLoad() {
+        mapLoaded = true;
+        updateControls();
+      },
+      onError() {
+        mapFailed = true;
+        updateControls();
+      }
     });
   }
-}
-
-function buildLayers(state: WildForestState) {
-  return [
-    new TreeLayer<TreeDatum>({
-      id: 'wild-forest',
-      data: FOREST_DATA,
-      getPosition: datum => datum.position,
-      getTreeType: datum => datum.type,
-      getHeight: datum => datum.height,
-      getTrunkRadius: datum => datum.trunkRadius,
-      getCanopyRadius: datum => datum.canopyRadius,
-      getTrunkHeightFraction: datum => datum.trunkHeightFraction,
-      getSeason: datum => datum.season,
-      getBranchLevels: datum => datum.branchLevels || 3,
-      getCrop: state.settings.render.showCrops ? datum => datum.crop : () => null,
-      sizeScale: state.settings.render.sizeScale,
-      pickable: true,
-      updateTriggers: {
-        getCrop: [state.settings.render.showCrops],
-        sizeScale: [state.settings.render.sizeScale]
-      }
-    })
-  ];
-}
-
-function buildControlPanel(
-  state: WildForestState,
-  onSettingsChange: (nextSettings: SettingsState) => void
-) {
-  return new ColumnPanel({
-    id: 'wild-forest-panel',
-    title: 'Wild Forest + Orchards',
-    panels: [
-      new MarkdownPanel({
-        id: 'summary',
-        title: '',
-        markdown: [
-          'A procedural forest scene rendered with `TreeLayer`.',
-          '',
-          `- Trees: **${FOREST_DATA.length}**`,
-          `- Size scale: **${state.settings.render.sizeScale.toFixed(1)}x**`,
-          `- Crops: **${state.settings.render.showCrops ? 'visible' : 'hidden'}**`
-        ].join('\n')
+  function getTreeAtPointer({x, y}: PickingInfo<ForestTree>) {
+    if (flightFrame !== null) return undefined;
+    return pickTreeAtPixel(SAMPLES, deck.getViewports()[0], currentView, x, y);
+  }
+  function buildLayers() {
+    return [
+      new SolidPolygonLayer({
+        id: 'forest-earth',
+        data: globeProjection ? GLOBE_BACKGROUND : WORLD_POLYGON,
+        getPolygon: polygon => polygon,
+        getFillColor: [247, 247, 239, 255],
+        parameters: {cullMode: 'back', depthWriteEnabled: globeProjection},
+        pickable: false
       }),
-      new SettingsPanel({
-        id: 'settings',
-        label: 'Controls',
-        schema: SETTINGS_SCHEMA,
-        settings: state.settings,
-        onSettingsChange
-      }),
-      new CustomPanel({
-        id: 'legend',
-        title: 'Forest Zones',
-        onRenderHTML(hostElement) {
-          const legend = hostElement.ownerDocument.createElement('div');
-          applyElementStyle(legend, {
-            display: 'grid',
-            gap: '6px',
-            fontSize: '12px'
-          });
-
-          for (const zone of ZONES) {
-            const row = hostElement.ownerDocument.createElement('div');
-            const swatch = hostElement.ownerDocument.createElement('span');
-            const label = hostElement.ownerDocument.createElement('span');
-
-            applyElementStyle(row, {
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px'
-            });
-            applyElementStyle(swatch, {
-              display: 'inline-block',
-              width: '12px',
-              height: '12px',
-              borderRadius: '3px',
-              background: zone.color,
-              border: '1px solid rgba(0, 0, 0, 0.12)',
-              flexShrink: '0'
-            });
-
-            label.textContent = zone.label;
-            row.append(swatch, label);
-            legend.append(row);
-          }
-
-          hostElement.replaceChildren(legend);
-
-          return () => {
-            hostElement.replaceChildren();
-          };
-        }
+      basemap,
+      ...groveLayers
+    ];
+  }
+  function createGroveLayers() {
+    return GROVES.flatMap(({site, trees}) => [
+      createTreeLayer(trees, site.id),
+      new LineLayer({
+        id: `forest-winter-${site.id}`,
+        parameters: {cullMode: 'none'},
+        data: state.season === 'winter' ? createWinterBranches(trees, 1) : [],
+        getSourcePosition: branch => branch.source,
+        getTargetPosition: branch => branch.target,
+        getColor: [113, 92, 69, 255],
+        getWidth: 1.5
       })
-    ]
-  });
-}
-
-function getTooltip({object}: {object?: unknown}) {
-  const datum = object as TreeDatum | null;
-  return datum
-    ? {
-        text: `${datum.label}\nHeight: ${datum.height.toFixed(1)} m\nCanopy ⌀: ${(datum.canopyRadius * 2).toFixed(1)} m`,
-        style: {
-          background: 'rgba(0,0,0,0.75)',
-          color: '#fff',
-          borderRadius: '6px',
-          padding: '6px 10px',
-          fontSize: '12px'
-        }
+    ]);
+  }
+  function createTreeLayer(trees: ForestTree[], id: string) {
+    const season = state.season;
+    return new TreeLayer<ForestTree>({
+      id: `forest-trees-${id}`,
+      data: trees,
+      getPosition: tree => tree.position,
+      getTreeType: tree => tree.type,
+      getHeight: tree => tree.height,
+      getTrunkRadius: tree => tree.trunkRadius,
+      getCanopyRadius: tree => getSeasonalCanopyRadius(tree, season),
+      getTrunkColor: getBarkColor,
+      getTrunkHeightFraction: tree => tree.trunkFraction,
+      getBranchLevels: tree => tree.branchLevels,
+      getCanopyColor: tree => getFoliageColor(tree, season),
+      getCrop: tree => getSeasonalCrop(tree, season),
+      sizeScale: 1,
+      _subLayerProps:
+        season === 'winter' && ['cherry', 'birch'].includes(trees[0]?.species)
+          ? {'canopy-cherry': {visible: false}, 'canopy-birch': {visible: false}}
+          : {},
+      pickable: true,
+      parameters: {cullMode: 'none'},
+      updateTriggers: {
+        getCanopyRadius: season,
+        getCanopyColor: season,
+        getCrop: season
       }
-    : null;
+    });
+  }
 }
 
-function cloneSettings(settings: WildForestSettings): WildForestSettings {
+function createControls(root: HTMLElement, showControls: boolean) {
+  const ui = root.ownerDocument.createElement('div');
+  ui.className = 'forest-ui';
+  ui.innerHTML = `
+    <div class="forest-title"><h1 class="forest-heading">TreeLayer</h1><p class="forest-caption"></p><a class="forest-source" target="_blank" rel="noreferrer" hidden>About this region ↗</a></div>
+    <div class="forest-toolbar" aria-label="Tree explorer" ${showControls ? '' : 'hidden'}>
+      <select aria-label="Explore a tree">${FOREST_SITES.map(site => `<option value="${site.id}">${SAMPLES.find(tree => tree.siteId === site.id)!.label} · ${site.country}</option>`).join('')}</select>
+      <select aria-label="Local season">${SEASONS.map(season => `<option value="${season}">${season[0].toUpperCase() + season.slice(1)}</option>`).join('')}</select>
+      <div class="forest-zoom"><button type="button" data-action="zoom-out" aria-label="Zoom out">−</button><button type="button" data-action="zoom-in" aria-label="Zoom in">+</button></div>
+    </div>
+    <div class="forest-map-status" role="status"><span></span><button type="button" data-action="retry" hidden>Retry</button></div>
+    <div class="forest-attribution"><span class="forest-scale-note"></span><span>© <a href="https://carto.com/attributions" target="_blank" rel="noreferrer">CARTO</a> · © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noreferrer">OpenStreetMap</a></span></div>`;
+  root.append(ui);
+  const find = <T extends HTMLElement>(selector: string) => ui.querySelector<T>(selector)!;
   return {
-    render: {...settings.render}
+    heading: find('h1'),
+    caption: find('.forest-caption'),
+    source: find<HTMLAnchorElement>('.forest-source'),
+    treeSelect: find<HTMLSelectElement>('[aria-label="Explore a tree"]'),
+    seasonSelect: find<HTMLSelectElement>('[aria-label="Local season"]'),
+    zoomIn: find<HTMLButtonElement>('[data-action="zoom-in"]'),
+    zoomOut: find<HTMLButtonElement>('[data-action="zoom-out"]'),
+    scaleNote: find('.forest-scale-note'),
+    status: find('.forest-map-status span'),
+    retry: find<HTMLButtonElement>('[data-action="retry"]')
   };
-}
-
-function applyElementStyle(element: HTMLElement, style: Record<string, string>) {
-  for (const [key, value] of Object.entries(style)) {
-    element.style.setProperty(camelCaseToKebabCase(key), value);
-  }
-}
-
-function camelCaseToKebabCase(value: string) {
-  return value.replace(/[A-Z]/g, character => `-${character.toLowerCase()}`);
-}
-
-function makeRng(seed: number) {
-  let s = seed;
-  return () => {
-    s = (s * 1664525 + 1013904223) & 0xffffffff;
-    return (s >>> 0) / 0xffffffff;
-  };
-}
-
-function generateForest(): TreeDatum[] {
-  const trees: TreeDatum[] = [];
-
-  const pineRng = makeRng(1);
-  for (let i = 0; i < 90; i++) {
-    trees.push({
-      position: [-0.055 + pineRng() * 0.04, 51.503 + pineRng() * 0.022],
-      type: 'pine',
-      height: 8 + pineRng() * 14,
-      trunkRadius: 0.25 + pineRng() * 0.35,
-      canopyRadius: 1.8 + pineRng() * 2.2,
-      trunkHeightFraction: 0.38 + pineRng() * 0.12,
-      season: 'summer',
-      branchLevels: 2 + Math.round(pineRng() * 2),
-      label: 'Pine',
-      crop: null
-    });
-  }
-
-  const oakRng = makeRng(2);
-  for (let i = 0; i < 65; i++) {
-    trees.push({
-      position: [0.01 + oakRng() * 0.04, 51.503 + oakRng() * 0.022],
-      type: 'oak',
-      height: 10 + oakRng() * 9,
-      trunkRadius: 0.45 + oakRng() * 0.45,
-      canopyRadius: 3 + oakRng() * 3.5,
-      trunkHeightFraction: 0.28 + oakRng() * 0.12,
-      season: 'autumn',
-      branchLevels: 0,
-      label: 'Oak (Autumn)',
-      crop: null
-    });
-  }
-
-  const cherryRng = makeRng(3);
-  for (let i = 0; i < 55; i++) {
-    const r = cherryRng;
-    trees.push({
-      position: [-0.025 + r() * 0.05, 51.495 + r() * 0.018],
-      type: 'cherry',
-      height: 5 + r() * 6,
-      trunkRadius: 0.2 + r() * 0.25,
-      canopyRadius: 2 + r() * 2.5,
-      trunkHeightFraction: 0.32 + r() * 0.12,
-      season: 'spring',
-      branchLevels: 0,
-      label: 'Cherry Blossom',
-      crop: {
-        color: [255, 230, 240, 210],
-        count: Math.round(20 + r() * 18),
-        droppedCount: Math.round(5 + r() * 10),
-        radius: 0.07
-      }
-    });
-  }
-
-  const palmRng = makeRng(4);
-  for (let i = 0; i < 35; i++) {
-    trees.push({
-      position: [0.022 + palmRng() * 0.025, 51.489 + palmRng() * 0.02],
-      type: 'palm',
-      height: 9 + palmRng() * 10,
-      trunkRadius: 0.18 + palmRng() * 0.18,
-      canopyRadius: 2.5 + palmRng() * 2.5,
-      trunkHeightFraction: 0.72 + palmRng() * 0.15,
-      season: 'summer',
-      branchLevels: 0,
-      label: 'Palm',
-      crop: null
-    });
-  }
-
-  const birchRng = makeRng(5);
-  for (let i = 0; i < 60; i++) {
-    trees.push({
-      position: [-0.072 + birchRng() * 0.03, 51.489 + birchRng() * 0.02],
-      type: 'birch',
-      height: 7 + birchRng() * 7,
-      trunkRadius: 0.12 + birchRng() * 0.13,
-      canopyRadius: 1.8 + birchRng() * 1.8,
-      trunkHeightFraction: 0.48 + birchRng() * 0.16,
-      season: 'autumn',
-      branchLevels: 0,
-      label: 'Birch (Autumn)',
-      crop: null
-    });
-  }
-
-  const winterRng = makeRng(6);
-  for (let i = 0; i < 40; i++) {
-    trees.push({
-      position: [-0.02 + winterRng() * 0.04, 51.518 + winterRng() * 0.012],
-      type: 'oak',
-      height: 11 + winterRng() * 7,
-      trunkRadius: 0.5 + winterRng() * 0.4,
-      canopyRadius: 3.5 + winterRng() * 2,
-      trunkHeightFraction: 0.3 + winterRng() * 0.1,
-      season: 'winter',
-      branchLevels: 0,
-      label: 'Oak (Winter)',
-      crop: null
-    });
-  }
-
-  const springBirchRng = makeRng(7);
-  for (let i = 0; i < 45; i++) {
-    trees.push({
-      position: [-0.085 + springBirchRng() * 0.025, 51.499 + springBirchRng() * 0.018],
-      type: 'birch',
-      height: 9 + springBirchRng() * 6,
-      trunkRadius: 0.14 + springBirchRng() * 0.12,
-      canopyRadius: 2 + springBirchRng() * 2,
-      trunkHeightFraction: 0.5 + springBirchRng() * 0.14,
-      season: 'spring',
-      branchLevels: 0,
-      label: 'Birch (Spring)',
-      crop: null
-    });
-  }
-
-  const citrusRng = makeRng(8);
-  for (let i = 0; i < 50; i++) {
-    const r = citrusRng;
-    trees.push({
-      position: [-0.01 + r() * 0.04, 51.481 + r() * 0.012],
-      type: 'cherry',
-      height: 4 + r() * 4,
-      trunkRadius: 0.18 + r() * 0.18,
-      canopyRadius: 2 + r() * 2,
-      trunkHeightFraction: 0.3 + r() * 0.12,
-      season: 'summer',
-      branchLevels: 0,
-      label: 'Citrus (Fruiting)',
-      crop: {
-        color: [255, 140, 0, 255],
-        count: Math.round(22 + r() * 20),
-        droppedCount: Math.round(6 + r() * 10),
-        radius: 0.11
-      }
-    });
-  }
-
-  const almondRng = makeRng(9);
-  for (let i = 0; i < 45; i++) {
-    const r = almondRng;
-    trees.push({
-      position: [-0.065 + r() * 0.03, 51.481 + r() * 0.012],
-      type: 'oak',
-      height: 5 + r() * 5,
-      trunkRadius: 0.22 + r() * 0.2,
-      canopyRadius: 2.5 + r() * 2,
-      trunkHeightFraction: 0.32 + r() * 0.12,
-      season: 'summer',
-      branchLevels: 0,
-      label: 'Almond (Harvest)',
-      crop: {
-        color: [195, 155, 90, 255],
-        count: Math.round(28 + r() * 22),
-        droppedCount: Math.round(10 + r() * 16),
-        radius: 0.09
-      }
-    });
-  }
-
-  return trees;
 }

--- a/examples/three/wild-forest/forest-basemap.ts
+++ b/examples/three/wild-forest/forest-basemap.ts
@@ -1,0 +1,86 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {TileLayer} from '@deck.gl/geo-layers';
+import {load} from '@loaders.gl/core';
+import {MVTLoader} from '@loaders.gl/mvt';
+import {GeoJsonLayer} from '@deck.gl/layers';
+import type {Color} from '@deck.gl/core';
+import type {Feature} from 'geojson';
+
+// CARTO's OpenMapTiles source ends at z14; overzoom those tiles at tree scale.
+const VECTOR_TILES =
+  'https://tiles-a.basemaps.cartocdn.com/vectortiles/carto.streets/v1/{z}/{x}/{y}.mvt';
+const SURFACES: {name: string; color: Color; line?: boolean}[] = [
+  {name: 'landcover', color: [227, 234, 220]},
+  {name: 'landuse', color: [234, 237, 224]},
+  {name: 'park', color: [224, 233, 215]},
+  {name: 'water', color: [178, 207, 216]},
+  {name: 'waterway', color: [178, 207, 216], line: true},
+  {name: 'building', color: [217, 216, 208]},
+  {name: 'transportation', color: [255, 255, 253], line: true},
+  {name: 'boundary', color: [188, 193, 182], line: true}
+];
+
+/** Muted vector geometry leaves the seasonal tree models as the visual focus. */
+export function createForestBasemap({
+  id,
+  onLoad,
+  onError
+}: {
+  id: string;
+  onLoad: () => void;
+  onError: () => void;
+}) {
+  return new TileLayer<Feature[]>({
+    id,
+    data: VECTOR_TILES,
+    minZoom: 0,
+    maxZoom: 14,
+    tileSize: 512,
+    maxRequests: 6,
+    // Do not parse and upload detailed tiles for every intermediate flight frame.
+    debounceTime: 200,
+    maxCacheSize: 128,
+    refinementStrategy: 'best-available',
+    pickable: false,
+    onTileLoad: onLoad,
+    onTileError: onError,
+    getTileData({url, index, signal}) {
+      // Keep cached tile coordinates identical across GlobeView and MapView.
+      // MVTLayer otherwise decodes local coordinates on the map and WGS84 on the globe.
+      return load(url!, MVTLoader, {
+        mvt: {shape: 'geojson', coordinates: 'wgs84', tileIndex: index},
+        fetch: {signal}
+      }) as Promise<Feature[]>;
+    },
+    renderSubLayers(props) {
+      const {data, ...tileProps} = props;
+      const features = (Array.isArray(data) ? data : []) as Feature[];
+      return SURFACES.map(
+        surface =>
+          new GeoJsonLayer(tileProps, {
+            id: `${props.id}-${surface.name}`,
+            data: features.filter(
+              feature =>
+                feature.properties?.layerName === surface.name &&
+                (surface.name !== 'boundary' ||
+                  (feature.properties?.admin_level === 2 && !feature.properties?.maritime))
+            ),
+            filled: !surface.line,
+            stroked: Boolean(surface.line),
+            getFillColor: surface.color,
+            getLineColor: surface.color,
+            getLineWidth: surface.name === 'transportation' ? 2 : 1,
+            lineWidthUnits: 'pixels',
+            pointRadiusMaxPixels: 0,
+            // Paint coplanar map surfaces in style order without depth fighting.
+            // Depth testing still hides the far side behind the globe.
+            parameters: {cullMode: 'none', depthCompare: 'less-equal', depthWriteEnabled: false},
+            pickable: false
+          })
+      );
+    }
+  });
+}

--- a/examples/three/wild-forest/forest-camera.spec.ts
+++ b/examples/three/wild-forest/forest-camera.spec.ts
@@ -1,0 +1,91 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {WebMercatorViewport, _GlobeViewport} from '@deck.gl/core';
+import {describe, expect, it, vi} from 'vitest';
+import {
+  getGroveBoundsPoints,
+  getGroveView,
+  pickTreeAtPixel,
+  createGroveFlight
+} from './forest-camera';
+import {createTreeSamples, FOREST_SITES} from './forest-data';
+
+describe('grove camera', () => {
+  it('projects geography once and reuses a fitted camera on repeat selection', () => {
+    const grove = createTreeSamples().filter(tree => tree.siteId === 'siwa');
+    const projection = vi.spyOn(WebMercatorViewport.prototype, 'projectFlat');
+    try {
+      const fitted = getGroveView(grove, 900, 600);
+      // The old nested fit projected 400 × 8 corners × 88 trial cameras.
+      expect(projection.mock.calls.length).toBeLessThan(1000);
+      projection.mockClear();
+      expect(getGroveView(grove, 900, 600)).toEqual(fitted);
+      expect(projection).not.toHaveBeenCalled();
+      getGroveView(grove, 390, 740);
+      expect(projection).toHaveBeenCalled();
+    } finally {
+      projection.mockRestore();
+    }
+  });
+  it('flies out and back in without enlarging models or losing the altitude target', () => {
+    const trees = createTreeSamples();
+    const from = getGroveView(
+      trees.filter(tree => tree.siteId === 'siwa'),
+      900,
+      600
+    );
+    const to = getGroveView(
+      trees.filter(tree => tree.siteId === 'kyoto'),
+      900,
+      600
+    );
+    const flight = createGroveFlight(from, to, 900, 600);
+    const midpoint = flight(0.5);
+    expect(flight(0).longitude).toBeCloseTo(from.longitude);
+    expect(midpoint.zoom).toBeLessThan(12);
+    expect(midpoint.longitude).toBeGreaterThan(from.longitude);
+    expect(midpoint.longitude).toBeLessThan(to.longitude);
+    expect(midpoint.position![2]).toBeCloseTo((from.position![2] + to.position![2]) / 2);
+    expect(flight(1)).toEqual(to);
+    const westbound = createGroveFlight(to, {...from, longitude: -119.58}, 900, 600);
+    expect(westbound(0.5).longitude).toBeGreaterThan(to.longitude);
+    expect(westbound(1).longitude).toBe(-119.58);
+  });
+  it('picks local crowns without making distant, invisible trees clickable', () => {
+    const trees = createTreeSamples();
+    const grove = trees.filter(tree => tree.siteId === 'alentejo');
+    const view = getGroveView(grove, 900, 600);
+    const viewport = new WebMercatorViewport({...view, width: 900, height: 600});
+    const oak = grove[12];
+    const [x, y] = viewport.project([oak.position[0], oak.position[1], oak.height * 0.65]);
+    expect(pickTreeAtPixel(trees, viewport, view, x, y)?.siteId).toBe('alentejo');
+    const globeView = {longitude: -20, latitude: 25, zoom: 1.3};
+    const globeViewport = new _GlobeViewport({...globeView, width: 900, height: 600});
+    const [globeX, globeY] = globeViewport.project(oak.position);
+    expect(pickTreeAtPixel(trees, globeViewport, globeView, globeX, globeY)).toBeUndefined();
+    expect(pickTreeAtPixel(trees, viewport, view, 0, 0)).toBeUndefined();
+  });
+  it.each([
+    {width: 900, height: 600},
+    {width: 390, height: 740},
+    {width: 664, height: 560}
+  ])('centers full 3D groves inside the controls at $width × $height', ({width, height}) => {
+    for (const site of FOREST_SITES) {
+      const trees = createTreeSamples().filter(tree => tree.siteId === site.id);
+      const view = getGroveView(trees, width, height);
+      const viewport = new WebMercatorViewport({...view, width, height});
+      const pixels = getGroveBoundsPoints(trees).map(point => viewport.project(point));
+      const xs = pixels.map(point => point[0]);
+      const ys = pixels.map(point => point[1]);
+      expect(Math.min(...xs)).toBeGreaterThanOrEqual(23.9);
+      expect(Math.max(...xs)).toBeLessThanOrEqual(width - 23.9);
+      expect(Math.min(...ys)).toBeGreaterThanOrEqual(119.9);
+      expect(Math.max(...ys)).toBeLessThanOrEqual(height - 89.9);
+      expect((Math.min(...xs) + Math.max(...xs)) / 2).toBeCloseTo(width / 2, 0);
+      expect((Math.min(...ys) + Math.max(...ys)) / 2).toBeCloseTo((height + 30) / 2, 0);
+      expect(view.position![2]).toBeGreaterThan(0);
+    }
+  });
+});

--- a/examples/three/wild-forest/forest-camera.ts
+++ b/examples/three/wild-forest/forest-camera.ts
@@ -1,0 +1,183 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {
+  FlyToInterpolator,
+  WebMercatorViewport,
+  type MapViewState,
+  type Viewport
+} from '@deck.gl/core';
+import {addMetersToLngLat, lngLatToWorld, worldToPixels} from '@math.gl/web-mercator';
+import type {ForestTree} from './forest-data';
+
+/** Include crown width, lean, and height instead of fitting trunk bases alone. */
+export function getGroveBoundsPoints(trees: ForestTree[]): number[][] {
+  return trees.flatMap(tree => {
+    const radius = tree.canopyRadius * 1.5;
+    return [-radius, radius].flatMap(x =>
+      [-radius, radius].flatMap(y =>
+        [0, tree.height * 1.1].map(z => addMetersToLngLat(tree.position, [x, y, z]))
+      )
+    );
+  });
+}
+
+const FIT_CACHE = new WeakMap<ForestTree[], Map<string, MapViewState>>();
+
+/** Fit and center the complete 3D grove between the title and the bottom controls. */
+export function getGroveView(trees: ForestTree[], width: number, height: number): MapViewState {
+  let cache = FIT_CACHE.get(trees);
+  const key = `${width}:${height}`;
+  const cached = cache?.get(key);
+  if (cached) return {...cached};
+  // Geographic projection is independent of the trial camera. Do its trigonometry
+  // once, then fit using only the changing pixel matrix and altitude scale.
+  const points = getGroveBoundsPoints(trees).map(point => [...lngLatToWorld(point), point[2]]);
+  const top = Math.min(120, height * 0.22);
+  const bottom = Math.min(90, height * 0.2);
+  const target = [width / 2, (top + height - bottom) / 2];
+  const altitude = Math.max(...trees.map(tree => tree.height)) / 2;
+  const center = {
+    longitude: trees.reduce((sum, tree) => sum + tree.position[0], 0) / trees.length,
+    latitude: trees.reduce((sum, tree) => sum + tree.position[1], 0) / trees.length
+  };
+  let best: MapViewState = {
+    ...center,
+    zoom: 13,
+    pitch: 50,
+    bearing: 20,
+    position: [0, 0, altitude]
+  };
+  let low = 13;
+  let high = 21;
+  for (let step = 0; step < 14; step++) {
+    const zoom = (low + high) / 2;
+    let view = {...best, ...center, zoom};
+    let bounds: number[] = [];
+    for (let pass = 0; pass < 4; pass++) {
+      const viewport = new WebMercatorViewport({...view, width, height});
+      bounds = [Infinity, Infinity, -Infinity, -Infinity];
+      for (const point of points) {
+        const [x, y] = worldToPixels(
+          [point[0], point[1], point[2] * viewport.distanceScales.unitsPerMeter[2]],
+          viewport.pixelProjectionMatrix
+        );
+        bounds[0] = Math.min(bounds[0], x);
+        bounds[1] = Math.min(bounds[1], y);
+        bounds[2] = Math.max(bounds[2], x);
+        bounds[3] = Math.max(bounds[3], y);
+      }
+      if (pass === 3) break;
+      const middle = [(bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2];
+      const from = viewport.unproject(middle, {targetZ: altitude});
+      const to = viewport.unproject(target, {targetZ: altitude});
+      view = {
+        ...view,
+        longitude: view.longitude + from[0] - to[0],
+        latitude: view.latitude + from[1] - to[1]
+      };
+    }
+    if (
+      bounds[0] >= 24 &&
+      bounds[2] <= width - 24 &&
+      bounds[1] >= top &&
+      bounds[3] <= height - bottom
+    ) {
+      best = view;
+      low = zoom;
+    } else {
+      high = zoom;
+    }
+  }
+  if (!cache) {
+    cache = new Map();
+    FIT_CACHE.set(trees, cache);
+  }
+  // Resizing can produce many dimensions; retain a small set per stable grove.
+  if (cache.size >= 8) cache.delete(cache.keys().next().value!);
+  cache.set(key, best);
+  return {...best};
+}
+
+type CrownHitArea = {tree: ForestTree; x: number; y: number; rx: number; ry: number};
+const PICK_CACHE = new WeakMap<Viewport, {trees: ForestTree[]; crowns: CrownHitArea[]}>();
+
+/** Cache projected crowns per camera so hovering a dense grove only checks ellipses. */
+export function pickTreeAtPixel(
+  trees: ForestTree[],
+  viewport: Viewport,
+  view: MapViewState,
+  x: number,
+  y: number
+): ForestTree | undefined {
+  if (view.zoom < 14) return undefined;
+  let cached = PICK_CACHE.get(viewport);
+  if (!cached || cached.trees !== trees) {
+    const crowns: CrownHitArea[] = [];
+    for (const tree of trees) {
+      // Other continents cannot be hit at grove zoom. Avoid projecting their geometry.
+      const lngDelta = ((tree.position[0] - view.longitude + 540) % 360) - 180;
+      if (Math.abs(lngDelta) > 1 || Math.abs(tree.position[1] - view.latitude) > 1) continue;
+      const radius = tree.canopyRadius * 1.35;
+      let left = Infinity;
+      let right = -Infinity;
+      let top = Infinity;
+      let bottom = -Infinity;
+      for (const dx of [-radius, radius]) {
+        for (const dy of [-radius, radius]) {
+          for (const z of [tree.height * tree.trunkFraction, tree.height]) {
+            const pixel = viewport.project(addMetersToLngLat(tree.position, [dx, dy, z]));
+            left = Math.min(left, pixel[0]);
+            right = Math.max(right, pixel[0]);
+            top = Math.min(top, pixel[1]);
+            bottom = Math.max(bottom, pixel[1]);
+          }
+        }
+      }
+      if (right < 0 || left > viewport.width || bottom < 0 || top > viewport.height) continue;
+      crowns.push({
+        tree,
+        x: (left + right) / 2,
+        y: (top + bottom) / 2,
+        rx: Math.max(4, (right - left) / 2),
+        ry: Math.max(4, (bottom - top) / 2)
+      });
+    }
+    cached = {trees, crowns};
+    PICK_CACHE.set(viewport, cached);
+  }
+  let nearest: ForestTree | undefined;
+  let nearestDistance = 1;
+  for (const crown of cached.crowns) {
+    const distance = ((x - crown.x) / crown.rx) ** 2 + ((y - crown.y) / crown.ry) ** 2;
+    if (distance < nearestDistance) {
+      nearestDistance = distance;
+      nearest = crown.tree;
+    }
+  }
+  return nearest;
+}
+
+/** Fly between groves along the shorter longitude arc, retaining the 3D camera target. */
+export function createGroveFlight(
+  from: MapViewState,
+  to: MapViewState,
+  width: number,
+  height: number
+): (progress: number) => MapViewState {
+  const interpolator = new FlyToInterpolator();
+  const wrapAngle = (angle: number) => ((((angle + 180) % 360) + 360) % 360) - 180;
+  const {start, end} = interpolator.initializeProps(
+    {...from, width, height},
+    {
+      ...to,
+      width,
+      height,
+      longitude: from.longitude + wrapAngle(to.longitude - from.longitude),
+      bearing: (from.bearing || 0) + wrapAngle((to.bearing || 0) - (from.bearing || 0))
+    }
+  );
+  return progress =>
+    progress >= 1 ? to : (interpolator.interpolateProps(start, end, progress) as MapViewState);
+}

--- a/examples/three/wild-forest/forest-data.spec.ts
+++ b/examples/three/wild-forest/forest-data.spec.ts
@@ -1,0 +1,122 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, it} from 'vitest';
+import {
+  FOREST_SITES,
+  createTreeSamples,
+  TREES_PER_SITE,
+  getFoliageColor,
+  getBarkColor,
+  getSeasonalCanopyRadius,
+  getSeasonalCrop,
+  createWinterBranches
+} from './forest-data';
+
+describe('geographic tree groves', () => {
+  it('places seven varied groves around the globe covering all five silhouettes', () => {
+    const trees = createTreeSamples();
+    expect(createTreeSamples()).toEqual(trees);
+    expect(trees).toHaveLength(2800);
+    expect(new Set(trees.map(tree => tree.id)).size).toBe(trees.length);
+    expect(new Set(trees.map(tree => tree.type))).toEqual(
+      new Set(['pine', 'oak', 'palm', 'birch', 'cherry'])
+    );
+    expect(new Set(trees.map(tree => tree.species)).size).toBe(7);
+    expect(Math.min(...trees.map(tree => tree.position[0]))).toBeLessThan(-100);
+    expect(Math.max(...trees.map(tree => tree.position[0]))).toBeGreaterThan(130);
+    expect(trees.some(tree => tree.position[1] < -20)).toBe(true);
+    for (const tree of trees) {
+      const site = FOREST_SITES.find(item => item.id === tree.siteId)!;
+      expect(tree.position[0]).toBeCloseTo(site.position[0], 2);
+      expect(tree.position[1]).toBeCloseTo(site.position[1], 2);
+      expect(tree.species).toBe(site.species);
+      expect(tree.height).toBeGreaterThan(1);
+      expect(tree.canopyRadius).toBeGreaterThan(tree.trunkRadius);
+    }
+  });
+
+  it('keeps all groves at metre scale with varied sizes', () => {
+    const local = createTreeSamples();
+    for (const site of FOREST_SITES) {
+      const grove = local.filter(tree => tree.siteId === site.id);
+      expect(grove).toHaveLength(TREES_PER_SITE);
+      expect(new Set(grove.map(tree => tree.height)).size).toBeGreaterThan(15);
+      expect(
+        Math.max(...grove.map(tree => tree.height)) / Math.min(...grove.map(tree => tree.height))
+      ).toBeGreaterThan(2);
+      expect(grove.reduce((sum, tree) => sum + tree.position[0], 0) / grove.length).toBeCloseTo(
+        site.position[0],
+        6
+      );
+      expect(grove.reduce((sum, tree) => sum + tree.position[1], 0) / grove.length).toBeCloseTo(
+        site.position[1],
+        6
+      );
+    }
+    expect(Math.max(...local.map(tree => tree.height))).toBeLessThan(40);
+  });
+
+  it('varies independent traits and seasonal responses throughout every grove', () => {
+    const trees = createTreeSamples();
+    for (const site of FOREST_SITES) {
+      const grove = trees.filter(tree => tree.siteId === site.id);
+      expect(new Set(grove.map(tree => tree.maturity)).size).toBe(4);
+      expect(new Set(grove.map(tree => tree.branchLevels)).size).toBe(5);
+      expect(new Set(grove.map(tree => tree.trunkFraction)).size).toBeGreaterThan(350);
+      expect(new Set(grove.map(tree => tree.canopyRadius / tree.height)).size).toBeGreaterThan(350);
+      expect(
+        new Set(grove.map(tree => getFoliageColor(tree, 'autumn').join(','))).size
+      ).toBeGreaterThan(32);
+      expect(new Set(grove.map(tree => getBarkColor(tree).join(','))).size).toBeGreaterThan(25);
+      for (const tree of grove) {
+        expect(getSeasonalCanopyRadius(tree, 'spring')).toBeLessThanOrEqual(tree.canopyRadius);
+        expect(tree.branchLevels).toBeGreaterThanOrEqual(1);
+        expect(tree.branchLevels).toBeLessThanOrEqual(5);
+        if (tree.maturity === 'sapling') expect(getSeasonalCrop(tree, 'autumn')).toBeNull();
+      }
+    }
+    const oranges = trees.filter(tree => tree.species === 'orange' && tree.maturity !== 'sapling');
+    const harvest = oranges.map(tree => getSeasonalCrop(tree, 'winter')!);
+    expect(new Set(harvest.map(crop => crop.count)).size).toBeGreaterThan(30);
+    expect(new Set(harvest.map(crop => crop.radius)).size).toBeGreaterThan(250);
+    const cherry = trees.find(tree => tree.species === 'cherry')!;
+    expect(getSeasonalCanopyRadius(cherry, 'spring')).toBeLessThan(
+      getSeasonalCanopyRadius(cherry, 'summer')
+    );
+  });
+
+  it('keeps evergreen crowns and reveals only the leafless cherry and birch branches', () => {
+    for (const tree of createTreeSamples()) {
+      const leafless = ['cherry', 'birch'].includes(tree.species);
+      expect(getFoliageColor(tree, 'winter')[3] === 0).toBe(leafless);
+      expect(createWinterBranches([tree], 1).length > 0).toBe(leafless);
+    }
+  });
+
+  it('shows local blossom and harvest stages without assigning fruit to ornamental cherries', () => {
+    const trees = createTreeSamples();
+    const cherry = trees.find(tree => tree.species === 'cherry')!;
+    expect(getSeasonalCrop(cherry, 'spring')?.count).toBeGreaterThan(0);
+    expect(getSeasonalCrop(cherry, 'summer')).toBeNull();
+    const almond = trees.find(tree => tree.species === 'almond')!;
+    expect(getSeasonalCrop(almond, 'winter')?.count).toBeGreaterThan(0);
+    const orange = trees.find(tree => tree.species === 'orange')!;
+    expect(getSeasonalCrop(orange, 'winter')?.color).not.toEqual(
+      getSeasonalCrop(orange, 'summer')?.color
+    );
+    expect(getSeasonalCrop(orange, 'winter')?.droppedCount).toBeGreaterThan(0);
+  });
+
+  it('scales the leafless scaffold without moving its geographic base', () => {
+    const tree = createTreeSamples().find(sample => sample.species === 'birch')!;
+    const normal = createWinterBranches([tree], 1);
+    const larger = createWinterBranches([tree], 2);
+    for (let index = 0; index < normal.length; index++) {
+      expect(larger[index].source.slice(0, 2)).toEqual(normal[index].source.slice(0, 2));
+      expect(larger[index].source[2]).toBeCloseTo(normal[index].source[2] * 2);
+      expect(larger[index].target[2]).toBeCloseTo(normal[index].target[2] * 2);
+    }
+  });
+});

--- a/examples/three/wild-forest/forest-data.ts
+++ b/examples/three/wild-forest/forest-data.ts
@@ -1,0 +1,388 @@
+// deck.gl-community
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {addMetersToLngLat} from '@math.gl/web-mercator';
+import type {Color} from '@deck.gl/core';
+import type {CropConfig, Season, TreeType} from '@deck.gl-community/three';
+
+export type Species = 'date' | 'orange' | 'cherry' | 'pine' | 'birch' | 'cork-oak' | 'almond';
+export type ForestSite = {
+  id: string;
+  name: string;
+  country: string;
+  position: [number, number];
+  species: Species;
+  source: string;
+};
+
+/** Regional examples, not surveyed individual-tree locations. */
+export const FOREST_SITES: ForestSite[] = [
+  {
+    id: 'siwa',
+    name: 'Siwa Oasis',
+    country: 'Egypt',
+    position: [25.53, 29.21],
+    species: 'date',
+    source: 'https://www.fao.org/giahs/giahs-around-the-world/egypt-siwa-oasis-dates-system/en'
+  },
+  {
+    id: 'saopaulo',
+    name: 'São Paulo',
+    country: 'Brazil',
+    position: [-47.04, -21.85],
+    species: 'orange',
+    source:
+      'https://agenciadenoticias.ibge.gov.br/en/agencia-press-room/2185-news-agency/releases-en/43106-in-march-ibge-s-harvest-estimate-for-2025-is-327-6-million-tonnes'
+  },
+  {
+    id: 'kyoto',
+    name: 'Kyoto',
+    country: 'Japan',
+    position: [135.7847, 35.0035],
+    species: 'cherry',
+    source: 'https://kyoto.travel/en/destinations/maruyama-park/'
+  },
+  {
+    id: 'nuuksio',
+    name: 'Nuuksio',
+    country: 'Finland',
+    position: [24.5008, 60.3078],
+    species: 'birch',
+    source: 'https://www.luontoon.fi/en/destinations/nuuksio-national-park'
+  },
+  {
+    id: 'alentejo',
+    name: 'Alentejo',
+    country: 'Portugal',
+    position: [-8.009, 38.5528],
+    species: 'cork-oak',
+    source: 'https://www.visitportugal.com/en/content/the-cork'
+  },
+  {
+    id: 'riverland',
+    name: 'Riverland',
+    country: 'Australia',
+    position: [140.63, -34.41],
+    species: 'almond',
+    source: 'https://almondboard.org.au/almond-story/'
+  },
+  {
+    id: 'yosemite',
+    name: 'Yosemite',
+    country: 'United States',
+    position: [-119.58, 37.7469],
+    species: 'pine',
+    source: 'https://www.nps.gov/yose/learn/nature/plants.htm'
+  }
+];
+
+export type ForestTree = {
+  id: string;
+  siteId: string;
+  position: [number, number, number];
+  species: Species;
+  type: TreeType;
+  label: string;
+  height: number;
+  canopyRadius: number;
+  trunkRadius: number;
+  trunkFraction: number;
+  branchLevels: number;
+  maturity: 'sapling' | 'young' | 'mature' | 'veteran';
+  vigor: number;
+  foliageTone: number;
+  barkTone: number;
+  phenology: number;
+  cropLoad: number;
+  fruitSize: number;
+  branchPhase: number;
+};
+
+const SPECIES: Record<
+  Species,
+  {type: TreeType; label: string; height: number; radius: number; trunk: number; fraction: number}
+> = {
+  date: {type: 'palm', label: 'Date palm', height: 17, radius: 4.8, trunk: 0.45, fraction: 0.8},
+  orange: {
+    type: 'cherry',
+    label: 'Orange tree',
+    height: 4.8,
+    radius: 4,
+    trunk: 0.24,
+    fraction: 0.24
+  },
+  cherry: {
+    type: 'cherry',
+    label: 'Ornamental cherry',
+    height: 8,
+    radius: 5.8,
+    trunk: 0.36,
+    fraction: 0.3
+  },
+  pine: {type: 'pine', label: 'Pine', height: 22, radius: 5, trunk: 0.38, fraction: 0.32},
+  birch: {type: 'birch', label: 'Birch', height: 16, radius: 4.5, trunk: 0.26, fraction: 0.42},
+  'cork-oak': {type: 'oak', label: 'Cork oak', height: 10, radius: 8, trunk: 0.8, fraction: 0.28},
+  almond: {type: 'oak', label: 'Almond tree', height: 5.5, radius: 4.8, trunk: 0.28, fraction: 0.28}
+};
+
+export const SEASONS: Season[] = ['spring', 'summer', 'autumn', 'winter'];
+
+export const TREES_PER_SITE = 400;
+
+/** Independent, repeatable traits; moving the camera never regenerates a grove. */
+function createRandom(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state = (state + 0x9e3779b9) | 0;
+    let value = Math.imul(state ^ (state >>> 16), 0x21f0aaad);
+    value = Math.imul(value ^ (value >>> 15), 0x735a2d97);
+    return ((value ^ (value >>> 15)) >>> 0) / 4294967296;
+  };
+}
+
+/** Seven substantial groves: planted orchard rows and irregular woodland clusters. */
+export function createTreeSamples(): ForestTree[] {
+  return FOREST_SITES.flatMap((site, siteIndex) => {
+    const model = SPECIES[site.species];
+    const orchard = ['date', 'orange', 'almond'].includes(site.species);
+    const spacing = model.radius * (orchard ? 1.65 : 1.9);
+    const random = createRandom(127 + siteIndex * 7919);
+    const offsets: [number, number][] = [];
+    const trees = Array.from({length: TREES_PER_SITE}, (_, index): ForestTree => {
+      const age = index === 0 ? 0.65 : random();
+      const maturity =
+        age < 0.1 ? 'sapling' : age < 0.32 ? 'young' : age < 0.88 ? 'mature' : 'veteran';
+      const growth = 0.28 + Math.sqrt(age) * 0.95;
+      const vigor = 0.5 + random() * 0.5;
+      const width = 0.65 + random() * 0.7;
+      const trunk = 0.7 + random() * 0.65 + (maturity === 'veteran' ? 0.35 : 0);
+      let x: number;
+      let y: number;
+      if (orchard) {
+        const col = index % 20;
+        const row = Math.floor(index / 20);
+        // Working lanes between blocks, with small planting offsets within rows.
+        x = (col - 9.5 + (Math.floor(col / 5) - 1.5) * 0.65 + (random() - 0.5) * 0.2) * spacing;
+        y = (row - 9.5 + (Math.floor(row / 5) - 1.5) * 0.65 + (random() - 0.5) * 0.2) * spacing;
+      } else {
+        const angle = index * 2.399963 + (random() - 0.5) * 0.35;
+        const radius = Math.sqrt(index / TREES_PER_SITE) * spacing * 11;
+        const edge = 1 + Math.sin(angle * 3) * 0.12 + Math.cos(angle * 5) * 0.08;
+        x = Math.cos(angle) * radius * edge;
+        y = Math.sin(angle) * radius * edge * 0.8;
+        // A winding opening through the woodland creates loose, uneven stands.
+        x += Math.sign(x) * spacing * (0.5 + 0.5 * Math.sin(y / (spacing * 3)));
+      }
+      offsets.push([x, y]);
+      return {
+        id: `${site.id}-${index}`,
+        siteId: site.id,
+        position: [0, 0, 0],
+        species: site.species,
+        type: model.type,
+        label: model.label,
+        height: model.height * growth * (0.85 + random() * 0.3),
+        canopyRadius: model.radius * growth * width,
+        trunkRadius: model.trunk * growth * trunk,
+        trunkFraction:
+          Math.max(0.18, model.fraction - 0.1) +
+          random() * (Math.min(0.87, model.fraction + 0.1) - Math.max(0.18, model.fraction - 0.1)),
+        branchLevels: Math.min(5, 1 + Math.floor(age * 4 + random() * 1.5)),
+        maturity,
+        vigor,
+        foliageTone: random(),
+        barkTone: random(),
+        phenology: random(),
+        cropLoad: maturity === 'sapling' ? 0 : (0.25 + random() * 1.4) * vigor * growth,
+        fruitSize: 0.7 + random() * 0.6,
+        branchPhase: random() * Math.PI * 2
+      };
+    });
+    const centerX = offsets.reduce((sum, point) => sum + point[0], 0) / trees.length;
+    const centerY = offsets.reduce((sum, point) => sum + point[1], 0) / trees.length;
+    for (let index = 0; index < trees.length; index++) {
+      trees[index].position = addMetersToLngLat(
+        [...site.position, 0],
+        [offsets[index][0] - centerX, offsets[index][1] - centerY, 0]
+      ) as [number, number, number];
+    }
+    return trees;
+  });
+}
+
+function mixColor(from: Color, to: Color, amount: number): Color {
+  return [
+    Math.round(from[0] + (to[0] - from[0]) * amount),
+    Math.round(from[1] + (to[1] - from[1]) * amount),
+    Math.round(from[2] + (to[2] - from[2]) * amount),
+    from[3] ?? 255
+  ];
+}
+
+/** Individual bark tones preserve the pale birch and warm date-palm trunks. */
+export function getBarkColor(tree: ForestTree): Color {
+  const base: Color =
+    tree.species === 'birch'
+      ? [221, 216, 200, 255]
+      : tree.species === 'date'
+        ? [153, 117, 71, 255]
+        : tree.species === 'cork-oak'
+          ? [112, 87, 65, 255]
+          : [112, 78, 51, 255];
+  return mixColor(base, [55, 48, 37, 255], tree.barkTone * 0.35);
+}
+
+/** Crown fullness changes with local season, vigor, and each tree's timing. */
+export function getSeasonalCanopyRadius(tree: ForestTree, season: Season): number {
+  const evergreen = ['date', 'orange', 'cork-oak', 'pine'].includes(tree.species);
+  const fullness = evergreen
+    ? 0.9 + tree.vigor * 0.1
+    : season === 'spring' || (tree.species === 'almond' && season === 'winter')
+      ? 0.68 + tree.phenology * 0.25
+      : season === 'autumn'
+        ? 0.66 + tree.phenology * 0.3
+        : 1;
+  return tree.canopyRadius * fullness;
+}
+
+export function getFoliageColor(tree: ForestTree, season: Season): Color {
+  const color = getSeasonColor(tree, season);
+  if (color[3] === 0) return color;
+  return mixColor(
+    color,
+    tree.foliageTone > 0.5 ? [223, 209, 111, 255] : [25, 69, 44, 255],
+    Math.abs(tree.foliageTone - 0.5) * 0.55 + (1 - tree.vigor) * 0.15
+  );
+}
+
+function getSeasonColor(tree: ForestTree, season: Season): Color {
+  if (tree.species === 'date') return season === 'spring' ? [91, 145, 55, 255] : [62, 122, 49, 255];
+  if (tree.species === 'orange') return [46, 111, 40, 255];
+  if (tree.species === 'cork-oak') return [91, 118, 65, 255];
+  if (tree.species === 'pine') return season === 'spring' ? [61, 124, 71, 255] : [37, 92, 60, 255];
+  if (tree.species === 'almond' && season === 'winter')
+    return mixColor([253, 245, 237, 255], [238, 179, 199, 255], tree.phenology);
+  if (season === 'winter') return [135, 119, 101, 0];
+  if (tree.species === 'cherry' && season === 'spring')
+    return mixColor([255, 240, 237, 255], [238, 151, 188, 255], tree.phenology);
+  if (season === 'autumn')
+    return tree.species === 'birch'
+      ? mixColor([151, 166, 57, 255], [236, 163, 32, 255], tree.phenology)
+      : mixColor([125, 155, 63, 255], [197, 73, 38, 255], tree.phenology);
+  return season === 'spring' ? [143, 191, 88, 255] : [65, 130, 53, 255];
+}
+
+/** Illustrative local seasons, not a synchronized global date; fruit is enlarged for visibility. */
+export function getSeasonalCrop(tree: ForestTree, season: Season): CropConfig | null {
+  const crop = (
+    color: Color,
+    count: number,
+    radius: number,
+    droppedCount = 0
+  ): CropConfig | null => {
+    if (tree.cropLoad === 0) return null;
+    return {
+      color: mixColor(color, [246, 219, 127, 255], tree.phenology * 0.24),
+      count: Math.round(count * tree.cropLoad),
+      radius: radius * tree.fruitSize,
+      droppedCount: Math.round(droppedCount * tree.cropLoad * (0.35 + tree.phenology))
+    };
+  };
+  switch (tree.species) {
+    case 'date':
+      return season === 'autumn'
+        ? crop([169, 82, 29, 255], 48, 0.12, 8)
+        : season === 'summer'
+          ? crop([216, 167, 52, 255], 34, 0.1)
+          : null;
+    case 'orange':
+      return season === 'spring'
+        ? crop([255, 250, 225, 255], 34, 0.13)
+        : season === 'summer'
+          ? crop([121, 160, 40, 255], 22, 0.14)
+          : crop([255, 151, 18, 255], 40, 0.18, season === 'winter' ? 7 : 2);
+    case 'cherry':
+      return season === 'spring' ? crop([255, 225, 238, 255], 46, 0.16, 14) : null;
+    case 'almond':
+      return season === 'winter'
+        ? crop([255, 239, 242, 255], 38, 0.14)
+        : season === 'summer' || season === 'autumn'
+          ? crop([184, 142, 81, 255], 30, 0.13, season === 'autumn' ? 14 : 0)
+          : null;
+    case 'cork-oak':
+      return season === 'autumn' ? crop([126, 80, 33, 255], 28, 0.15, 16) : null;
+    default:
+      return null;
+  }
+}
+
+export function getSeasonDescription(site: ForestSite, season: Season): string {
+  if (site.species === 'almond' && season === 'winter')
+    return 'Winter blossom · white and pink almond flowers';
+  if (site.species === 'cherry')
+    return {
+      spring: 'Blossom · ornamental cherries in flower',
+      summer: 'Full green crowns · no edible-cherry crop shown',
+      autumn: 'Amber foliage · leaves turning',
+      winter: 'Leafless crowns · branching structure revealed'
+    }[season];
+  if (site.species === 'date')
+    return {
+      spring: 'Evergreen fronds · new growth',
+      summer: 'Evergreen fronds · ripening dates',
+      autumn: 'Date harvest · ripe fruit and fallen dates',
+      winter: 'Evergreen fronds · fruiting display rests'
+    }[season];
+  if (site.species === 'orange')
+    return {
+      spring: 'Orange blossom · pale flowers',
+      summer: 'Green fruit · evergreen foliage',
+      autumn: 'Fruit colouring · oranges on the canopy',
+      winter: 'Ripe oranges · evergreen winter crowns'
+    }[season];
+  if (site.species === 'birch')
+    return {
+      spring: 'Fresh birch leaves',
+      summer: 'Full green birch canopy',
+      autumn: 'Golden birch foliage',
+      winter: 'Bare birch branches'
+    }[season];
+  if (site.species === 'cork-oak')
+    return season === 'autumn'
+      ? 'Acorns on the canopy and pasture · evergreen oak'
+      : 'Evergreen cork-oak crowns · open woodland';
+  if (site.species === 'pine') return 'Evergreen pine · tiered canopy';
+  return season === 'summer' || season === 'autumn'
+    ? 'Almonds ripening · harvest on the ground'
+    : 'Fresh green almond leaves';
+}
+
+export type TreeBranch = {source: [number, number, number]; target: [number, number, number]};
+
+/** A lightweight branching scaffold for winter's leafless cherry and birch silhouettes. */
+export function createWinterBranches(trees: ForestTree[], sizeScale: number): TreeBranch[] {
+  return trees
+    .filter(tree => tree.species === 'cherry' || tree.species === 'birch')
+    .flatMap(tree => {
+      const h = tree.height * sizeScale;
+      const base = h * tree.trunkFraction;
+      return Array.from({length: 5 + tree.branchLevels * 2}, (_, index) => {
+        const angle = tree.branchPhase + index * 2.39996;
+        const level = 0.25 + (index % 3) * 0.24;
+        const radius = tree.canopyRadius * sizeScale * 0.45 * (1 - level * 0.55);
+        return {
+          source: [tree.position[0], tree.position[1], base + (h - base) * level * 0.4] as [
+            number,
+            number,
+            number
+          ],
+          target: addMetersToLngLat(tree.position, [
+            Math.cos(angle) * radius,
+            Math.sin(angle) * radius,
+            base + (h - base) * level
+          ]) as [number, number, number]
+        };
+      });
+    });
+}

--- a/examples/three/wild-forest/package.json
+++ b/examples/three/wild-forest/package.json
@@ -5,17 +5,20 @@
     "start-local": "vite --config ../../vite.config.local.mjs"
   },
   "dependencies": {
-    "@deck.gl-community/panels": "workspace:*",
     "@deck.gl-community/three": "workspace:*",
-    "@deck.gl-community/widgets": "workspace:*",
     "@deck.gl/core": "~9.4.0",
+    "@deck.gl/extensions": "~9.4.0",
+    "@deck.gl/geo-layers": "~9.4.0",
+    "@deck.gl/layers": "~9.4.0",
     "@deck.gl/mesh-layers": "~9.4.0",
-    "@deck.gl/widgets": "~9.4.0",
+    "@loaders.gl/core": "^4.4.3",
+    "@loaders.gl/mvt": "^4.4.3",
     "@luma.gl/core": "~9.4.0",
     "@luma.gl/engine": "~9.4.0",
     "@luma.gl/shadertools": "~9.4.0",
     "@luma.gl/webgl": "~9.4.0",
-    "@luma.gl/webgpu": "~9.4.0"
+    "@luma.gl/webgpu": "~9.4.0",
+    "@math.gl/web-mercator": "^4.1.0"
   },
   "devDependencies": {
     "vite": "^7.3.1"

--- a/examples/three/wild-forest/style.css
+++ b/examples/three/wild-forest/style.css
@@ -1,0 +1,172 @@
+.forest-explorer {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 300px;
+  overflow: hidden;
+  background: #e6ecee;
+  color: #2e4038;
+  font:
+    12px / 1.5 system-ui,
+    sans-serif;
+  container: forest / inline-size;
+}
+.forest-explorer * {
+  box-sizing: border-box;
+}
+.forest-explorer .forest-canvas,
+.forest-explorer .forest-ui {
+  position: absolute;
+  inset: 0;
+}
+.forest-explorer .forest-ui {
+  pointer-events: none;
+}
+.forest-explorer :is(button, select, a) {
+  pointer-events: auto;
+  font: inherit;
+  color: inherit;
+}
+.forest-explorer [hidden] {
+  display: none !important;
+}
+.forest-explorer .forest-title {
+  position: absolute;
+  top: 18px;
+  left: 20px;
+  max-width: 55%;
+  text-shadow: 0 1px 3px #ffffffd9;
+}
+/* Preserve the sample typography in the website's heading cascade. */
+.forest-explorer .forest-heading {
+  font:
+    600 18px / 1.2 system-ui,
+    sans-serif !important;
+  color: #304737 !important;
+  margin: 0 0 4px !important;
+  letter-spacing: -0.4px;
+}
+.forest-explorer .forest-caption {
+  font-size: 11px;
+  margin: 0 !important;
+  color: #607469;
+}
+.forest-explorer .forest-source {
+  display: inline-block;
+  margin-top: 4px;
+  color: #4e6d58;
+  font-size: 10px;
+}
+.forest-explorer .forest-toolbar {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 36px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px;
+  max-width: calc(100% - 24px);
+  background: #fffffff5;
+  border: 1px solid #dce3d9;
+  border-radius: 9px;
+  box-shadow: 0 2px 10px #293d3012;
+  pointer-events: auto;
+}
+.forest-explorer select {
+  min-width: 0;
+  max-width: 235px;
+  border: 0;
+  background: transparent;
+  padding: 9px 6px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.forest-explorer select[aria-label="Local season"] {
+  border-left: 1px solid #e4e9e0;
+}
+.forest-explorer .forest-zoom {
+  display: flex;
+  border-left: 1px solid #e4e9e0;
+  padding-left: 4px;
+}
+.forest-explorer button {
+  cursor: pointer;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+}
+.forest-explorer .forest-zoom button {
+  font-size: 20px;
+  width: 32px;
+  height: 34px;
+  padding: 0;
+}
+.forest-explorer button:hover,
+.forest-explorer select:hover {
+  background: #edf2e8;
+}
+.forest-explorer button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.forest-explorer :is(button, select, a):focus-visible {
+  outline: 2px solid #39764c;
+  outline-offset: 1px;
+}
+.forest-explorer .forest-map-status {
+  position: absolute;
+  right: 12px;
+  bottom: 90px;
+  font-size: 10px;
+  background: #ffffffec;
+  border-radius: 4px;
+}
+.forest-explorer .forest-attribution {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 2px 8px;
+  padding: 4px 10px;
+  font-size: 9px;
+  background: #ffffffe6;
+  color: #5b6f60;
+}
+@container forest (max-width: 600px) {
+  .forest-explorer .forest-title {
+    top: 16px;
+    left: 14px;
+    max-width: calc(100% - 28px);
+  }
+  .forest-explorer[data-managed-device="true"] .forest-title {
+    top: 60px;
+  }
+  .forest-explorer .forest-heading {
+    font-size: 16px !important;
+  }
+  .forest-explorer .forest-toolbar {
+    width: calc(100% - 24px);
+    bottom: 32px;
+    gap: 2px;
+  }
+  .forest-explorer select {
+    font-size: 10px;
+    padding: 9px 2px;
+  }
+  .forest-explorer select[aria-label="Explore a tree"] {
+    flex: 1;
+  }
+  .forest-explorer .forest-zoom {
+    padding-left: 2px;
+  }
+  .forest-explorer .forest-zoom button {
+    width: 26px;
+  }
+  .forest-explorer .forest-attribution {
+    font-size: 8px;
+  }
+}

--- a/examples/three/wild-forest/vite-env.d.ts
+++ b/examples/three/wild-forest/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/three/wild-forest/vite.config.ts
+++ b/examples/three/wild-forest/vite.config.ts
@@ -3,8 +3,8 @@
 // Copyright (c) vis.gl contributors
 
 // Local vite config for the wild-forest example.
-// Aliases @deck.gl-community/three directly to the TypeScript source so that
-// Vite HMR picks up changes to the module without requiring a dist rebuild.
+// Resolve the local TreeLayer package from source,
+// so a fresh checkout can start without a package build.
 import {defineConfig} from 'vite';
 import path from 'path';
 import {fileURLToPath} from 'url';

--- a/modules/three/README.md
+++ b/modules/three/README.md
@@ -185,12 +185,16 @@ type CropConfig = {
 
 ## Wild-Forest example
 
-A full demo with 9 forest zones (pines, oaks, palms, birches, cherry blossoms, citrus orchards, almond groves) is available at `examples/three/wild-forest/`.
+A [Wild Forest demo](https://visgl.github.io/deck.gl-community/examples/three/wild-forest)
+opens in Siwa's date-palm grove, with seven regional settings and 400 varied trees each.
+See the [example README](../../examples/three/wild-forest/README.md) for setup and data details.
 
 ```bash
 cd examples/three/wild-forest
 yarn          # first time only
-yarn start    # opens http://localhost:8080
+yarn start    # opens the local demo URL shown by Vite
 ```
 
-The example includes a live `sizeScale` slider, a crop toggle, and a zone legend.
+Choose a region to fly to its centered grove, select a local season to update foliage and
+crops, and use the zoom buttons or map gestures to explore. Trees retain metre-scale
+dimensions; the source-linked locations and tree attributes are illustrative, not surveyed.

--- a/modules/three/README.md
+++ b/modules/three/README.md
@@ -183,18 +183,9 @@ type CropConfig = {
 
 ---
 
-## Wild-Forest example
+## Wild Forest example
 
-A [Wild Forest demo](https://visgl.github.io/deck.gl-community/examples/three/wild-forest)
-opens in Siwa's date-palm grove, with seven regional settings and 400 varied trees each.
-See the [example README](../../examples/three/wild-forest/README.md) for setup and data details.
-
-```bash
-cd examples/three/wild-forest
-yarn          # first time only
-yarn start    # opens the local demo URL shown by Vite
-```
-
-Choose a region to fly to its centered grove, select a local season to update foliage and
-crops, and use the zoom buttons or map gestures to explore. Trees retain metre-scale
-dimensions; the source-linked locations and tree attributes are illustrative, not surveyed.
+Explore seven regional groves in the
+[Wild Forest demo](https://visgl.github.io/deck.gl-community/examples/three/wild-forest),
+with controls for region, season, and zoom. See the
+[example README](../../examples/three/wild-forest/README.md) for setup and data details.

--- a/modules/three/src/tree-layer/tree-geometry.ts
+++ b/modules/three/src/tree-layer/tree-geometry.ts
@@ -31,9 +31,9 @@ export type TreeMesh = {
 
 /**
  * Rotation matrix that converts from Three.js Y-up to deck.gl Z-up.
- * Rotates -90 degrees around the X axis: Y -> Z, Z -> -Y.
+ * Rotates +90 degrees around the X axis: Y -> Z, Z -> -Y.
  */
-const Y_TO_Z_UP = new Matrix4().makeRotationX(-Math.PI / 2);
+const Y_TO_Z_UP = new Matrix4().makeRotationX(Math.PI / 2);
 
 /**
  * Perturb each vertex radially using a sum of low-frequency sinusoidal waves

--- a/modules/three/src/tree-layer/tree-layer.ts
+++ b/modules/three/src/tree-layer/tree-layer.ts
@@ -472,7 +472,9 @@ export class TreeLayer<DataT = unknown, ExtraPropsT extends {} = {}> extends Com
 
         if (type === 'pine') {
           const levels = Math.max(1, Math.min(5, Math.round(getBranchLevels(d) as number)));
-          pineMeshes[levels] ??= createPineCanopyMesh(levels);
+          // A scale/crop/color update does not change the unit mesh. Preserve its
+          // identity so SimpleMeshLayer can retain the existing GPU model.
+          pineMeshes[levels] ??= this.state.pineMeshes[levels] ?? createPineCanopyMesh(levels);
         }
 
         const cropConfig = getCrop(d);

--- a/modules/three/test/tree-layer.spec.ts
+++ b/modules/three/test/tree-layer.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect, vi} from 'vitest';
 import {TreeLayer} from '../src/index';
 import {
   createTrunkMesh,
@@ -15,6 +15,31 @@ import {
 } from '../src/tree-layer/tree-geometry';
 
 describe('TreeLayer', () => {
+  it('reuses pine meshes across scale and crop updates while removing unused tiers', () => {
+    const layer = new TreeLayer({
+      data: [{position: [0, 0], levels: 2}],
+      getBranchLevels: d => d.levels
+    });
+    layer.initializeState();
+    vi.spyOn(layer, 'setState').mockImplementation(state => {
+      Object.assign(layer.state, state);
+    });
+    const update = (overrides = {}) =>
+      layer.updateState({
+        props: Object.assign(Object.create(layer.props), overrides),
+        oldProps: layer.props,
+        changeFlags: {propsChanged: true}
+      });
+    update();
+    const mesh = layer.state.pineMeshes[2];
+    update({sizeScale: 40});
+    expect(layer.state.pineMeshes[2]).toBe(mesh);
+    update({getCrop: () => null});
+    expect(layer.state.pineMeshes[2]).toBe(mesh);
+    update({data: [{position: [0, 0], levels: 4}]});
+    expect(Object.keys(layer.state.pineMeshes)).toEqual(['4']);
+  });
+
   it('exports TreeLayer', () => {
     expect(TreeLayer).toBeTruthy();
     expect(TreeLayer.layerName).toBe('TreeLayer');
@@ -56,6 +81,24 @@ describe('TreeLayer', () => {
 });
 
 describe('tree geometry generators', () => {
+  it('pine tiers point upward and trunks taper toward the canopy', () => {
+    for (const mesh of [createPineCanopyMesh(1), createTrunkMesh()]) {
+      const positions = mesh.attributes.POSITION.value;
+      let bottomRadius = 0;
+      let topRadius = 0;
+      let maxZ = 0;
+      for (let index = 2; index < positions.length; index += 3) {
+        maxZ = Math.max(maxZ, positions[index]);
+      }
+      for (let index = 0; index < positions.length; index += 3) {
+        const radius = Math.hypot(positions[index], positions[index + 1]);
+        if (positions[index + 2] < maxZ * 0.2) bottomRadius = Math.max(bottomRadius, radius);
+        if (positions[index + 2] > maxZ * 0.8) topRadius = Math.max(topRadius, radius);
+      }
+      expect(topRadius).toBeLessThan(bottomRadius);
+    }
+  });
+
   it('createTrunkMesh returns valid mesh', () => {
     const mesh = createTrunkMesh();
     expect(mesh.topology).toBe('triangle-list');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,10 @@ import react from '@vitejs/plugin-react';
 const ALIASES = [
   {find: 'crypto', replacement: 'node:crypto'}, // ensure Vite/Vitest get Node's crypto
   {
+    find: '@deck.gl-community/three',
+    replacement: fileURLToPath(new URL('./modules/three/src/index.ts', import.meta.url))
+  },
+  {
     find: '@deck.gl-community/basemap-layers/style-spec',
     replacement: fileURLToPath(
       new URL('./modules/basemap-layers/src/style-spec.ts', import.meta.url)
@@ -128,6 +132,7 @@ const CONFIG = defineConfig({
           environment: 'node',
           include: [
             'modules/**/*.browser.{test,spec}.{js,ts,jsx,tsx}',
+            'examples/**/*.browser.{test,spec}.{js,ts,jsx,tsx}',
             'modules/panels/test/imports.spec.ts',
             'modules/**/*.{test,spec}.{jsx,tsx}',
             'dev/**/*.browser.{test,spec}.{js,ts,jsx,tsx}',
@@ -150,6 +155,7 @@ const CONFIG = defineConfig({
           environment: 'node',
           include: [
             'modules/**/*.browser.{test,spec}.{js,ts,jsx,tsx}',
+            'examples/**/*.browser.{test,spec}.{js,ts,jsx,tsx}',
             'modules/panels/test/imports.spec.ts',
             'modules/**/*.{test,spec}.{jsx,tsx}',
             'dev/**/*.browser.{test,spec}.{js,ts,jsx,tsx}',
@@ -170,7 +176,8 @@ const CONFIG = defineConfig({
         test: {
           name: 'examples',
           environment: 'node',
-          include: ['examples/**/*.{test,spec}.{js,ts,jsx,tsx}']
+          include: ['examples/**/*.{test,spec}.{js,ts,jsx,tsx}'],
+          exclude: ['examples/**/*.browser.{test,spec}.{js,ts,jsx,tsx}']
         }
       }
     ]

--- a/website/src/components/docs/layer-live-example.jsx
+++ b/website/src/components/docs/layer-live-example.jsx
@@ -171,7 +171,7 @@ async function mountLayerDocsExample(container, highlight, mountProps = {}) {
     }
     case 'tree-layer': {
       const {mountWildForestExample} = await import('../../../../examples/three/wild-forest/app');
-      return mountWildForestExample(container, {showControlsWidget: false, ...mountProps});
+      return mountWildForestExample(container, mountProps);
     }
     case 'horizon-graph-layer': {
       const {mountHorizonGraphLayerExample} = await import(

--- a/website/src/examples-sidebar.js
+++ b/website/src/examples-sidebar.js
@@ -54,6 +54,11 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: '@deck.gl-community/three',
+      items: ['three/wild-forest']
+    },
+    {
+      type: 'category',
       label: '@deck.gl-community/timeline-layers',
       items: ['timeline-layers/horizon-graph-layer', 'timeline-layers/multi-horizon-graph-layer']
     },

--- a/website/src/examples/index.mdx
+++ b/website/src/examples/index.mdx
@@ -1,6 +1,7 @@
 import {ExamplesIndex} from '../components';
 
 export const thumbnailOverrides = {
+  'three/wild-forest': '/images/maps.jpg',
   'layers/path-outline-and-markers': '/images/examples/layers/path-outline-and-markers.svg',
   'layers/skybox-map-view': '/images/layers.png',
   'layers/skybox-globe': '/images/layers.png',

--- a/website/src/examples/three/wild-forest.mdx
+++ b/website/src/examples/three/wild-forest.mdx
@@ -1,0 +1,8 @@
+---
+title: Wild Forest
+hide_title: true
+---
+
+import Demo from './wild-forest';
+
+<Demo />

--- a/website/src/examples/three/wild-forest.tsx
+++ b/website/src/examples/three/wild-forest.tsx
@@ -1,0 +1,15 @@
+import {GITHUB_TREE} from '../../constants/defaults';
+import {makeImperativeExample} from '../../components';
+
+export default makeImperativeExample(
+  {
+    title: 'Wild Forest · TreeLayer',
+    code: `${GITHUB_TREE}/examples/three/wild-forest`,
+    deviceTabs: {placement: 'top-right'},
+    async mount(container, props) {
+      const {mountWildForestExample} = await import('../../../../examples/three/wild-forest/app');
+      return mountWildForestExample(container, props);
+    }
+  },
+  {addInfoPanel: false}
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -12638,17 +12638,20 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wild-forest-ea7bdb@workspace:examples/three/wild-forest"
   dependencies:
-    "@deck.gl-community/panels": "workspace:*"
     "@deck.gl-community/three": "workspace:*"
-    "@deck.gl-community/widgets": "workspace:*"
     "@deck.gl/core": "npm:~9.4.0"
+    "@deck.gl/extensions": "npm:~9.4.0"
+    "@deck.gl/geo-layers": "npm:~9.4.0"
+    "@deck.gl/layers": "npm:~9.4.0"
     "@deck.gl/mesh-layers": "npm:~9.4.0"
-    "@deck.gl/widgets": "npm:~9.4.0"
+    "@loaders.gl/core": "npm:^4.4.3"
+    "@loaders.gl/mvt": "npm:^4.4.3"
     "@luma.gl/core": "npm:~9.4.0"
     "@luma.gl/engine": "npm:~9.4.0"
     "@luma.gl/shadertools": "npm:~9.4.0"
     "@luma.gl/webgl": "npm:~9.4.0"
     "@luma.gl/webgpu": "npm:~9.4.0"
+    "@math.gl/web-mercator": "npm:^4.1.0"
     vite: "npm:^7.3.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Seasonal Farm replaces the Wild Forest example with seven outlined, labelled plots and 416 varied trees. Four season buttons change foliage, blossom, fruit, and winter branches; tooltips describe trees and plots. The source directory, mount function, website route, gallery, and docs now consistently use `seasonal-farm` / `Seasonal Farm`.

Standard MapController navigation supports pan, rotation, close-ups to zoom 23, and pitch up to 80°. Responsive layouts fit desktop and mobile, and website graphics backend switches preserve the camera and season. Screen-space inspection avoids GPU picking readbacks. The same mount powers standalone, documentation, and gallery views without basemap requests.

Also correct TreeLayer's upright geometry and reuse pine meshes when attributes change. The planting and seasonal traits are illustrative; no library API migration is required.

## Validation

- Full Node suite: 618 passed, 9 skipped.
- Full Chrome browser suite: 242 passed, including WebGL2/WebGPU farm rendering, seasons, hover, controller limits, responsive layout, and camera preservation during remounts. WebGPU skips when no adapter is available.
- Root package build, example TypeScript, website production build, and repository lint passed.
- Verified the renamed website route, gallery link, TreeLayer docs link, standalone rendering, and season controls with no page errors.
